### PR TITLE
Acki-nacki support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "api_derive"
-version = "1.47.0"
+version = "1.47.1"
 dependencies = [
  "api_info",
  "proc-macro2",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "api_info"
-version = "1.47.0"
+version = "1.47.1"
 dependencies = [
  "serde",
  "serde_derive",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "api_test"
-version = "1.47.0"
+version = "1.47.1"
 dependencies = [
  "api_derive",
  "api_info",
@@ -489,6 +489,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17cc5e6b5ab06331c33589842070416baa137e8b0eb912b008cfd4a78ada7919"
 
 [[package]]
+name = "chitchat"
+version = "0.8.0"
+source = "git+https://github.com/gosh-sh/chitchat.git#c3ac1874aac9479f1602c2a5a652873b4e4310c1"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "itertools 0.12.1",
+ "rand 0.8.5",
+ "serde",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,7 +754,7 @@ dependencies = [
  "clap 4.5.1",
  "criterion-plot",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -759,7 +775,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1729,6 +1745,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -3561,6 +3586,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -3706,7 +3732,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_abi"
-version = "1.47.0"
+version = "1.47.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3722,7 +3748,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_api"
-version = "1.47.0"
+version = "1.47.1"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -3742,7 +3768,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_assembler"
-version = "1.47.0"
+version = "1.47.1"
 dependencies = [
  "anyhow",
  "clap 4.5.1",
@@ -3758,7 +3784,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_block"
-version = "1.47.0"
+version = "1.47.1"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -3778,7 +3804,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_block_json"
-version = "1.47.0"
+version = "1.47.1"
 dependencies = [
  "anyhow",
  "hex",
@@ -3799,12 +3825,13 @@ dependencies = [
 
 [[package]]
 name = "tvm_cli"
-version = "1.47.0"
+version = "1.47.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
  "async-trait",
  "base64 0.21.7",
+ "chitchat",
  "chrono",
  "clap 2.34.0",
  "futures",
@@ -3840,7 +3867,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_client"
-version = "1.47.0"
+version = "1.47.1"
 dependencies = [
  "aes",
  "anyhow",
@@ -3908,7 +3935,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_client_processing"
-version = "1.47.0"
+version = "1.47.1"
 dependencies = [
  "api_derive",
  "api_info",
@@ -3927,7 +3954,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_common"
-version = "1.47.0"
+version = "1.47.1"
 dependencies = [
  "external-ip",
  "log",
@@ -3939,7 +3966,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_executor"
-version = "1.47.0"
+version = "1.47.1"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -3952,7 +3979,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_sdk"
-version = "1.47.0"
+version = "1.47.1"
 dependencies = [
  "anyhow",
  "api_derive",
@@ -3976,7 +4003,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_struct"
-version = "1.47.0"
+version = "1.47.1"
 dependencies = [
  "hex-literal",
  "thiserror",
@@ -3986,7 +4013,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_tl_codegen"
-version = "1.47.0"
+version = "1.47.1"
 dependencies = [
  "crc 1.8.1",
  "pom",
@@ -3999,7 +4026,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_types"
-version = "1.47.0"
+version = "1.47.1"
 dependencies = [
  "aes-ctr",
  "anyhow",
@@ -4029,7 +4056,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_vm"
-version = "1.47.0"
+version = "1.47.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -4127,7 +4154,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "update_trusted_blocks"
-version = "1.47.0"
+version = "1.47.1"
 dependencies = [
  "bincode",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
     "tvm_vm",
 ]
 [workspace.package]
-version = "1.47.0"
+version = "1.47.1"
 rust-version = "1.76.0"
 
 authors = ["TVM Labs <hello@tvmlabs.io>"]

--- a/tvm_cli/Cargo.toml
+++ b/tvm_cli/Cargo.toml
@@ -6,7 +6,7 @@ keywords = [
     #
     "TVM",
     "SDK",
-    "smart contract",
+    "smart-contract",
     "tvmlabs",
     "solidity",
 ]
@@ -25,6 +25,7 @@ repository.workspace = true
 anyhow.workspace = true
 async-trait.workspace = true
 base64.workspace = true
+chitchat = { git = "https://github.com/gosh-sh/chitchat.git", optional = true }
 chrono.workspace = true
 clap = "2"
 futures.workspace = true
@@ -68,3 +69,6 @@ path = "src/main.rs"
 [[bin]]
 name = "__tvm-cli_completion"
 path = "src/completion.rs"
+
+[features]
+acki-nacki = ["tvm_client/acki-nacki", "dep:chitchat"]

--- a/tvm_cli/src/completion.rs
+++ b/tvm_cli/src/completion.rs
@@ -59,7 +59,7 @@ pub struct Config {
     pub endpoints: Vec<String>,
 }
 
-const CONFIG_BASE_NAME: &str = "tonos-cli.conf.json";
+const CONFIG_BASE_NAME: &str = "tvm-cli.conf.json";
 
 fn print_paths(prefix: &str) {
     let folder = if !prefix.contains('/') { "./" } else { prefix.trim_end_matches(|c| c != '/') };

--- a/tvm_cli/src/config.rs
+++ b/tvm_cli/src/config.rs
@@ -78,6 +78,11 @@ fn default_config() -> Config {
     Config::new()
 }
 
+#[cfg(feature = "acki-nacki")]
+fn default_gossip_seeds() -> Vec<String> {
+    Vec::new()
+}
+
 #[derive(Serialize, Deserialize, Clone, PartialEq)]
 pub struct Config {
     #[serde(default = "default_url")]
@@ -122,6 +127,9 @@ pub struct Config {
     ////////////////////////////////
     #[serde(default = "default_endpoints")]
     pub endpoints: Vec<String>,
+    #[cfg(feature = "acki-nacki")]
+    #[serde(default = "default_gossip_seeds")]
+    pub gossip_seeds: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -170,6 +178,8 @@ impl Default for Config {
             debug_fail: default_trace(),
             project_id: None,
             access_key: None,
+            #[cfg(feature = "acki-nacki")]
+            gossip_seeds: default_gossip_seeds(),
         }
     }
 }
@@ -214,6 +224,8 @@ impl Config {
             debug_fail: default_trace(),
             project_id: None,
             access_key: None,
+            #[cfg(feature = "acki-nacki")]
+            gossip_seeds: default_gossip_seeds(),
         }
     }
 }
@@ -468,6 +480,18 @@ pub fn set_config(
         let empty: Vec<String> = Vec::new();
         config.endpoints = full_config.endpoints_map.get(&resolved_url).unwrap_or(&empty).clone();
         config.url = resolved_url;
+    }
+    #[cfg(feature = "acki-nacki")]
+    if let Some(s) = matches.value_of("GOSSIP_SEEDS") {
+        config.gossip_seeds = s
+            .trim_start_matches('[')
+            .trim_end_matches(']')
+            .split(',')
+            .map(|s| s.trim()
+                .trim_start_matches('"')
+                .trim_end_matches('"')
+                .to_string())
+            .collect();
     }
     if let Some(s) = matches.value_of("ADDR") {
         config.addr = Some(s.to_string());

--- a/tvm_cli/src/config.rs
+++ b/tvm_cli/src/config.rs
@@ -487,10 +487,7 @@ pub fn set_config(
             .trim_start_matches('[')
             .trim_end_matches(']')
             .split(',')
-            .map(|s| s.trim()
-                .trim_start_matches('"')
-                .trim_end_matches('"')
-                .to_string())
+            .map(|s| s.trim().trim_start_matches('"').trim_end_matches('"').to_string())
             .collect();
     }
     if let Some(s) = matches.value_of("ADDR") {

--- a/tvm_cli/src/gossip.rs
+++ b/tvm_cli/src/gossip.rs
@@ -1,0 +1,54 @@
+#[cfg(feature = "acki-nacki")]
+use chitchat::{ChitchatId, ClusterStateSnapshot};
+use serde_derive::{Deserialize, Serialize};
+use crate::config::Config;
+
+#[cfg(feature = "acki-nacki")]
+const ADDRESS_VALUE: &str = "public_endpoint";
+
+#[cfg(feature = "acki-nacki")]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ApiResponse {
+    pub cluster_id: String,
+    pub cluster_state: ClusterStateSnapshot,
+    pub live_nodes: Vec<ChitchatId>,
+    pub dead_nodes: Vec<ChitchatId>,
+}
+
+#[cfg(feature = "acki-nacki")]
+pub async fn resolve_gossip_to_endpoints(config: &mut Config) -> anyhow::Result<()> {
+    if config.gossip_seeds.is_empty() {
+        return Ok(());
+    }
+
+    let mut endpoints = vec![];
+    for gossip_seed in &config.gossip_seeds {
+        eprintln!("resolve_gossip_to_endpoints {gossip_seed}");
+        let network_response = match reqwest::get(gossip_seed).await {
+            Ok(response) => match response.text().await {
+                Ok(text) => text,
+                _ => continue,
+            },
+            _ => continue,
+        };
+        let decoded: ApiResponse = match serde_json::from_str(&network_response) {
+            Ok(value) => value,
+            _ => continue,
+        };
+        eprintln!("resolve_gossip_to_endpoints {gossip_seed} successfully decoded response");
+        for node_state in decoded.cluster_state.node_state_snapshots {
+            for (key, value) in node_state.node_state.key_values() {
+                if key == ADDRESS_VALUE {
+                    endpoints.push(value.value.clone());
+                }
+            }
+        }
+        if !endpoints.is_empty() {
+            eprintln!("set config endpoints: {endpoints:?}");
+            config.url = "".to_string();
+            config.endpoints = endpoints;
+            return Ok(());
+        }
+    }
+    Ok(())
+}

--- a/tvm_cli/src/gossip.rs
+++ b/tvm_cli/src/gossip.rs
@@ -1,6 +1,10 @@
 #[cfg(feature = "acki-nacki")]
-use chitchat::{ChitchatId, ClusterStateSnapshot};
-use serde_derive::{Deserialize, Serialize};
+use chitchat::ChitchatId;
+#[cfg(feature = "acki-nacki")]
+use chitchat::ClusterStateSnapshot;
+use serde_derive::Deserialize;
+use serde_derive::Serialize;
+
 use crate::config::Config;
 
 #[cfg(feature = "acki-nacki")]

--- a/tvm_cli/src/helpers.rs
+++ b/tvm_cli/src/helpers.rs
@@ -59,8 +59,8 @@ use crate::FullConfig;
 pub const HD_PATH: &str = "m/44'/396'/0'/0/0";
 pub const WORD_COUNT: u8 = 12;
 
-const CONFIG_BASE_NAME: &str = "tonos-cli.conf.json";
-const GLOBAL_CONFIG_PATH: &str = ".tonos-cli.global.conf.json";
+const CONFIG_BASE_NAME: &str = "tvm-cli.conf.json";
+const GLOBAL_CONFIG_PATH: &str = ".tvm-cli.global.conf.json";
 
 pub fn default_config_name() -> String {
     env::current_dir()

--- a/tvm_cli/src/main.rs
+++ b/tvm_cli/src/main.rs
@@ -508,7 +508,7 @@ async fn main_internal() -> Result<(), String> {
             .help("Disables wait for transaction to appear in the network after call command."))
         .arg(Arg::with_name("DEBUG_FAIL")
             .long("--debug_fail")
-            .help("When enabled tonos-cli executes debug command on fail of run or call command. Can be enabled with values 'full' or 'minimal' which set the trace level for debug run and disabled with value 'none'."))
+            .help("When enabled tvm-cli executes debug command on fail of run or call command. Can be enabled with values 'full' or 'minimal' which set the trace level for debug run and disabled with value 'none'."))
         .arg(Arg::with_name("OUT_OF_SYNC")
             .long("--out_of_sync")
             .help("Network connection \"out_of_sync_threshold\" parameter in seconds. Mind that it cant exceed half of the \"lifetime\" parameter."))
@@ -654,7 +654,7 @@ async fn main_internal() -> Result<(), String> {
         .arg(Arg::with_name("DEBUG_FAIL")
             .long("--debug_fail")
             .takes_value(true)
-            .help("When enabled tonos-cli executes debug command on fail of run or call command. Can be enabled with values 'full' or 'minimal' which set the trace level for debug run and disabled with value 'none'."))
+            .help("When enabled tvm-cli executes debug command on fail of run or call command. Can be enabled with values 'full' or 'minimal' which set the trace level for debug run and disabled with value 'none'."))
         .arg(Arg::with_name("OUT_OF_SYNC")
             .long("--out_of_sync")
             .takes_value(true)
@@ -697,7 +697,7 @@ async fn main_internal() -> Result<(), String> {
             .takes_value(true)
             .conflicts_with("DUMPTVC")
             .conflicts_with("BOC")
-            .help("Dumps the whole account state boc to the specified file. Works only if one address was given. Use 'tonos-cli dump account` to dump several accounts."));
+            .help("Dumps the whole account state boc to the specified file. Works only if one address was given. Use 'tvm-cli dump account` to dump several accounts."));
 
     let account_wait_cmd = SubCommand::with_name("account-wait")
         .setting(AppSettings::AllowLeadingHyphen)
@@ -938,7 +938,7 @@ async fn main_internal() -> Result<(), String> {
         )
         .arg(
             Arg::with_name("CONFIG")
-                .help("Path to the tonos-cli configuration file.")
+                .help("Path to the tvm-cli configuration file.")
                 .short("-c")
                 .long("--config")
                 .takes_value(true),
@@ -1170,7 +1170,7 @@ async fn command_parser(matches: &ArgMatches<'_>, is_json: bool) -> Result<(), S
     if matches.subcommand_matches("version").is_some() {
         if config.is_json {
             println!("{{");
-            println!(r#"  "tonos-cli": "{}","#, env!("CARGO_PKG_VERSION"));
+            println!(r#"  "tvm-cli": "{}","#, env!("CARGO_PKG_VERSION"));
             println!(r#"  "COMMIT_ID": "{}","#, env!("BUILD_GIT_COMMIT"));
             println!(r#"  "BUILD_DATE": "{}","#, env!("BUILD_TIME"));
             println!(r#"  "COMMIT_DATE": "{}","#, env!("BUILD_GIT_DATE"));
@@ -1178,7 +1178,7 @@ async fn command_parser(matches: &ArgMatches<'_>, is_json: bool) -> Result<(), S
             println!("}}");
         } else {
             println!(
-                "tonos-cli {}\nCOMMIT_ID: {}\nBUILD_DATE: {}\nCOMMIT_DATE: {}\nGIT_BRANCH: {}",
+                "tvm-cli {}\nCOMMIT_ID: {}\nBUILD_DATE: {}\nCOMMIT_DATE: {}\nGIT_BRANCH: {}",
                 env!("CARGO_PKG_VERSION"),
                 env!("BUILD_GIT_COMMIT"),
                 env!("BUILD_TIME"),

--- a/tvm_cli/src/main.rs
+++ b/tvm_cli/src/main.rs
@@ -26,6 +26,8 @@ mod depool;
 mod depool_abi;
 mod genaddr;
 mod getconfig;
+#[cfg(feature = "acki-nacki")]
+mod gossip;
 mod helpers;
 mod message;
 mod multisig;
@@ -34,8 +36,6 @@ mod run;
 mod sendfile;
 mod test;
 mod voting;
-#[cfg(feature = "acki-nacki")]
-mod gossip;
 
 use std::collections::BTreeMap;
 use std::env;
@@ -680,11 +680,12 @@ async fn main_internal() -> Result<(), String> {
         .subcommand(alias_cmd);
 
     #[cfg(feature = "acki-nacki")]
-    let config_cmd = config_cmd
-        .arg(Arg::with_name("GOSSIP_SEEDS")
+    let config_cmd = config_cmd.arg(
+        Arg::with_name("GOSSIP_SEEDS")
             .long("--gossip-seeds")
             .takes_value(true)
-            .help("Gossip seeds to work with Acki-Nacki network."));
+            .help("Gossip seeds to work with Acki-Nacki network."),
+    );
 
     let account_cmd = SubCommand::with_name("account")
         .setting(AppSettings::AllowLeadingHyphen)

--- a/tvm_client/Cargo.toml
+++ b/tvm_client/Cargo.toml
@@ -146,3 +146,4 @@ wasm-base = [
     "wasm-bindgen-futures",
     "web-sys",
 ]
+acki-nacki = []

--- a/tvm_client/src/net/server_link.rs
+++ b/tvm_client/src/net/server_link.rs
@@ -657,6 +657,7 @@ impl ServerLink {
         params: &[ParamsOfQueryOperation],
         endpoint: Option<Endpoint>,
     ) -> ClientResult<Vec<Value>> {
+        #[cfg(not(feature = "acki-nacki"))]
         let latency_detection_required = if endpoint.is_some() {
             false
         } else if self.state.has_multiple_endpoints() {
@@ -665,6 +666,8 @@ impl ServerLink {
         } else {
             false
         };
+        #[cfg(feature = "acki-nacki")]
+        let latency_detection_required = false;
         let mut query =
             GraphQLQuery::build(params, latency_detection_required, self.config.wait_for_timeout);
         let info_request_time = self.client_env.now_ms();


### PR DESCRIPTION
Added feature acki-nacki for tvm-client and tvm-cli
When `gossip-seed` config set in tvm-cli it queries gossip group of nodes to get list of endpoints. This list overrides usual settings.