### PR TITLE
feat: add tvm-debugger json output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4117,6 +4117,7 @@ dependencies = [
  "clap 4.5.19",
  "hex",
  "lazy_static",
+ "serde",
  "serde_json",
  "tvm_abi",
  "tvm_block",

--- a/tvm_debugger/Cargo.toml
+++ b/tvm_debugger/Cargo.toml
@@ -25,3 +25,6 @@ tvm_block.workspace = true
 tvm_client.workspace = true
 tvm_types.workspace = true
 tvm_vm.workspace = true
+serde = { version = "1.0.210", features = [
+    "derive"
+] }

--- a/tvm_debugger/src/result.rs
+++ b/tvm_debugger/src/result.rs
@@ -1,0 +1,91 @@
+use crate::decode::tree_of_cells_into_base64;
+use serde_json::{json, Value};
+use tvm_block::{CommonMsgInfo, Message, Serializable};
+use tvm_types::base64_encode;
+
+pub struct ExecutionResult {
+    is_json: bool,
+    log: Vec<String>,
+    messages: Vec<Value>,
+    response: Value,
+    response_code: i32,
+    pub(crate) is_vm_success: bool,
+    gas_used: i64,
+}
+
+impl ExecutionResult {
+    pub(crate) fn new(is_json: bool) -> ExecutionResult {
+        return ExecutionResult {
+            is_json,
+            log: vec![],
+            messages: vec![],
+            response: "{}".into(),
+            response_code: -1,
+            is_vm_success: false,
+            gas_used: 0,
+        };
+    }
+
+    pub fn exit_code(&mut self, code: i32) {
+        self.response_code = code;
+        self.log(format!("TVM terminated with exit code {}", code));
+    }
+
+    pub fn vm_success(&mut self, is_vm_success: bool) {
+        self.is_vm_success = is_vm_success;
+        self.log(format!("Computing phase is success: {}", is_vm_success));
+    }
+
+    pub fn gas_used(&mut self, gas: i64) {
+        self.gas_used = gas;
+        self.log(format!("Gas used: {}", self.gas_used));
+        self.log("".to_string());
+    }
+
+    pub fn response(&mut self, data: String) {
+        self.response = serde_json::from_str(&*data.clone()).expect("Failed to parse JSON");
+        self.log(data);
+    }
+
+    pub fn add_out_message(&mut self, message: Message) {
+        match message.header() {
+            CommonMsgInfo::IntMsgInfo(_) => {
+                let state_init = match message.state_init() {
+                    None => None,
+                    Some(state_init) => Some(base64_encode(state_init.write_to_bytes().unwrap())),
+                };
+                let destination =
+                    message.header().get_dst_address().unwrap_or_default().to_string();
+                let body =
+                    tree_of_cells_into_base64(message.body().map(|s| s.into_cell()).as_ref());
+                let boc = base64_encode(message.write_to_bytes().unwrap());
+                self.messages.push(json!({
+                    "state_init": state_init,
+                    "destination": destination,
+                    "body": body,
+                    "boc": boc,
+                }));
+            }
+            CommonMsgInfo::ExtInMsgInfo(_) => {}
+            CommonMsgInfo::ExtOutMsgInfo(_) => {}
+        }
+    }
+
+    pub fn log(&mut self, data: String) {
+        self.log.push(data);
+    }
+
+    pub fn to_json(&self) -> Value {
+        json!({
+            "exit_code": self.response_code,
+            "vm_success": self.is_vm_success,
+            "gas_used": self.gas_used,
+            "response": self.response,
+            "messages": self.messages,
+        })
+    }
+
+    pub fn output(&mut self) -> String {
+        return if self.is_json { self.to_json().to_string() } else { self.log.join("\n") };
+    }
+}


### PR DESCRIPTION
## Changes are backward compatible

```bash
 ./target/release/tvm-debugger -i tvm_debugger/tests/contract/contract.tvc -a tvm_debugger/tests/contract/contract.abi.json -m counter
TVM terminated with exit code 0
Computing phase is success: true
Gas used: 4065

--- Post-execution stack state ---------
0
----------------------------------------

--- Control registers ------------------
0: Continuation x24bfa6ede47d53c9ee64e8092c83551cb05eb1be4baeaa7263b6924a8d8530ae
1: Continuation x0000000000000000000000000000000000000000000000000000000000000000
3: Continuation x7f6b335302de33db4c2c9a98a5088a0b6956725f3aae40737edec2fa0041c01b
4: Cell x5c00170d89e7700b1ab33bbd438ae613a868bc7b2c5fbf66a97f061a1ee98281 x467047e81d6a8461d2377daca513c54a3e2c38ba202d50eae00cbfd7bf3f577000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004_
5: Cell xd7ac5f7c59e1047f656730d1e0acb63a55713c691419f70f719184c16d9734e9 x0ec3c86d00
7: Tuple (12)["Tuple (14)", "Null", "31860282553879950199035741648495377296566513688950141184983206852133432285040", "0", "Null", "Null", "0", "Null", "Null", "Null", "0", "0"]
----------------------------------------

Output actions:
----------------
Action(SendMsg):
message header
   source      : 
   destination : 
   created_lt  : 0
   created_at  : 0
init  : None
body  : bits: 288   refs: 0   data: fc1216300000000000000000000000000000000000000000000000000000000000000000
body_hex: b5ee9c72010101010026000048fc1216300000000000000000000000000000000000000000000000000000000000000000
body_base64: te6ccgEBAQEAJgAASPwSFjAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
boc_base64: te6ccgEBAQEAMwAAYsAAAAAAAAAAAAAAAAD8EhYwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=

{"counter":"0x0000000000000000000000000000000000000000000000000000000000000000"}
Contract persistent data updated
EXECUTION COMPLETED
```

## Added option `--json`

```bash
$ ./target/release/tvm-debugger -i tvm_debugger/tests/contract/contract.tvc -a tvm_debugger/tests/contract/contract.abi.json -m counter -j
```

Output

```json
{
  "exit_code": 0,
  "vm_success": true,
  "gas_used": 4065,
  "response": {
    "counter": "0x0000000000000000000000000000000000000000000000000000000000000000"
  },
  "messages": []
}
```