### PR TITLE
cargo clippy fix (see description)

### DIFF
--- a/api/derive/src/derive_function.rs
+++ b/api/derive/src/derive_function.rs
@@ -24,7 +24,7 @@ pub fn impl_api_function(attr: TokenStream, item: TokenStream) -> TokenStream {
     let syn_meta = syn::parse::<Meta>(attr).ok();
     let fn_impl_tokens = function_to_tokens(&function_from(syn_meta, syn_func));
 
-    let fn_ident = Ident::new(&format!("{}_api", name), Span::call_site().into());
+    let fn_ident = Ident::new(&format!("{name}_api"), Span::call_site().into());
     let fn_tokens = quote! {
         pub fn #fn_ident () -> api_info::Function {
             #fn_impl_tokens

--- a/api/test/src/tests/mod.rs
+++ b/api/test/src/tests/mod.rs
@@ -8,12 +8,12 @@ use api_info::Type;
 
 fn reflect<T: ApiType>() {
     let info = serde_json::to_string_pretty(&T::api()).unwrap();
-    println!("{}", info);
+    println!("{info}");
 }
 
 fn reflect_module<T: ApiModule>() {
     let info = serde_json::to_string_pretty(&T::api()).unwrap();
-    println!("{}", info);
+    println!("{info}");
 }
 
 enum ExpectType {
@@ -25,9 +25,9 @@ enum ExpectType {
 
 impl ExpectType {
     fn check_fields(actual: &[Field], expected: &[(&'static str, ExpectType)], parent_hint: &str) {
-        assert_eq!(actual.len(), expected.len(), "Unexpected field count for {}", parent_hint);
+        assert_eq!(actual.len(), expected.len(), "Unexpected field count for {parent_hint}");
         for i in 0..actual.len() {
-            assert_eq!(actual[i].name, expected[i].0, "Unexpected field for {}", parent_hint);
+            assert_eq!(actual[i].name, expected[i].0, "Unexpected field for {parent_hint}");
             expected[i].1.check(&actual[i].value, &format!("{}.{}", parent_hint, actual[i].name));
         }
     }
@@ -85,12 +85,12 @@ fn type_name(ty: &Type) -> String {
         Type::Boolean => "Boolean".to_string(),
         Type::String => "String".to_string(),
         Type::Number { number_type, number_size } => {
-            format!("Number({:?},{})", number_type, number_size)
+            format!("Number({number_type:?},{number_size})")
         }
         Type::BigInt { number_type, number_size } => {
-            format!("BigInt({:?},{})", number_type, number_size)
+            format!("BigInt({number_type:?},{number_size})")
         }
-        Type::Ref { name } => format!("Ref({})", name),
+        Type::Ref { name } => format!("Ref({name})"),
         Type::Optional { inner } => format!("Optional({})", type_name(inner)),
         Type::Array { item } => format!("Array({})", type_name(item)),
         Type::Struct { fields } => format!("Struct({})", fields.len()),

--- a/tools/tl_code_gen/src/main.rs
+++ b/tools/tl_code_gen/src/main.rs
@@ -21,7 +21,7 @@ const TL_DIR: &str = "tvm_api/tl";
 
 fn main() {
     let mut files = fs::read_dir(TL_DIR)
-        .unwrap_or_else(|_| panic!("Unable to read directory contents: {}", TL_DIR))
+        .unwrap_or_else(|_| panic!("Unable to read directory contents: {TL_DIR}"))
         .filter_map(Result::ok)
         .map(|d| d.path())
         .filter(|path| path.to_str().unwrap().ends_with(".tl"))

--- a/tools/tvm_api_gen/src/api.rs
+++ b/tools/tvm_api_gen/src/api.rs
@@ -156,7 +156,7 @@ pub fn command(args: &[String]) -> Result<(), CliError> {
     if let Some(out_dir) = out_dir {
         write_text_to_out_dir(text, out_dir)
     } else {
-        println!("{}", text);
+        println!("{text}");
         Ok(())
     }
 }

--- a/tools/tvm_api_gen/src/main.rs
+++ b/tools/tvm_api_gen/src/main.rs
@@ -50,7 +50,7 @@ Example:
 "#;
 
 fn print_usage_and_exit() {
-    println!("{}", USAGE);
+    println!("{USAGE}");
     std::process::exit(1)
 }
 

--- a/tools/tvm_api_gen/src/request.rs
+++ b/tools/tvm_api_gen/src/request.rs
@@ -52,14 +52,14 @@ fn include_json(json_ref: &str) -> Result<String, CliError> {
     let ref_path = if ref_parts.len() > 1 { ref_parts[1] } else { "" };
     if ref_file.ends_with(".json") {
         let ref_string = std::fs::read_to_string(&ref_file)
-            .map_err(|e| CliError::with_message(format!("Include [{}] failed: {}", ref_file, e)))?;
+            .map_err(|e| CliError::with_message(format!("Include [{ref_file}] failed: {e}")))?;
         let value: Value = serde_json::from_str(&ref_string)
-            .map_err(|e| CliError::with_message(format!("Include [{}] failed: {}", ref_file, e)))?;
+            .map_err(|e| CliError::with_message(format!("Include [{ref_file}] failed: {e}")))?;
         let value = resolve_json_path(&value, ref_path);
         Ok(value.to_string())
     } else {
         let ref_bytes = std::fs::read(&ref_file)
-            .map_err(|e| CliError::with_message(format!("Include [{}] failed: {}", ref_file, e)))?;
+            .map_err(|e| CliError::with_message(format!("Include [{ref_file}] failed: {e}")))?;
         Ok(format!("\"{}\"", base64::engine::general_purpose::STANDARD.encode(&ref_bytes)))
     }
 }
@@ -78,7 +78,7 @@ fn parse_sync_response<R: DeserializeOwned>(response: *const String) -> Result<R
                 Ok(serde_json::from_value(value["result"].clone()).unwrap())
             }
         }
-        Err(err) => Err(CliError::with_message(format!("Read core response failed: {}", err))),
+        Err(err) => Err(CliError::with_message(format!("Read core response failed: {err}"))),
     }
 }
 

--- a/tools/update_trusted_blocks/src/main.rs
+++ b/tools/update_trusted_blocks/src/main.rs
@@ -18,9 +18,9 @@ fn with_project(endpoint: &str) -> String {
     match env::var(key) {
         Ok(project) => {
             if endpoint.ends_with('/') {
-                format!("{}{}", endpoint, project)
+                format!("{endpoint}{project}")
             } else {
-                format!("{}/{}", endpoint, project)
+                format!("{endpoint}/{project}")
             }
         }
         Err(_) => endpoint.to_string(),
@@ -32,7 +32,7 @@ async fn query_network_keyblocks(
     zs_root_hash: UInt256,
     trusted_blocks: Option<Vec<(u32, [u8; 32])>>,
 ) -> Result<Vec<(u32, [u8; 32])>> {
-    println!("*** [{}] ***", endpoint);
+    println!("*** [{endpoint}] ***");
     let context = Arc::new(ClientContext::new(serde_json::from_value(json!({
         "network": {
             "endpoints": [endpoint],
@@ -76,14 +76,14 @@ async fn query_network_keyblocks(
         .result;
 
         if key_blocks.is_empty() {
-            println!("*** [{} done] ***", endpoint);
+            println!("*** [{endpoint} done] ***");
             return Ok(result);
         }
 
         for key_block in key_blocks {
             let seq_no =
                 key_block["seq_no"].as_u64().expect("Field `seq_no` must be an integer") as u32;
-            print!("Proof for key_block #{}...", seq_no);
+            print!("Proof for key_block #{seq_no}...");
             proof_block_data(
                 Arc::clone(&context),
                 ParamsOfProofBlockData { block: key_block.clone() },

--- a/tvm_abi/build.rs
+++ b/tvm_abi/build.rs
@@ -16,9 +16,9 @@ fn main() {
     let build_time = get_value("date", &["+%Y-%m-%d %T %z"]);
     let rust_version = get_value("rustc", &["--version"]);
 
-    println!("cargo:rustc-env=BUILD_GIT_BRANCH={}", git_branch);
-    println!("cargo:rustc-env=BUILD_GIT_COMMIT={}", git_commit);
-    println!("cargo:rustc-env=BUILD_GIT_DATE={}", commit_date);
-    println!("cargo:rustc-env=BUILD_TIME={}", build_time);
-    println!("cargo:rustc-env=BUILD_RUST_VERSION={}", rust_version);
+    println!("cargo:rustc-env=BUILD_GIT_BRANCH={git_branch}");
+    println!("cargo:rustc-env=BUILD_GIT_COMMIT={git_commit}");
+    println!("cargo:rustc-env=BUILD_GIT_DATE={commit_date}");
+    println!("cargo:rustc-env=BUILD_TIME={build_time}");
+    println!("cargo:rustc-env=BUILD_RUST_VERSION={rust_version}");
 }

--- a/tvm_abi/src/contract.rs
+++ b/tvm_abi/src/contract.rs
@@ -59,21 +59,18 @@ impl AbiVersion {
         let parts: Vec<&str> = str_version.split('.').collect();
         if parts.len() < 2 {
             fail!(AbiError::InvalidVersion(format!(
-                "version must consist of two parts divided by `.` ({})",
-                str_version
+                "version must consist of two parts divided by `.` ({str_version})"
             )));
         }
 
         let major = parts[0].parse::<u8>().map_err(|err| {
             error!(AbiError::InvalidVersion(format!(
-                "can not parse version string: {} ({})",
-                err, str_version
+                "can not parse version string: {err} ({str_version})"
             )))
         })?;
         let minor = parts[1].parse::<u8>().map_err(|err| {
             error!(AbiError::InvalidVersion(format!(
-                "can not parse version string: {} ({})",
-                err, str_version
+                "can not parse version string: {err} ({str_version})"
             )))
         })?;
 
@@ -141,13 +138,12 @@ where
         Ok(string) => {
             if !string.starts_with("0x") {
                 return Err(D::Error::custom(format!(
-                    "Number parsing error: number must be prefixed with 0x ({})",
-                    string
+                    "Number parsing error: number must be prefixed with 0x ({string})"
                 )));
             }
 
             u32::from_str_radix(&string[2..], 16)
-                .map_err(|err| D::Error::custom(format!("Error parsing number: {}", err)))
+                .map_err(|err| D::Error::custom(format!("Error parsing number: {err}")))
                 .map(Some)
         }
     }
@@ -258,8 +254,7 @@ impl Contract {
 
         if !version.is_supported() {
             fail!(AbiError::InvalidVersion(format!(
-                "Provided ABI version is not supported ({})",
-                version
+                "Provided ABI version is not supported ({version})"
             )));
         }
 

--- a/tvm_abi/src/param.rs
+++ b/tvm_abi/src/param.rs
@@ -77,8 +77,7 @@ impl<'a> Deserialize<'a> for Param {
                 | ParamType::FixedArray(_, _)
                 | ParamType::Map(_, _) => {
                     return Err(D::Error::custom(format!(
-                        "Invalid parameter specification: {}. Only simple types can be represented as strings",
-                        type_str
+                        "Invalid parameter specification: {type_str}. Only simple types can be represented as strings"
                     )));
                 }
                 _ => {}

--- a/tvm_abi/src/param_type/param_type.rs
+++ b/tvm_abi/src/param_type/param_type.rs
@@ -79,10 +79,10 @@ impl ParamType {
     /// Returns type signature according to ABI specification
     pub fn type_signature(&self) -> String {
         match self {
-            ParamType::Uint(size) => format!("uint{}", size),
-            ParamType::Int(size) => format!("int{}", size),
-            ParamType::VarUint(size) => format!("varuint{}", size),
-            ParamType::VarInt(size) => format!("varint{}", size),
+            ParamType::Uint(size) => format!("uint{size}"),
+            ParamType::Int(size) => format!("int{size}"),
+            ParamType::VarUint(size) => format!("varuint{size}"),
+            ParamType::VarInt(size) => format!("varint{size}"),
             ParamType::Bool => "bool".to_owned(),
             ParamType::Tuple(params) => {
                 let mut signature = "".to_owned();
@@ -103,7 +103,7 @@ impl ParamType {
             }
             ParamType::Address => "address".to_string(),
             ParamType::Bytes => "bytes".to_string(),
-            ParamType::FixedBytes(size) => format!("fixedbytes{}", size),
+            ParamType::FixedBytes(size) => format!("fixedbytes{size}"),
             ParamType::String => "string".to_string(),
             ParamType::Token => "gram".to_string(),
             ParamType::Time => "time".to_string(),

--- a/tvm_abi/src/tests/test_param.rs
+++ b/tvm_abi/src/tests/test_param.rs
@@ -235,10 +235,7 @@ fn test_empty_tuple_error() {
 
     let result = serde_json::from_str::<Param>(s).unwrap_err();
 
-    assert_eq!(
-        "Tuple description should contain non empty `components` field",
-        format!("{result}")
-    )
+    assert_eq!("Tuple description should contain non empty `components` field", format!("{result}"))
 }
 
 #[test]

--- a/tvm_abi/src/tests/test_param.rs
+++ b/tvm_abi/src/tests/test_param.rs
@@ -237,7 +237,7 @@ fn test_empty_tuple_error() {
 
     assert_eq!(
         "Tuple description should contain non empty `components` field",
-        format!("{}", result)
+        format!("{result}")
     )
 }
 

--- a/tvm_abi/src/tests/v1/test_contract.rs
+++ b/tvm_abi/src/tests/v1/test_contract.rs
@@ -211,7 +211,7 @@ fn print_function_singnatures() {
     for function in functions.values() {
         println!("{}", function.get_function_signature());
         let id = function.get_function_id();
-        println!("{:X?}\n", id);
+        println!("{id:X?}\n");
     }
 
     println!("Events\n");
@@ -221,7 +221,7 @@ fn print_function_singnatures() {
     for event in events.values() {
         println!("{}", event.get_function_signature());
         let id = event.get_function_id();
-        println!("{:X?}\n", id);
+        println!("{id:X?}\n");
     }
 }
 

--- a/tvm_abi/src/tests/v2/test_contract.rs
+++ b/tvm_abi/src/tests/v2/test_contract.rs
@@ -228,7 +228,7 @@ fn print_function_singnatures() {
     for function in functions.values() {
         println!("{}", function.get_function_signature());
         let id = function.get_function_id();
-        println!("{:X?}\n", id);
+        println!("{id:X?}\n");
     }
 
     println!("Events\n");
@@ -238,6 +238,6 @@ fn print_function_singnatures() {
     for event in events.values() {
         println!("{}", event.get_function_signature());
         let id = event.get_function_id();
-        println!("{:X?}\n", id);
+        println!("{id:X?}\n");
     }
 }

--- a/tvm_abi/src/token/deserialize.rs
+++ b/tvm_abi/src/token/deserialize.rs
@@ -453,7 +453,7 @@ impl TokenValue {
         let (data, cursor) = Self::read_bytes_from_chain(cursor, last, abi_version)?;
 
         let string = String::from_utf8(data).map_err(|err| AbiError::InvalidData {
-            msg: format!("Can not deserialize string: {}", err),
+            msg: format!("Can not deserialize string: {err}"),
         })?;
         Ok((TokenValue::String(string), cursor))
     }

--- a/tvm_abi/src/token/mod.rs
+++ b/tvm_abi/src/token/mod.rs
@@ -143,20 +143,20 @@ impl fmt::Display for TokenValue {
         match self {
             TokenValue::Uint(u) => write!(f, "{}", u.number),
             TokenValue::Int(u) => write!(f, "{}", u.number),
-            TokenValue::VarUint(_, u) => write!(f, "{}", u),
-            TokenValue::VarInt(_, u) => write!(f, "{}", u),
-            TokenValue::Bool(b) => write!(f, "{}", b),
+            TokenValue::VarUint(_, u) => write!(f, "{u}"),
+            TokenValue::VarInt(_, u) => write!(f, "{u}"),
+            TokenValue::Bool(b) => write!(f, "{b}"),
             TokenValue::Tuple(ref arr) => {
-                let s = arr.iter().map(|ref t| format!("{}", t)).collect::<Vec<String>>().join(",");
+                let s = arr.iter().map(|ref t| format!("{t}")).collect::<Vec<String>>().join(",");
 
-                write!(f, "({})", s)
+                write!(f, "({s})")
             }
             TokenValue::Array(_, ref arr) | TokenValue::FixedArray(_, ref arr) => {
-                let s = arr.iter().map(|ref t| format!("{}", t)).collect::<Vec<String>>().join(",");
+                let s = arr.iter().map(|ref t| format!("{t}")).collect::<Vec<String>>().join(",");
 
-                write!(f, "[{}]", s)
+                write!(f, "[{s}]")
             }
-            TokenValue::Cell(c) => write!(f, "{:?}", c),
+            TokenValue::Cell(c) => write!(f, "{c:?}"),
             TokenValue::Map(_key_type, _value_type, map) => {
                 let s = map
                     .iter()
@@ -164,15 +164,15 @@ impl fmt::Display for TokenValue {
                     .collect::<Vec<String>>()
                     .join(",");
 
-                write!(f, "{{{}}}", s)
+                write!(f, "{{{s}}}")
             }
-            TokenValue::Address(a) => write!(f, "{}", a),
-            TokenValue::Bytes(ref arr) | TokenValue::FixedBytes(ref arr) => write!(f, "{:?}", arr),
-            TokenValue::String(string) => write!(f, "{}", string),
-            TokenValue::Token(g) => write!(f, "{}", g),
-            TokenValue::Time(time) => write!(f, "{}", time),
-            TokenValue::Expire(expire) => write!(f, "{}", expire),
-            TokenValue::Ref(value) => write!(f, "{}", value),
+            TokenValue::Address(a) => write!(f, "{a}"),
+            TokenValue::Bytes(ref arr) | TokenValue::FixedBytes(ref arr) => write!(f, "{arr:?}"),
+            TokenValue::String(string) => write!(f, "{string}"),
+            TokenValue::Token(g) => write!(f, "{g}"),
+            TokenValue::Time(time) => write!(f, "{time}"),
+            TokenValue::Expire(expire) => write!(f, "{expire}"),
+            TokenValue::Ref(value) => write!(f, "{value}"),
             TokenValue::PublicKey(key) => {
                 if let Some(key) = key {
                     write!(f, "{}", hex::encode(key))
@@ -182,7 +182,7 @@ impl fmt::Display for TokenValue {
             }
             TokenValue::Optional(_, value) => {
                 if let Some(value) = value {
-                    write!(f, "{}", value)
+                    write!(f, "{value}")
                 } else {
                     write!(f, "None")
                 }
@@ -304,8 +304,7 @@ impl TokenValue {
             ParamType::PublicKey => Ok(TokenValue::PublicKey(None)),
             any_type => Err(AbiError::InvalidInputData {
                 msg: format!(
-                    "Type {} doesn't have default value and must be explicitly defined",
-                    any_type
+                    "Type {any_type} doesn't have default value and must be explicitly defined"
                 ),
             }
             .into()),

--- a/tvm_abi/src/token/serialize.rs
+++ b/tvm_abi/src/token/serialize.rs
@@ -241,7 +241,7 @@ impl TokenValue {
 
         if vec.len() > size - 1 {
             fail!(AbiError::InvalidData {
-                msg: format!("Too long value for varint{}: {}", size, value)
+                msg: format!("Too long value for varint{size}: {value}")
             });
         }
         Self::write_varnumber(&vec, size)
@@ -252,7 +252,7 @@ impl TokenValue {
 
         if vec.len() > size - 1 {
             fail!(AbiError::InvalidData {
-                msg: format!("Too long value for varuint{}: {}", size, value)
+                msg: format!("Too long value for varuint{size}: {value}")
             });
         }
         Self::write_varnumber(&vec, size)

--- a/tvm_abi/src/token/tests.rs
+++ b/tvm_abi/src/token/tests.rs
@@ -75,7 +75,7 @@ mod tokenize_tests {
 
         // check that detokenizer gives the same result
         let input = Detokenizer::detokenize(&expected_tokens).unwrap();
-        println!("{}", input);
+        println!("{input}");
         assert_eq!(
             Tokenizer::tokenize_all_params(&params, &serde_json::from_str(&input).unwrap())
                 .unwrap(),
@@ -177,7 +177,7 @@ mod tokenize_tests {
 
         // check that detokenizer gives the same result
         let input = Detokenizer::detokenize(&expected_tokens).unwrap();
-        println!("{}", input);
+        println!("{input}");
         assert_eq!(
             Tokenizer::tokenize_all_params(&params, &serde_json::from_str(&input).unwrap())
                 .unwrap(),
@@ -200,7 +200,7 @@ mod tokenize_tests {
 
         // check that detokenizer gives the same result
         let input = Detokenizer::detokenize(&expected_tokens).unwrap();
-        println!("{}", input);
+        println!("{input}");
         assert_eq!(
             Tokenizer::tokenize_all_params(&params, &serde_json::from_str(&input).unwrap())
                 .unwrap(),
@@ -265,7 +265,7 @@ mod tokenize_tests {
 
         // check that detokenizer gives the same result
         let input = Detokenizer::detokenize(&expected_tokens).unwrap();
-        println!("{}", input);
+        println!("{input}");
         assert_eq!(
             Tokenizer::tokenize_all_params(&params, &serde_json::from_str(&input).unwrap())
                 .unwrap(),
@@ -376,7 +376,7 @@ mod tokenize_tests {
 
         // check that detokenizer gives the same result
         let input = Detokenizer::detokenize(&expected_tokens).unwrap();
-        println!("{}", input);
+        println!("{input}");
         assert_eq!(
             Tokenizer::tokenize_all_params(&params, &serde_json::from_str(&input).unwrap())
                 .unwrap(),
@@ -421,7 +421,7 @@ mod tokenize_tests {
 
         // check that detokenizer gives the same result
         let input = Detokenizer::detokenize(&expected_tokens).unwrap();
-        println!("{}", input);
+        println!("{input}");
         assert_eq!(
             Tokenizer::tokenize_all_params(&params, &serde_json::from_str(&input).unwrap())
                 .unwrap(),
@@ -537,7 +537,7 @@ mod tokenize_tests {
 
         // check that detokenizer gives the same result
         let input = Detokenizer::detokenize(&expected_tokens).unwrap();
-        println!("{}", input);
+        println!("{input}");
         assert_eq!(
             Tokenizer::tokenize_all_params(&params, &serde_json::from_str(&input).unwrap())
                 .unwrap(),
@@ -577,7 +577,7 @@ mod tokenize_tests {
 
         // check that detokenizer gives the same result
         let input = Detokenizer::detokenize(&expected_tokens).unwrap();
-        println!("{}", input);
+        println!("{input}");
         assert_eq!(
             Tokenizer::tokenize_all_params(&params, &serde_json::from_str(&input).unwrap())
                 .unwrap(),
@@ -612,7 +612,7 @@ mod tokenize_tests {
 
         // check that detokenizer gives the same result
         let input = Detokenizer::detokenize(&expected_tokens).unwrap();
-        println!("{}", input);
+        println!("{input}");
         assert_eq!(
             Tokenizer::tokenize_all_params(&params, &serde_json::from_str(&input).unwrap())
                 .unwrap(),
@@ -650,7 +650,7 @@ mod tokenize_tests {
 
         // check that detokenizer gives the same result
         let input = Detokenizer::detokenize(&expected_tokens).unwrap();
-        println!("{}", input);
+        println!("{input}");
         assert_eq!(
             Tokenizer::tokenize_all_params(&params, &serde_json::from_str(&input).unwrap())
                 .unwrap(),
@@ -713,7 +713,7 @@ mod tokenize_tests {
 
         // check that detokenizer gives the same result
         let input = Detokenizer::detokenize(&expected_tokens).unwrap();
-        println!("{}", input);
+        println!("{input}");
         assert_eq!(
             Tokenizer::tokenize_all_params(&params, &serde_json::from_str(&input).unwrap())
                 .unwrap(),
@@ -768,7 +768,7 @@ mod tokenize_tests {
 
         // check that detokenizer gives the same result
         let input = Detokenizer::detokenize(&expected_tokens).unwrap();
-        println!("{}", input);
+        println!("{input}");
         assert_eq!(
             Tokenizer::tokenize_all_params(&params, &serde_json::from_str(&input).unwrap())
                 .unwrap(),

--- a/tvm_abi/src/token/tokenizer.rs
+++ b/tvm_abi/src/token/tokenizer.rs
@@ -107,7 +107,7 @@ impl Tokenizer {
                 let unknown =
                     map.iter().map(|(key, _)| key.as_ref()).collect::<Vec<&str>>().join(", ");
                 return Err(AbiError::InvalidInputData {
-                    msg: format!("Contract doesn't have following parameters: {}", unknown),
+                    msg: format!("Contract doesn't have following parameters: {unknown}"),
                 }
                 .into());
             }
@@ -150,7 +150,7 @@ impl Tokenizer {
             false => fail!(AbiError::InvalidParameterLength {
                 val: value.clone(),
                 name: name.to_string(),
-                expected: format!("array of {} elements", size),
+                expected: format!("array of {size} elements"),
             }),
         }
     }
@@ -358,12 +358,12 @@ impl Tokenizer {
         let data = base64_decode(string).map_err(|err| AbiError::InvalidParameterValue {
             val: value.clone(),
             name: name.to_string(),
-            err: format!("can not decode base64: {}", err),
+            err: format!("can not decode base64: {err}"),
         })?;
         let cell = read_single_root_boc(data).map_err(|err| AbiError::InvalidParameterValue {
             val: value.clone(),
             name: name.to_string(),
-            err: format!("can not deserialize cell: {}", err),
+            err: format!("can not deserialize cell: {err}"),
         })?;
         Ok(TokenValue::Cell(cell))
     }
@@ -399,7 +399,7 @@ impl Tokenizer {
         let mut data = hex::decode(string).map_err(|err| AbiError::InvalidParameterValue {
             val: value.clone(),
             name: name.to_string(),
-            err: format!("can not decode hex: {}", err),
+            err: format!("can not decode hex: {err}"),
         })?;
         match size {
             Some(size) => {
@@ -410,7 +410,7 @@ impl Tokenizer {
                     fail!(AbiError::InvalidParameterLength {
                         val: value.clone(),
                         name: name.to_string(),
-                        expected: format!("{} bytes", size),
+                        expected: format!("{size} bytes"),
                     })
                 }
             }
@@ -451,7 +451,7 @@ impl Tokenizer {
 
         let time = number.to_u64().ok_or_else(|| {
             error!(AbiError::InvalidInputData {
-                msg: format!("`{}` value {} should fit into u64", name, number)
+                msg: format!("`{name}` value {number} should fit into u64")
             })
         })?;
 
@@ -464,7 +464,7 @@ impl Tokenizer {
 
         let expire = number.to_u32().ok_or_else(|| {
             error!(AbiError::InvalidInputData {
-                msg: format!("`{}` value {} should fit into u32", name, number)
+                msg: format!("`{name}` value {number} should fit into u32")
             })
         })?;
 
@@ -484,12 +484,12 @@ impl Tokenizer {
             let data = hex::decode(string).map_err(|err| AbiError::InvalidParameterValue {
                 val: value.clone(),
                 name: name.to_string(),
-                err: format!("can not decode hex: {}", err),
+                err: format!("can not decode hex: {err}"),
             })?;
             let bytes = data.try_into().map_err(|_| AbiError::InvalidParameterLength {
                 val: value.clone(),
                 name: name.to_string(),
-                expected: format!("{} bytes", ED25519_PUBLIC_KEY_LENGTH),
+                expected: format!("{ED25519_PUBLIC_KEY_LENGTH} bytes"),
             })?;
             Ok(TokenValue::PublicKey(Some(bytes)))
         }
@@ -520,7 +520,7 @@ impl Tokenizer {
             .map_err(|err| AbiError::InvalidParameterValue {
                 val: value.clone(),
                 name: name.to_string(),
-                err: format!("can not parse address: {}", err),
+                err: format!("can not parse address: {err}"),
             })?;
         Ok(TokenValue::Address(address))
     }

--- a/tvm_api/build.rs
+++ b/tvm_api/build.rs
@@ -27,9 +27,9 @@ fn main() {
     let build_time = get_value("date", &["+%Y-%m-%d %T %z"]);
     let rust_version = get_value("rustc", &["--version"]);
 
-    println!("cargo:rustc-env=BUILD_GIT_BRANCH={}", git_branch);
-    println!("cargo:rustc-env=BUILD_GIT_COMMIT={}", git_commit);
-    println!("cargo:rustc-env=BUILD_GIT_DATE={}", commit_date);
-    println!("cargo:rustc-env=BUILD_TIME={}", build_time);
-    println!("cargo:rustc-env=BUILD_RUST_VERSION={}", rust_version);
+    println!("cargo:rustc-env=BUILD_GIT_BRANCH={git_branch}");
+    println!("cargo:rustc-env=BUILD_GIT_COMMIT={git_commit}");
+    println!("cargo:rustc-env=BUILD_GIT_DATE={commit_date}");
+    println!("cargo:rustc-env=BUILD_TIME={build_time}");
+    println!("cargo:rustc-env=BUILD_RUST_VERSION={rust_version}");
 }

--- a/tvm_assembler/build.rs
+++ b/tvm_assembler/build.rs
@@ -28,8 +28,8 @@ fn main() {
         build_time = String::from_utf8(b_time.stdout).unwrap_or_else(|_| "Unknown".to_string());
     }
 
-    println!("cargo:rustc-env=BUILD_GIT_BRANCH={}", git_branch);
-    println!("cargo:rustc-env=BUILD_GIT_COMMIT={}", git_commit);
-    println!("cargo:rustc-env=BUILD_GIT_DATE={}", commit_date);
-    println!("cargo:rustc-env=BUILD_TIME={}", build_time);
+    println!("cargo:rustc-env=BUILD_GIT_BRANCH={git_branch}");
+    println!("cargo:rustc-env=BUILD_GIT_COMMIT={git_commit}");
+    println!("cargo:rustc-env=BUILD_GIT_DATE={commit_date}");
+    println!("cargo:rustc-env=BUILD_TIME={build_time}");
 }

--- a/tvm_assembler/src/bin/asm.rs
+++ b/tvm_assembler/src/bin/asm.rs
@@ -35,7 +35,7 @@ struct Args {
 
 fn main() -> ExitCode {
     if let Err(e) = main_impl() {
-        eprintln!("{}", e);
+        eprintln!("{e}");
         ExitCode::from(1)
     } else {
         ExitCode::from(0)

--- a/tvm_assembler/src/bin/disasm.rs
+++ b/tvm_assembler/src/bin/disasm.rs
@@ -70,7 +70,7 @@ enum Commands {
 
 fn main() -> ExitCode {
     if let Err(e) = main_impl() {
-        eprintln!("{}", e);
+        eprintln!("{e}");
         ExitCode::from(1)
     } else {
         ExitCode::from(0)
@@ -159,7 +159,7 @@ fn subcommand_fragment(fragment: String) -> Status {
     let code = loader.load(&mut slice, false)?;
     let text = code.print("", true, 12);
 
-    print!("{}", text);
+    print!("{text}");
     Ok(())
 }
 
@@ -173,7 +173,7 @@ fn subcommand_text(filename: String, stateinit: bool, full: bool) -> Status {
         println!("boc is empty");
         return Ok(());
     } else if roots_count > 1 {
-        println!("warning: boc contains {} roots, getting the first one", roots_count)
+        println!("warning: boc contains {roots_count} roots, getting the first one")
     }
 
     let root0 = roots.first().ok_or_else(|| tvm_types::error!("failed to get root 0"))?;

--- a/tvm_assembler/src/disasm/codedict.rs
+++ b/tvm_assembler/src/disasm/codedict.rs
@@ -151,14 +151,14 @@ impl DelimitedHashmapE {
 
     fn print_impl(&self, cell: &Cell, indent: &str, path: Vec<u8>) -> String {
         let mut text = String::new();
-        text += &format!("{}.cell ", indent);
+        text += &format!("{indent}.cell ");
         text += &format!("{{ ;; #{}\n", cell.repr_hash().to_hex_string());
         let inner_indent = String::from("  ") + indent;
         let mut slice = SliceData::load_cell_ref(cell).unwrap();
         if let Some((id, offset, code)) = self.map.get(&path) {
             let aux = slice.get_next_slice(*offset).unwrap();
             text += &format!("{}.blob x{}\n", inner_indent, aux.to_hex_string());
-            text += &format!("{};; method {}\n", inner_indent, id);
+            text += &format!("{inner_indent};; method {id}\n");
             text += &code.print(&inner_indent, true, 0);
         } else {
             if slice.remaining_bits() > 0 {
@@ -170,7 +170,7 @@ impl DelimitedHashmapE {
                 text += &self.print_impl(&cell.reference(i).unwrap(), inner_indent.as_str(), path);
             }
         }
-        text += &format!("{}}}\n", indent);
+        text += &format!("{indent}}}\n");
         text
     }
 

--- a/tvm_assembler/src/disasm/fmt.rs
+++ b/tvm_assembler/src/disasm/fmt.rs
@@ -33,7 +33,7 @@ pub fn print_tree_of_cells(toc: &Cell) {
             }
             println!("{}{}{}", prefix, if first { indent } else { indent_next }, hex);
         } else {
-            println!("{}{}8_", prefix, indent);
+            println!("{prefix}{indent}8_");
         }
 
         let prefix_child = if last { "  " } else { "│ " };
@@ -83,7 +83,7 @@ fn print_dictpushconst(insn: &Instruction, indent: &str) -> String {
 fn print_cell(cell: &Cell, indent: &str, dot_cell: bool) -> String {
     let mut text = String::new();
     if dot_cell {
-        text += &format!("{}.cell ", indent);
+        text += &format!("{indent}.cell ");
     }
     text += &format!("{{ ;; #{}\n", cell.repr_hash().to_hex_string());
     let inner_indent = String::from("  ") + indent;
@@ -94,7 +94,7 @@ fn print_cell(cell: &Cell, indent: &str, dot_cell: bool) -> String {
     for i in 0..refs {
         text += &print_cell(&cell.reference(i).unwrap(), &inner_indent, true);
     }
-    text += &format!("{}}}", indent);
+    text += &format!("{indent}}}");
     if dot_cell {
         text += "\n";
     }
@@ -115,11 +115,11 @@ fn print_bytecode(slice: Option<(&SliceData, usize)>, bytecode_width: usize) -> 
         if let Some((slice, refs)) = slice {
             let mut b = slice.to_hex_string();
             if refs > 0 {
-                b += &format!(" {{{}r}}", refs);
+                b += &format!(" {{{refs}r}}");
             }
             bytecode = truncate(b, bytecode_width);
         }
-        text += &format!("{:<bytecode_width$} │ ", bytecode);
+        text += &format!("{bytecode:<bytecode_width$} │ ");
     }
     text
 }
@@ -142,7 +142,7 @@ impl Code {
                             insn.params().first()
                         {
                             let hash = cell.as_ref().unwrap().repr_hash().to_hex_string();
-                            text += &format!(".cell {{ ;; #{}\n", hash);
+                            text += &format!(".cell {{ ;; #{hash}\n");
                             let inner_indent = String::from("  ") + indent;
                             text += &code.print(&inner_indent, full, bytecode_width);
                             text += indent;
@@ -161,7 +161,7 @@ impl Code {
             }
             text += &print_insn_params(insn.params(), indent, full, bytecode_width);
             if let Some(comment) = insn.comment() {
-                text += &format!(" ;; {}", comment);
+                text += &format!(" ;; {comment}");
             }
             text += "\n";
         }
@@ -187,28 +187,28 @@ fn print_insn_params(
         let mut curr_is_block = false;
         match param {
             BigInteger(i) => {
-                text += &format!("{}", i);
+                text += &format!("{i}");
             }
             ControlRegister(c) => {
-                text += &format!("c{}", c);
+                text += &format!("c{c}");
             }
             Integer(i) => {
-                text += &format!("{}", i);
+                text += &format!("{i}");
             }
             Length(l) => {
-                text += &format!("{}", l);
+                text += &format!("{l}");
             }
             LengthAndIndex(l, i) => {
-                text += &format!("{}, {}", l, i);
+                text += &format!("{l}, {i}");
             }
             Nargs(n) => {
-                text += &format!("{}", n);
+                text += &format!("{n}");
             }
             Pargs(p) => {
-                text += &format!("{}", p);
+                text += &format!("{p}");
             }
             Rargs(r) => {
-                text += &format!("{}", r);
+                text += &format!("{r}");
             }
             Slice(s) => {
                 // TODO slice may have references
@@ -216,13 +216,13 @@ fn print_insn_params(
                 text += &format!("x{}", s.to_hex_string());
             }
             StackRegister(r) => {
-                text += &format!("s{}", r);
+                text += &format!("s{r}");
             }
             StackRegisterPair(ra, rb) => {
-                text += &format!("s{}, s{}", ra, rb);
+                text += &format!("s{ra}, s{rb}");
             }
             StackRegisterTriple(ra, rb, rc) => {
-                text += &format!("s{}, s{}, s{}", ra, rb, rc);
+                text += &format!("s{ra}, s{rb}, s{rc}");
             }
             Code { code, cell } => {
                 if full {
@@ -248,7 +248,7 @@ fn print_insn_params(
                     } else {
                         text += "{\n";
                         text += &print_bytecode(None, bytecode_width);
-                        text += &format!("{}  ;; missing cell\n", indent);
+                        text += &format!("{indent}  ;; missing cell\n");
                         text += &print_bytecode(None, bytecode_width);
                         text += indent;
                         text += "}";

--- a/tvm_assembler/src/disasm/handlers.rs
+++ b/tvm_assembler/src/disasm/handlers.rs
@@ -886,10 +886,10 @@ impl Handlers {
                     self.directs[code as usize] = Handler::Subset(self.subsets.len());
                     self.subsets.push(std::mem::replace(subset, Handlers::new()))
                 } else {
-                    panic!("Slot for subset {:02x} is already occupied", code)
+                    panic!("Slot for subset {code:02x} is already occupied")
                 }
             }
-            _ => panic!("Subset {:02x} is already registered", code),
+            _ => panic!("Subset {code:02x} is already registered"),
         }
         self
     }
@@ -900,10 +900,10 @@ impl Handlers {
                 if x as usize == Loader::unknown as usize {
                     self.directs[code as usize] = Handler::Direct(handler)
                 } else {
-                    panic!("Code {:02x} is already registered", code)
+                    panic!("Code {code:02x} is already registered")
                 }
             }
-            _ => panic!("Slot for code {:02x} is already occupied", code),
+            _ => panic!("Slot for code {code:02x} is already occupied"),
         }
     }
 

--- a/tvm_assembler/src/disasm/loader.rs
+++ b/tvm_assembler/src/disasm/loader.rs
@@ -125,14 +125,14 @@ fn comment_missing_bits_and_refs(insn: &mut Instruction, missing_bits: usize, mi
         let mut comment = String::from("missing");
         if missing_bits > 0 {
             let plural = if missing_bits > 1 { "s" } else { "" };
-            comment += &format!(" {} bit{}", missing_bits, plural);
+            comment += &format!(" {missing_bits} bit{plural}");
         }
         if missing_bits > 0 && missing_refs > 0 {
             comment += " and";
         }
         if missing_refs > 0 {
             let plural = if missing_refs > 1 { "s" } else { "" };
-            comment += &format!(" {} ref{}", missing_refs, plural);
+            comment += &format!(" {missing_refs} ref{plural}");
         }
         insn.set_comment(comment)
     }

--- a/tvm_assembler/src/errors.rs
+++ b/tvm_assembler/src/errors.rs
@@ -233,10 +233,10 @@ impl fmt::Display for OperationError {
         use OperationError::*;
         match self {
             Parameter(name, error) => {
-                write!(f, "Operation parameter {} has the following problem: {}", name, error)
+                write!(f, "Operation parameter {name} has the following problem: {error}")
             }
             TooManyParameters => write!(f, "Operation has too many parameters."),
-            LogicErrorInParameters(ref error) => write!(f, "Logic error {}", error),
+            LogicErrorInParameters(ref error) => write!(f, "Logic error {error}"),
             MissingRequiredParameters => {
                 write!(f, "Operation requires more parameters.")
             }
@@ -250,10 +250,10 @@ impl fmt::Display for OperationError {
             }
             CellComputeNotACell => write!(f, "Top of the stack is not a cell"),
             CellComputeInternal => write!(f, "Failed to compute the cell"),
-            FragmentIsAlreadyDefined(name) => write!(f, "Fragment {} is already defined", name),
-            FragmentIsNotDefined(name) => write!(f, "Fragment {} is not defined", name),
+            FragmentIsAlreadyDefined(name) => write!(f, "Fragment {name} is already defined"),
+            FragmentIsNotDefined(name) => write!(f, "Fragment {name} is not defined"),
             CodeDictConstruction => write!(f, "Failed to construct code dictionary"),
-            Internal(message) => write!(f, "{}", message),
+            Internal(message) => write!(f, "{message}"),
         }
     }
 }
@@ -262,13 +262,13 @@ impl fmt::Display for CompileError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             CompileError::Syntax(position, explanation) => {
-                write!(f, "{} Syntax error: {}", position, explanation)
+                write!(f, "{position} Syntax error: {explanation}")
             }
             CompileError::UnknownOperation(position, name) => {
-                write!(f, "{} Unknown operation {}", position, name)
+                write!(f, "{position} Unknown operation {name}")
             }
             CompileError::Operation(position, name, error) => {
-                write!(f, "Instruction {} at {}: {}", name, position, error)
+                write!(f, "Instruction {name} at {position}: {error}")
             }
         }
     }

--- a/tvm_assembler/src/instructions_tests/test_framework.rs
+++ b/tvm_assembler/src/instructions_tests/test_framework.rs
@@ -289,9 +289,9 @@ impl<T: Into<TestCase>> Expects for T {
                 print_stack(&test_case, executor);
                 match message {
                     None => panic!("Expected failure: {exc_name}, however execution succeeded."),
-                    Some(msg) => panic!(
-                        "{msg}.\nExpected failure: {exc_name}, however execution succeeded."
-                    ),
+                    Some(msg) => {
+                        panic!("{msg}.\nExpected failure: {exc_name}, however execution succeeded.")
+                    }
                 }
             }
             Err(ref e) => {
@@ -301,9 +301,9 @@ impl<T: Into<TestCase>> Expects for T {
                             Some(msg) => panic!(
                                 "{msg2} - {msg}\nNon expected exception: {e}, expected: {exc_name}"
                             ),
-                            None => panic!(
-                                "{msg2}\nNon expected exception: {e}, expected: {exc_name}"
-                            ),
+                            None => {
+                                panic!("{msg2}\nNon expected exception: {e}, expected: {exc_name}")
+                            }
                         }
                     }
                 } else {

--- a/tvm_assembler/src/instructions_tests/test_framework.rs
+++ b/tvm_assembler/src/instructions_tests/test_framework.rs
@@ -90,12 +90,10 @@ impl TestCase {
                 let err = self.compilation_result.as_ref().unwrap_err();
                 match message {
                     Some(msg) => panic!(
-                        "{}No executor was created, because of bytecode compilation error {:?}",
-                        msg, err
+                        "{msg}No executor was created, because of bytecode compilation error {err:?}"
                     ),
                     None => panic!(
-                        "No executor was created, because of bytecode compilation error {:?}",
-                        err
+                        "No executor was created, because of bytecode compilation error {err:?}"
                     ),
                 }
             }
@@ -121,7 +119,7 @@ impl TestCase {
                     log::error!(target: "compile", "Cannot use 4 refs with long code");
                     bytecode.clone()
                 };
-                log::trace!(target: "compile", "code: {}\n", code);
+                log::trace!(target: "compile", "code: {code}\n");
                 let mut executor = Engine::with_capabilities(args.capabilities)
                     .setup_with_libraries(
                         code.clone(),
@@ -186,9 +184,9 @@ impl<T: Into<TestCase>> Expects for T {
             Ok(_) => {
                 if executor.eq_stack(stack) {
                     if let Some(msg) = message {
-                        log::info!("{}", msg)
+                        log::info!("{msg}")
                     }
-                    log::info!(target: "tvm", "\nExpected stack: \n{}", stack);
+                    log::info!(target: "tvm", "\nExpected stack: \n{stack}");
                     log::info!(
                         target: "tvm",
                         "\n{}\n",
@@ -199,9 +197,9 @@ impl<T: Into<TestCase>> Expects for T {
             }
             // TODO this is not quite right: execution may fail but still produce a stack
             Err(ref e) => {
-                log::info!(target: "tvm", "\nExpected stack: \n{}", stack);
+                log::info!(target: "tvm", "\nExpected stack: \n{stack}");
                 // print_failed_detail_extended(&test_case, e, message);
-                panic!("Execution error: {:?}", e)
+                panic!("Execution error: {e:?}")
             }
         }
         test_case
@@ -214,9 +212,9 @@ impl<T: Into<TestCase>> Expects for T {
             Ok(_) => {
                 if !executor.eq_stack(stack) {
                     if let Some(msg) = message {
-                        log::info!("{}", msg)
+                        log::info!("{msg}")
                     }
-                    log::info!(target: "tvm", "\nExpected stack: \n{}", stack);
+                    log::info!(target: "tvm", "\nExpected stack: \n{stack}");
                     log::info!(
                         target: "tvm",
                         "\n{}\n",
@@ -227,9 +225,9 @@ impl<T: Into<TestCase>> Expects for T {
             }
             // TODO this is not quite right: execution may fail but still produce a stack
             Err(ref e) => {
-                log::info!(target: "tvm", "\nExpected stack: \n{}", stack);
+                log::info!(target: "tvm", "\nExpected stack: \n{stack}");
                 // print_failed_detail_extended(&test_case, e, message);
-                panic!("Execution error: {:?}", e)
+                panic!("Execution error: {e:?}")
             }
         }
         test_case
@@ -247,11 +245,11 @@ impl<T: Into<TestCase>> Expects for T {
             match message {
                 None => {
                     // print_failed_detail_extended(&test_case, e, message);
-                    panic!("Execution error: {:?}", e);
+                    panic!("Execution error: {e:?}");
                 }
                 Some(msg) => {
                     // print_failed_detail_extended(&test_case, e, message);
-                    panic!("{}\nExecution error: {:?}", msg, e);
+                    panic!("{msg}\nExecution error: {e:?}");
                 }
             }
         }
@@ -269,7 +267,7 @@ impl<T: Into<TestCase>> Expects for T {
     ) -> TestCase {
         self.expect_custom_failure_extended(
             |e| e.exception_code() != Some(exception_code),
-            &format!("{}", exception_code),
+            &format!("{exception_code}"),
             message,
         )
     }
@@ -286,15 +284,13 @@ impl<T: Into<TestCase>> Expects for T {
             Ok(_) => {
                 log::info!(
                     target: "tvm",
-                    "Expected failure: {}, however execution succeeded.",
-                    exc_name
+                    "Expected failure: {exc_name}, however execution succeeded."
                 );
                 print_stack(&test_case, executor);
                 match message {
-                    None => panic!("Expected failure: {}, however execution succeeded.", exc_name),
+                    None => panic!("Expected failure: {exc_name}, however execution succeeded."),
                     Some(msg) => panic!(
-                        "{}.\nExpected failure: {}, however execution succeeded.",
-                        msg, exc_name
+                        "{msg}.\nExpected failure: {exc_name}, however execution succeeded."
                     ),
                 }
             }
@@ -303,12 +299,10 @@ impl<T: Into<TestCase>> Expects for T {
                     if op(e) {
                         match message {
                             Some(msg) => panic!(
-                                "{} - {}\nNon expected exception: {}, expected: {}",
-                                msg2, msg, e, exc_name
+                                "{msg2} - {msg}\nNon expected exception: {e}, expected: {exc_name}"
                             ),
                             None => panic!(
-                                "{}\nNon expected exception: {}, expected: {}",
-                                msg2, e, exc_name
+                                "{msg2}\nNon expected exception: {e}, expected: {exc_name}"
                             ),
                         }
                     }
@@ -318,12 +312,12 @@ impl<T: Into<TestCase>> Expects for T {
                         Some(code) => {
                             let e = Exception::from(*code);
                             if op(&e) {
-                                panic!("Non expected exception: {}, expected: {}", e, exc_name)
+                                panic!("Non expected exception: {e}, expected: {exc_name}")
                             }
                         }
                         None => {
                             if op(&Exception::from(ExceptionCode::FatalError)) {
-                                panic!("Non expected exception: {}, expected: {}", e, exc_name)
+                                panic!("Non expected exception: {e}, expected: {exc_name}")
                             }
                         }
                     }

--- a/tvm_assembler/src/instructions_tests/zk/test_helper.rs
+++ b/tvm_assembler/src/instructions_tests/zk/test_helper.rs
@@ -66,12 +66,12 @@ pub fn prepare_proof_and_public_key_cells_for_stack(
     max_epoch: u64,
 ) -> (Cell, Cell) {
     let (iss, kid) = (zk_login_inputs.get_iss().to_string(), zk_login_inputs.get_kid().to_string());
-    println!("kid = {}", kid);
-    println!("all_jwk = {:?}", all_jwk);
+    println!("kid = {kid}");
+    println!("all_jwk = {all_jwk:?}");
 
     let jwk = all_jwk
         .get(&JwkId::new(iss.clone(), kid.clone()))
-        .ok_or_else(|| ZkCryptoError::GeneralError(format!("JWK not found ({} - {})", iss, kid)))
+        .ok_or_else(|| ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})")))
         .unwrap();
 
     // Decode modulus to bytes.
@@ -85,14 +85,14 @@ pub fn prepare_proof_and_public_key_cells_for_stack(
 
     let mut proof_as_bytes = vec![];
     proof.serialize_compressed(&mut proof_as_bytes).unwrap();
-    println!("proof_as_bytes : {:?}", proof_as_bytes);
+    println!("proof_as_bytes : {proof_as_bytes:?}");
     println!("proof_as_bytes len: {:?}", proof_as_bytes.len());
 
     let proof_cell = pack_data_to_cell(&proof_as_bytes, &mut 0).unwrap();
 
     let mut public_inputs_as_bytes = vec![];
     public_inputs.serialize_compressed(&mut public_inputs_as_bytes).unwrap();
-    println!("public_inputs_as_bytes : {:?}", public_inputs_as_bytes);
+    println!("public_inputs_as_bytes : {public_inputs_as_bytes:?}");
     println!("public_inputs_as_bytes len : {:?}", public_inputs_as_bytes.len());
 
     let public_inputs_cell = pack_data_to_cell(&public_inputs_as_bytes, &mut 0).unwrap();

--- a/tvm_assembler/src/instructions_tests/zk/test_poseidon_bad_args.rs
+++ b/tvm_assembler/src/instructions_tests/zk/test_poseidon_bad_args.rs
@@ -161,9 +161,7 @@ mod tests {
             (zk_login_inputs.get_iss().to_string(), zk_login_inputs.get_kid().to_string());
         let jwk = all_jwk
             .get(&JwkId::new(iss.clone(), kid.clone()))
-            .ok_or_else(|| {
-                ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})"))
-            })
+            .ok_or_else(|| ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})")))
             .unwrap();
 
         let max_epoch = 142; // data from the react test
@@ -358,9 +356,7 @@ mod tests {
             (zk_login_inputs.get_iss().to_string(), zk_login_inputs.get_kid().to_string());
         let jwk = all_jwk
             .get(&JwkId::new(iss.clone(), kid.clone()))
-            .ok_or_else(|| {
-                ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})"))
-            })
+            .ok_or_else(|| ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})")))
             .unwrap();
 
         let max_epoch = 142; // data from the react test
@@ -550,9 +546,7 @@ mod tests {
             (zk_login_inputs.get_iss().to_string(), zk_login_inputs.get_kid().to_string());
         let jwk = all_jwk
             .get(&JwkId::new(iss.clone(), kid.clone()))
-            .ok_or_else(|| {
-                ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})"))
-            })
+            .ok_or_else(|| ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})")))
             .unwrap();
 
         let max_epoch = 142; // data from the react test
@@ -741,9 +735,7 @@ mod tests {
             (zk_login_inputs.get_iss().to_string(), zk_login_inputs.get_kid().to_string());
         let jwk = all_jwk
             .get(&JwkId::new(iss.clone(), kid.clone()))
-            .ok_or_else(|| {
-                ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})"))
-            })
+            .ok_or_else(|| ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})")))
             .unwrap();
 
         let max_epoch = 142; // data from the react test
@@ -985,9 +977,7 @@ mod tests {
             (zk_login_inputs.get_iss().to_string(), zk_login_inputs.get_kid().to_string());
         let jwk = all_jwk
             .get(&JwkId::new(iss.clone(), kid.clone()))
-            .ok_or_else(|| {
-                ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})"))
-            })
+            .ok_or_else(|| ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})")))
             .unwrap();
 
         let max_epoch = 142; // data from the react test

--- a/tvm_assembler/src/instructions_tests/zk/test_poseidon_bad_args.rs
+++ b/tvm_assembler/src/instructions_tests/zk/test_poseidon_bad_args.rs
@@ -105,11 +105,11 @@ mod tests {
         // replace by Alina's data (ephemeral public key place to byte array ), depends
         // on iteration
         eph_pubkey.extend(ephemeral_kp.public().as_ref());
-        println!("eph_pubkey: {:?}", eph_pubkey);
+        println!("eph_pubkey: {eph_pubkey:?}");
         println!("len eph_pubkey: {:?}", eph_pubkey.len());
 
         let eph_pubkey_hex_number = "0x".to_owned() + &hex::encode(eph_pubkey.clone());
-        println!("eph_pubkey_hex_number: {:?}", eph_pubkey_hex_number);
+        println!("eph_pubkey_hex_number: {eph_pubkey_hex_number:?}");
 
         let zk_seed = gen_address_seed(
             user_pass_salt,
@@ -118,7 +118,7 @@ mod tests {
             "232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com", // Alina's data (fixed by app id ) from jwt
         ).unwrap();
 
-        println!("zk_seed = {:?}", zk_seed);
+        println!("zk_seed = {zk_seed:?}");
 
         let proof_and_jwt = "{\"proofPoints\":{\"a\":[\"2352077003566407045854435506409565889408960755152253285189640818725808263237\",\
     \"9548308350778027075240385782578683112366097953461273569343148999989145049123\",\"1\"],\
@@ -131,9 +131,9 @@ mod tests {
     \"issBase64Details\":{\"value\":\"yJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLC\",\"indexMod4\":1},\
     \"headerBase64\":\"eyJhbGciOiJSUzI1NiIsImtpZCI6ImEzYjc2MmY4NzFjZGIzYmFlMDA0NGM2NDk2MjJmYzEzOTZlZGEzZTMiLCJ0eXAiOiJKV1QifQ\"}";
         let len = proof_and_jwt.bytes().len();
-        println!(" proof_and_jwt_bytes len (in bytes) = {:?}", len);
+        println!(" proof_and_jwt_bytes len (in bytes) = {len:?}");
 
-        println!("proof_and_jwt: {}", proof_and_jwt);
+        println!("proof_and_jwt: {proof_and_jwt}");
 
         let header_base_64 = "eyJhbGciOiJSUzI1NiIsImtpZCI6ImEzYjc2MmY4NzFjZGIzYmFlMDA0NGM2NDk2MjJmYzEzOTZlZGEzZTMiLCJ0eXAiOiJKV1QifQ";
         let iss_base_64 = "yJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLC";
@@ -162,7 +162,7 @@ mod tests {
         let jwk = all_jwk
             .get(&JwkId::new(iss.clone(), kid.clone()))
             .ok_or_else(|| {
-                ZkCryptoError::GeneralError(format!("JWK not found ({} - {})", iss, kid))
+                ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})"))
             })
             .unwrap();
 
@@ -185,7 +185,7 @@ mod tests {
 
         let mut public_inputs_as_bytes = vec![];
         public_inputs.serialize_compressed(&mut public_inputs_as_bytes).unwrap();
-        println!("HERE public_inputs_as_bytes : {:?}", public_inputs_as_bytes);
+        println!("HERE public_inputs_as_bytes : {public_inputs_as_bytes:?}");
         println!("HERE public_inputs_as_bytes len : {:?}", public_inputs_as_bytes.len());
 
         let public_inputs_cell = pack_data_to_cell(&public_inputs_as_bytes, &mut 0).unwrap();
@@ -302,11 +302,11 @@ mod tests {
         // replace by Alina's data (ephemeral public key place to byte array ), depends
         // on iteration
         eph_pubkey.extend(ephemeral_kp.public().as_ref());
-        println!("eph_pubkey: {:?}", eph_pubkey);
+        println!("eph_pubkey: {eph_pubkey:?}");
         println!("len eph_pubkey: {:?}", eph_pubkey.len());
 
         let eph_pubkey_hex_number = "0x".to_owned() + &hex::encode(eph_pubkey.clone());
-        println!("eph_pubkey_hex_number: {:?}", eph_pubkey_hex_number);
+        println!("eph_pubkey_hex_number: {eph_pubkey_hex_number:?}");
 
         let zk_seed = gen_address_seed(
             user_pass_salt,
@@ -315,7 +315,7 @@ mod tests {
             "232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com", // Alina's data (fixed by app id ) from jwt
         ).unwrap();
 
-        println!("zk_seed = {:?}", zk_seed);
+        println!("zk_seed = {zk_seed:?}");
 
         let proof_and_jwt = "{\"proofPoints\":{\"a\":[\"2352077003566407045854435506409565889408960755152253285189640818725808263237\",\
     \"9548308350778027075240385782578683112366097953461273569343148999989145049123\",\"1\"],\
@@ -328,9 +328,9 @@ mod tests {
     \"issBase64Details\":{\"value\":\"yJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLC\",\"indexMod4\":1},\
     \"headerBase64\":\"eyJhbGciOiJSUzI1NiIsImtpZCI6ImEzYjc2MmY4NzFjZGIzYmFlMDA0NGM2NDk2MjJmYzEzOTZlZGEzZTMiLCJ0eXAiOiJKV1QifQ\"}";
         let len = proof_and_jwt.bytes().len();
-        println!(" proof_and_jwt_bytes len (in bytes) = {:?}", len);
+        println!(" proof_and_jwt_bytes len (in bytes) = {len:?}");
 
-        println!("proof_and_jwt: {}", proof_and_jwt);
+        println!("proof_and_jwt: {proof_and_jwt}");
 
         let header_base_64 = "eyJhbGciOiJSUzI1NiIsImtpZCI6ImEzYjc2MmY4NzFjZGIzYmFlMDA0NGM2NDk2MjJmYzEzOTZlZGEzZTMiLCJ0eXAiOiJKV1QifQ";
 
@@ -359,7 +359,7 @@ mod tests {
         let jwk = all_jwk
             .get(&JwkId::new(iss.clone(), kid.clone()))
             .ok_or_else(|| {
-                ZkCryptoError::GeneralError(format!("JWK not found ({} - {})", iss, kid))
+                ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})"))
             })
             .unwrap();
 
@@ -382,7 +382,7 @@ mod tests {
 
         let mut public_inputs_as_bytes = vec![];
         public_inputs.serialize_compressed(&mut public_inputs_as_bytes).unwrap();
-        println!("HERE public_inputs_as_bytes : {:?}", public_inputs_as_bytes);
+        println!("HERE public_inputs_as_bytes : {public_inputs_as_bytes:?}");
         println!("HERE public_inputs_as_bytes len : {:?}", public_inputs_as_bytes.len());
 
         let public_inputs_cell = pack_data_to_cell(&public_inputs_as_bytes, &mut 0).unwrap();
@@ -495,11 +495,11 @@ mod tests {
         // replace by Alina's data (ephemeral public key place to byte array ), depends
         // on iteration
         eph_pubkey.extend(ephemeral_kp.public().as_ref());
-        println!("eph_pubkey: {:?}", eph_pubkey);
+        println!("eph_pubkey: {eph_pubkey:?}");
         println!("len eph_pubkey: {:?}", eph_pubkey.len());
 
         let eph_pubkey_hex_number = "0x".to_owned() + &hex::encode(eph_pubkey.clone());
-        println!("eph_pubkey_hex_number: {:?}", eph_pubkey_hex_number);
+        println!("eph_pubkey_hex_number: {eph_pubkey_hex_number:?}");
 
         let zk_seed = gen_address_seed(
             user_pass_salt,
@@ -508,7 +508,7 @@ mod tests {
             "232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com", // Alina's data (fixed by app id ) from jwt
         ).unwrap();
 
-        println!("zk_seed = {:?}", zk_seed);
+        println!("zk_seed = {zk_seed:?}");
 
         let proof_and_jwt = "{\"proofPoints\":{\"a\":[\"2352077003566407045854435506409565889408960755152253285189640818725808263237\",\
     \"9548308350778027075240385782578683112366097953461273569343148999989145049123\",\"1\"],\
@@ -521,9 +521,9 @@ mod tests {
     \"issBase64Details\":{\"value\":\"yJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLC\",\"indexMod4\":1},\
     \"headerBase64\":\"eyJhbGciOiJSUzI1NiIsImtpZCI6ImEzYjc2MmY4NzFjZGIzYmFlMDA0NGM2NDk2MjJmYzEzOTZlZGEzZTMiLCJ0eXAiOiJKV1QifQ\"}";
         let len = proof_and_jwt.bytes().len();
-        println!(" proof_and_jwt_bytes len (in bytes) = {:?}", len);
+        println!(" proof_and_jwt_bytes len (in bytes) = {len:?}");
 
-        println!("proof_and_jwt: {}", proof_and_jwt);
+        println!("proof_and_jwt: {proof_and_jwt}");
 
         let iss_base_64 = "yJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLC";
         let index_mod_4 = "1";
@@ -551,7 +551,7 @@ mod tests {
         let jwk = all_jwk
             .get(&JwkId::new(iss.clone(), kid.clone()))
             .ok_or_else(|| {
-                ZkCryptoError::GeneralError(format!("JWK not found ({} - {})", iss, kid))
+                ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})"))
             })
             .unwrap();
 
@@ -574,7 +574,7 @@ mod tests {
 
         let mut public_inputs_as_bytes = vec![];
         public_inputs.serialize_compressed(&mut public_inputs_as_bytes).unwrap();
-        println!("HERE public_inputs_as_bytes : {:?}", public_inputs_as_bytes);
+        println!("HERE public_inputs_as_bytes : {public_inputs_as_bytes:?}");
         println!("HERE public_inputs_as_bytes len : {:?}", public_inputs_as_bytes.len());
 
         let public_inputs_cell = pack_data_to_cell(&public_inputs_as_bytes, &mut 0).unwrap();
@@ -685,11 +685,11 @@ mod tests {
         // replace by Alina's data (ephemeral public key place to byte array ), depends
         // on iteration
         eph_pubkey.extend(ephemeral_kp.public().as_ref());
-        println!("eph_pubkey: {:?}", eph_pubkey);
+        println!("eph_pubkey: {eph_pubkey:?}");
         println!("len eph_pubkey: {:?}", eph_pubkey.len());
 
         let eph_pubkey_hex_number = "0x".to_owned() + &hex::encode(eph_pubkey.clone());
-        println!("eph_pubkey_hex_number: {:?}", eph_pubkey_hex_number);
+        println!("eph_pubkey_hex_number: {eph_pubkey_hex_number:?}");
 
         let zk_seed = gen_address_seed(
             user_pass_salt,
@@ -698,7 +698,7 @@ mod tests {
             "232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com", // Alina's data (fixed by app id ) from jwt
         ).unwrap();
 
-        println!("zk_seed = {:?}", zk_seed);
+        println!("zk_seed = {zk_seed:?}");
 
         let proof_and_jwt = "{\"proofPoints\":{\"a\":[\"2352077003566407045854435506409565889408960755152253285189640818725808263237\",\
     \"9548308350778027075240385782578683112366097953461273569343148999989145049123\",\"1\"],\
@@ -711,9 +711,9 @@ mod tests {
     \"issBase64Details\":{\"value\":\"yJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLC\",\"indexMod4\":1},\
     \"headerBase64\":\"eyJhbGciOiJSUzI1NiIsImtpZCI6ImEzYjc2MmY4NzFjZGIzYmFlMDA0NGM2NDk2MjJmYzEzOTZlZGEzZTMiLCJ0eXAiOiJKV1QifQ\"}";
         let len = proof_and_jwt.bytes().len();
-        println!(" proof_and_jwt_bytes len (in bytes) = {:?}", len);
+        println!(" proof_and_jwt_bytes len (in bytes) = {len:?}");
 
-        println!("proof_and_jwt: {}", proof_and_jwt);
+        println!("proof_and_jwt: {proof_and_jwt}");
 
         let header_base_64 = "eyJhbGciOiJSUzI1NiIsImtpZCI6ImEzYjc2MmY4NzFjZGIzYmFlMDA0NGM2NDk2MjJmYzEzOTZlZGEzZTMiLCJ0eXAiOiJKV1QifQ";
         let iss_base_64 = "yJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLC";
@@ -742,7 +742,7 @@ mod tests {
         let jwk = all_jwk
             .get(&JwkId::new(iss.clone(), kid.clone()))
             .ok_or_else(|| {
-                ZkCryptoError::GeneralError(format!("JWK not found ({} - {})", iss, kid))
+                ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})"))
             })
             .unwrap();
 
@@ -763,7 +763,7 @@ mod tests {
 
         let mut public_inputs_as_bytes = vec![];
         public_inputs.serialize_compressed(&mut public_inputs_as_bytes).unwrap();
-        println!("HERE public_inputs_as_bytes : {:?}", public_inputs_as_bytes);
+        println!("HERE public_inputs_as_bytes : {public_inputs_as_bytes:?}");
         println!("HERE public_inputs_as_bytes len : {:?}", public_inputs_as_bytes.len());
 
         let public_inputs_cell = pack_data_to_cell(&public_inputs_as_bytes, &mut 0).unwrap();
@@ -929,11 +929,11 @@ mod tests {
         // replace by Alina's data (ephemeral public key place to byte array ), depends
         // on iteration
         eph_pubkey.extend(ephemeral_kp.public().as_ref());
-        println!("eph_pubkey: {:?}", eph_pubkey);
+        println!("eph_pubkey: {eph_pubkey:?}");
         println!("len eph_pubkey: {:?}", eph_pubkey.len());
 
         let eph_pubkey_hex_number = "0x".to_owned() + &hex::encode(eph_pubkey.clone());
-        println!("eph_pubkey_hex_number: {:?}", eph_pubkey_hex_number);
+        println!("eph_pubkey_hex_number: {eph_pubkey_hex_number:?}");
 
         let zk_seed = gen_address_seed(
             user_pass_salt,
@@ -942,7 +942,7 @@ mod tests {
             "232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com", // Alina's data (fixed by app id ) from jwt
         ).unwrap();
 
-        println!("zk_seed = {:?}", zk_seed);
+        println!("zk_seed = {zk_seed:?}");
 
         let proof_and_jwt = "{\"proofPoints\":{\"a\":[\"2352077003566407045854435506409565889408960755152253285189640818725808263237\",\
     \"9548308350778027075240385782578683112366097953461273569343148999989145049123\",\"1\"],\
@@ -955,9 +955,9 @@ mod tests {
     \"issBase64Details\":{\"value\":\"yJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLC\",\"indexMod4\":1},\
     \"headerBase64\":\"eyJhbGciOiJSUzI1NiIsImtpZCI6ImEzYjc2MmY4NzFjZGIzYmFlMDA0NGM2NDk2MjJmYzEzOTZlZGEzZTMiLCJ0eXAiOiJKV1QifQ\"}";
         let len = proof_and_jwt.bytes().len();
-        println!(" proof_and_jwt_bytes len (in bytes) = {:?}", len);
+        println!(" proof_and_jwt_bytes len (in bytes) = {len:?}");
 
-        println!("proof_and_jwt: {}", proof_and_jwt);
+        println!("proof_and_jwt: {proof_and_jwt}");
 
         let header_base_64 = "eyJhbGciOiJSUzI1NiIsImtpZCI6ImEzYjc2MmY4NzFjZGIzYmFlMDA0NGM2NDk2MjJmYzEzOTZlZGEzZTMiLCJ0eXAiOiJKV1QifQ";
         let iss_base_64 = "yJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLC";
@@ -986,7 +986,7 @@ mod tests {
         let jwk = all_jwk
             .get(&JwkId::new(iss.clone(), kid.clone()))
             .ok_or_else(|| {
-                ZkCryptoError::GeneralError(format!("JWK not found ({} - {})", iss, kid))
+                ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})"))
             })
             .unwrap();
 
@@ -1011,7 +1011,7 @@ mod tests {
 
         let mut public_inputs_as_bytes = vec![];
         public_inputs.serialize_compressed(&mut public_inputs_as_bytes).unwrap();
-        println!("HERE public_inputs_as_bytes : {:?}", public_inputs_as_bytes);
+        println!("HERE public_inputs_as_bytes : {public_inputs_as_bytes:?}");
         println!("HERE public_inputs_as_bytes len : {:?}", public_inputs_as_bytes.len());
 
         let public_inputs_cell = pack_data_to_cell(&public_inputs_as_bytes, &mut 0).unwrap();

--- a/tvm_assembler/src/instructions_tests/zk/test_zk_bad_proof.rs
+++ b/tvm_assembler/src/instructions_tests/zk/test_zk_bad_proof.rs
@@ -159,9 +159,7 @@ mod tests {
             (zk_login_inputs.get_iss().to_string(), zk_login_inputs.get_kid().to_string());
         let jwk = all_jwk
             .get(&JwkId::new(iss.clone(), kid.clone()))
-            .ok_or_else(|| {
-                ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})"))
-            })
+            .ok_or_else(|| ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})")))
             .unwrap();
 
         let max_epoch = 142; // data from the react test

--- a/tvm_assembler/src/instructions_tests/zk/test_zk_bad_proof.rs
+++ b/tvm_assembler/src/instructions_tests/zk/test_zk_bad_proof.rs
@@ -99,11 +99,11 @@ mod tests {
         // replace by Alina's data (ephemeral public key place to byte array ), depends
         // on iteration
         eph_pubkey.extend(ephemeral_kp.public().as_ref());
-        println!("eph_pubkey: {:?}", eph_pubkey);
+        println!("eph_pubkey: {eph_pubkey:?}");
         println!("len eph_pubkey: {:?}", eph_pubkey.len());
 
         let eph_pubkey_hex_number = "0x".to_owned() + &hex::encode(eph_pubkey.clone());
-        println!("eph_pubkey_hex_number: {:?}", eph_pubkey_hex_number);
+        println!("eph_pubkey_hex_number: {eph_pubkey_hex_number:?}");
 
         // Get the zklogin seed.
         // This stuff is a kind of bound between  smart contract and email (some
@@ -116,7 +116,7 @@ mod tests {
             "232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com", // Alina's data (fixed by app id ) from jwt
         ).unwrap();
 
-        println!("zk_seed = {:?}", zk_seed);
+        println!("zk_seed = {zk_seed:?}");
 
         let proof_and_jwt = "{\"proofPoints\":{\"a\":[\"2352077003566407045854435506409565889408960755152253285189640818725808263237\",\
     \"9548308350778027075240385782578683112366097953461273569343148999989145049123\",\"1\"],\
@@ -129,13 +129,13 @@ mod tests {
     \"issBase64Details\":{\"value\":\"yJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLC\",\"indexMod4\":1},\
     \"headerBase64\":\"eyJhbGciOiJSUzI1NiIsImtpZCI6ImEzYjc2MmY4NzFjZGIzYmFlMDA0NGM2NDk2MjJmYzEzOTZlZGEzZTMiLCJ0eXAiOiJKV1QifQ\"}";
         let len = proof_and_jwt.bytes().len();
-        println!(" proof_and_jwt_bytes len (in bytes) = {:?}", len);
+        println!(" proof_and_jwt_bytes len (in bytes) = {len:?}");
 
-        println!("proof_and_jwt: {}", proof_and_jwt);
+        println!("proof_and_jwt: {proof_and_jwt}");
 
         let iss_and_header_base64details = "{\"issBase64Details\":{\"value\":\"yJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLC\",\"indexMod4\":1},\"headerBase64\":\"eyJhbGciOiJSUzI1NiIsImtpZCI6ImEzYjc2MmY4NzFjZGIzYmFlMDA0NGM2NDk2MjJmYzEzOTZlZGEzZTMiLCJ0eXAiOiJKV1QifQ\"}";
 
-        println!("iss_and_header_base64details: {}", iss_and_header_base64details);
+        println!("iss_and_header_base64details: {iss_and_header_base64details}");
 
         let zk_login_inputs =
             ZkLoginInputs::from_json(&*proof_and_jwt, &*zk_seed.to_string()).unwrap();
@@ -160,7 +160,7 @@ mod tests {
         let jwk = all_jwk
             .get(&JwkId::new(iss.clone(), kid.clone()))
             .ok_or_else(|| {
-                ZkCryptoError::GeneralError(format!("JWK not found ({} - {})", iss, kid))
+                ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})"))
             })
             .unwrap();
 
@@ -178,7 +178,7 @@ mod tests {
 
         let mut public_inputs_as_bytes = vec![];
         public_inputs.serialize_compressed(&mut public_inputs_as_bytes).unwrap();
-        println!("HERE public_inputs_as_bytes : {:?}", public_inputs_as_bytes);
+        println!("HERE public_inputs_as_bytes : {public_inputs_as_bytes:?}");
         println!("HERE public_inputs_as_bytes len : {:?}", public_inputs_as_bytes.len());
 
         let public_inputs_cell = pack_data_to_cell(&public_inputs_as_bytes, &mut 0).unwrap();
@@ -198,14 +198,14 @@ mod tests {
 
         let mut proof_as_bytes = vec![];
         proof.serialize_compressed(&mut proof_as_bytes).unwrap();
-        println!("proof_as_bytes : {:?}", proof_as_bytes);
+        println!("proof_as_bytes : {proof_as_bytes:?}");
         println!("proof_as_bytes len: {:?}", proof_as_bytes.len());
 
         // INTENTIONALLY SPOIL PROOF
 
         proof_as_bytes.pop();
 
-        println!("proof_as_bytes : {:?}", proof_as_bytes);
+        println!("proof_as_bytes : {proof_as_bytes:?}");
         println!("proof_as_bytes len: {:?}", proof_as_bytes.len());
 
         let proof_cell = pack_data_to_cell(&proof_as_bytes, &mut 0).unwrap();
@@ -232,14 +232,14 @@ mod tests {
 
         let mut proof_as_bytes = vec![];
         proof.serialize_compressed(&mut proof_as_bytes).unwrap();
-        println!("proof_as_bytes : {:?}", proof_as_bytes);
+        println!("proof_as_bytes : {proof_as_bytes:?}");
         println!("proof_as_bytes len: {:?}", proof_as_bytes.len());
 
         // INTENTIONALLY SPOIL PROOF
 
         proof_as_bytes.push(1);
 
-        println!("proof_as_bytes : {:?}", proof_as_bytes);
+        println!("proof_as_bytes : {proof_as_bytes:?}");
         println!("proof_as_bytes len: {:?}", proof_as_bytes.len());
 
         let proof_cell = pack_data_to_cell(&proof_as_bytes, &mut 0).unwrap();
@@ -266,9 +266,9 @@ mod tests {
 
         let proof_as_bytes = vec![1; 129];
 
-        println!("proof_as_bytes: {:?}", proof_as_bytes);
+        println!("proof_as_bytes: {proof_as_bytes:?}");
 
-        println!("proof_as_bytes : {:?}", proof_as_bytes);
+        println!("proof_as_bytes : {proof_as_bytes:?}");
         println!("proof_as_bytes len: {:?}", proof_as_bytes.len());
 
         let proof_cell = pack_data_to_cell(&proof_as_bytes, &mut 0).unwrap();
@@ -294,9 +294,9 @@ mod tests {
 
         let proof_as_bytes = vec![2; 128];
 
-        println!("proof_as_bytes: {:?}", proof_as_bytes);
+        println!("proof_as_bytes: {proof_as_bytes:?}");
 
-        println!("proof_as_bytes : {:?}", proof_as_bytes);
+        println!("proof_as_bytes : {proof_as_bytes:?}");
         println!("proof_as_bytes len: {:?}", proof_as_bytes.len());
 
         let proof_cell = pack_data_to_cell(&proof_as_bytes, &mut 0).unwrap();
@@ -323,14 +323,14 @@ mod tests {
 
         let mut proof_as_bytes = vec![];
         proof.serialize_compressed(&mut proof_as_bytes).unwrap();
-        println!("proof_as_bytes : {:?}", proof_as_bytes);
+        println!("proof_as_bytes : {proof_as_bytes:?}");
         println!("proof_as_bytes len: {:?}", proof_as_bytes.len());
 
         // INTENTIONALLY SPOIL PROOF
 
         proof_as_bytes[0] = 1;
 
-        println!("proof_as_bytes : {:?}", proof_as_bytes);
+        println!("proof_as_bytes : {proof_as_bytes:?}");
         println!("proof_as_bytes len: {:?}", proof_as_bytes.len());
 
         let proof_cell = pack_data_to_cell(&proof_as_bytes, &mut 0).unwrap();
@@ -356,14 +356,14 @@ mod tests {
 
         let mut proof_as_bytes = vec![];
         proof.serialize_compressed(&mut proof_as_bytes).unwrap();
-        println!("proof_as_bytes : {:?}", proof_as_bytes);
+        println!("proof_as_bytes : {proof_as_bytes:?}");
         println!("proof_as_bytes len: {:?}", proof_as_bytes.len());
 
         // INTENTIONALLY SPOIL PROOF
 
         proof_as_bytes[120] = 25;
 
-        println!("proof_as_bytes : {:?}", proof_as_bytes);
+        println!("proof_as_bytes : {proof_as_bytes:?}");
         println!("proof_as_bytes len: {:?}", proof_as_bytes.len());
 
         let proof_cell = pack_data_to_cell(&proof_as_bytes, &mut 0).unwrap();

--- a/tvm_assembler/src/instructions_tests/zk/test_zk_bad_public_input.rs
+++ b/tvm_assembler/src/instructions_tests/zk/test_zk_bad_public_input.rs
@@ -157,9 +157,7 @@ mod tests {
             (zk_login_inputs.get_iss().to_string(), zk_login_inputs.get_kid().to_string());
         let jwk = all_jwk
             .get(&JwkId::new(iss.clone(), kid.clone()))
-            .ok_or_else(|| {
-                ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})"))
-            })
+            .ok_or_else(|| ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})")))
             .unwrap();
 
         let max_epoch = 142; // data from the react test

--- a/tvm_assembler/src/instructions_tests/zk/test_zk_bad_public_input.rs
+++ b/tvm_assembler/src/instructions_tests/zk/test_zk_bad_public_input.rs
@@ -97,11 +97,11 @@ mod tests {
         // replace by Alina's data (ephemeral public key place to byte array ), depends
         // on iteration
         eph_pubkey.extend(ephemeral_kp.public().as_ref());
-        println!("eph_pubkey: {:?}", eph_pubkey);
+        println!("eph_pubkey: {eph_pubkey:?}");
         println!("len eph_pubkey: {:?}", eph_pubkey.len());
 
         let eph_pubkey_hex_number = "0x".to_owned() + &hex::encode(eph_pubkey.clone());
-        println!("eph_pubkey_hex_number: {:?}", eph_pubkey_hex_number);
+        println!("eph_pubkey_hex_number: {eph_pubkey_hex_number:?}");
 
         // Get the zklogin seed.
         // This stuff is a kind of bound between  smart contract and email (some
@@ -114,7 +114,7 @@ mod tests {
             "232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com", // Alina's data (fixed by app id ) from jwt
         ).unwrap();
 
-        println!("zk_seed = {:?}", zk_seed);
+        println!("zk_seed = {zk_seed:?}");
 
         let proof_and_jwt = "{\"proofPoints\":{\"a\":[\"2352077003566407045854435506409565889408960755152253285189640818725808263237\",\
     \"9548308350778027075240385782578683112366097953461273569343148999989145049123\",\"1\"],\
@@ -127,13 +127,13 @@ mod tests {
     \"issBase64Details\":{\"value\":\"yJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLC\",\"indexMod4\":1},\
     \"headerBase64\":\"eyJhbGciOiJSUzI1NiIsImtpZCI6ImEzYjc2MmY4NzFjZGIzYmFlMDA0NGM2NDk2MjJmYzEzOTZlZGEzZTMiLCJ0eXAiOiJKV1QifQ\"}";
         let len = proof_and_jwt.bytes().len();
-        println!(" proof_and_jwt_bytes len (in bytes) = {:?}", len);
+        println!(" proof_and_jwt_bytes len (in bytes) = {len:?}");
 
-        println!("proof_and_jwt: {}", proof_and_jwt);
+        println!("proof_and_jwt: {proof_and_jwt}");
 
         let iss_and_header_base64details = "{\"issBase64Details\":{\"value\":\"yJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLC\",\"indexMod4\":1},\"headerBase64\":\"eyJhbGciOiJSUzI1NiIsImtpZCI6ImEzYjc2MmY4NzFjZGIzYmFlMDA0NGM2NDk2MjJmYzEzOTZlZGEzZTMiLCJ0eXAiOiJKV1QifQ\"}";
 
-        println!("iss_and_header_base64details: {}", iss_and_header_base64details);
+        println!("iss_and_header_base64details: {iss_and_header_base64details}");
 
         let zk_login_inputs =
             ZkLoginInputs::from_json(&*proof_and_jwt, &*zk_seed.to_string()).unwrap();
@@ -158,7 +158,7 @@ mod tests {
         let jwk = all_jwk
             .get(&JwkId::new(iss.clone(), kid.clone()))
             .ok_or_else(|| {
-                ZkCryptoError::GeneralError(format!("JWK not found ({} - {})", iss, kid))
+                ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})"))
             })
             .unwrap();
 
@@ -176,7 +176,7 @@ mod tests {
 
         let mut public_inputs_as_bytes = vec![];
         public_inputs.serialize_compressed(&mut public_inputs_as_bytes).unwrap();
-        println!("HERE public_inputs_as_bytes : {:?}", public_inputs_as_bytes);
+        println!("HERE public_inputs_as_bytes : {public_inputs_as_bytes:?}");
         println!("HERE public_inputs_as_bytes len : {:?}", public_inputs_as_bytes.len());
 
         let proof = zk_login_inputs.get_proof();
@@ -192,7 +192,7 @@ mod tests {
         let mut proof_as_bytes = vec![];
         proof.serialize_compressed(&mut proof_as_bytes).unwrap();
 
-        println!("proof_as_bytes : {:?}", proof_as_bytes);
+        println!("proof_as_bytes : {proof_as_bytes:?}");
         println!("proof_as_bytes len: {:?}", proof_as_bytes.len());
 
         let mut public_inputs_as_bytes = data.public_inputs_as_bytes;
@@ -224,12 +224,12 @@ mod tests {
         let mut proof_as_bytes = vec![];
         proof.serialize_compressed(&mut proof_as_bytes).unwrap();
 
-        println!("proof_as_bytes : {:?}", proof_as_bytes);
+        println!("proof_as_bytes : {proof_as_bytes:?}");
         println!("proof_as_bytes len: {:?}", proof_as_bytes.len());
 
         let mut public_inputs_as_bytes = data.public_inputs_as_bytes;
 
-        println!("public_inputs_as_bytes : {:?}", public_inputs_as_bytes);
+        println!("public_inputs_as_bytes : {public_inputs_as_bytes:?}");
         println!("public_inputs_as_bytes len: {:?}", public_inputs_as_bytes.len());
 
         public_inputs_as_bytes.push(1);
@@ -261,17 +261,17 @@ mod tests {
         let mut proof_as_bytes = vec![];
         proof.serialize_compressed(&mut proof_as_bytes).unwrap();
 
-        println!("proof_as_bytes : {:?}", proof_as_bytes);
+        println!("proof_as_bytes : {proof_as_bytes:?}");
         println!("proof_as_bytes len: {:?}", proof_as_bytes.len());
 
         let mut public_inputs_as_bytes = data.public_inputs_as_bytes;
 
-        println!("public_inputs_as_bytes : {:?}", public_inputs_as_bytes);
+        println!("public_inputs_as_bytes : {public_inputs_as_bytes:?}");
         println!("public_inputs_as_bytes len: {:?}", public_inputs_as_bytes.len());
 
         public_inputs_as_bytes[0] = 0;
 
-        println!("public_inputs_as_bytes : {:?}", public_inputs_as_bytes);
+        println!("public_inputs_as_bytes : {public_inputs_as_bytes:?}");
 
         let public_inputs_cell = pack_data_to_cell(&public_inputs_as_bytes, &mut 0).unwrap();
 
@@ -298,17 +298,17 @@ mod tests {
         let mut proof_as_bytes = vec![];
         proof.serialize_compressed(&mut proof_as_bytes).unwrap();
 
-        println!("proof_as_bytes : {:?}", proof_as_bytes);
+        println!("proof_as_bytes : {proof_as_bytes:?}");
         println!("proof_as_bytes len: {:?}", proof_as_bytes.len());
 
         let mut public_inputs_as_bytes = data.public_inputs_as_bytes;
 
-        println!("public_inputs_as_bytes : {:?}", public_inputs_as_bytes);
+        println!("public_inputs_as_bytes : {public_inputs_as_bytes:?}");
         println!("public_inputs_as_bytes len: {:?}", public_inputs_as_bytes.len());
 
         public_inputs_as_bytes[20] = 50;
 
-        println!("public_inputs_as_bytes : {:?}", public_inputs_as_bytes);
+        println!("public_inputs_as_bytes : {public_inputs_as_bytes:?}");
 
         let public_inputs_cell = pack_data_to_cell(&public_inputs_as_bytes, &mut 0).unwrap();
 
@@ -335,12 +335,12 @@ mod tests {
         let mut proof_as_bytes = vec![];
         proof.serialize_compressed(&mut proof_as_bytes).unwrap();
 
-        println!("proof_as_bytes : {:?}", proof_as_bytes);
+        println!("proof_as_bytes : {proof_as_bytes:?}");
         println!("proof_as_bytes len: {:?}", proof_as_bytes.len());
 
         let public_inputs_as_bytes = vec![0; 32];
 
-        println!("public_inputs_as_bytes : {:?}", public_inputs_as_bytes);
+        println!("public_inputs_as_bytes : {public_inputs_as_bytes:?}");
 
         let public_inputs_cell = pack_data_to_cell(&public_inputs_as_bytes, &mut 0).unwrap();
 

--- a/tvm_assembler/src/instructions_tests/zk/test_zk_for_apple.rs
+++ b/tvm_assembler/src/instructions_tests/zk/test_zk_for_apple.rs
@@ -56,7 +56,7 @@ mod tests {
             content,
         );
 
-        println!("all_jwk = {:?}", all_jwk);
+        println!("all_jwk = {all_jwk:?}");
 
         // let jwt_randomness = "100681567828351849884072155819400689117";
         // A dummy salt
@@ -72,13 +72,13 @@ mod tests {
         // "84029355920633174015103288781128426107680789454168570548782290541079926444544"
         // ;
 
-        println!("kp_bigint = {:?} ", kp_bigint);
+        println!("kp_bigint = {kp_bigint:?} ");
 
         let jwt_data_vector: Vec<&str> = parsed_token.split(".").collect();
         let jwt_data_1 = decode(jwt_data_vector[0]).expect("Base64 decoding failed");
 
         let jwt_string_1 = String::from_utf8(jwt_data_1).expect("UTF-8 conversion failed");
-        println!("jwt_string_1 is {:?}", jwt_string_1); // jwt_string_1 is
+        println!("jwt_string_1 is {jwt_string_1:?}"); // jwt_string_1 is
 
         // JwtDataDecodedPart1
         let jwt_data_decoded1: JwtDataDecodedPart1 = serde_json::from_str(&jwt_string_1).unwrap();
@@ -86,7 +86,7 @@ mod tests {
 
         let jwt_data_2 = decode(jwt_data_vector[1]).expect("Base64 decoding failed");
         let jwt_string_2 = String::from_utf8(jwt_data_2).expect("UTF-8 conversion failed");
-        println!("jwt_string_2 is {:?}", jwt_string_2);
+        println!("jwt_string_2 is {jwt_string_2:?}");
 
         let jwt_data_decoded2: JwtDataDecodedPart2 = serde_json::from_str(&jwt_string_2).unwrap();
 

--- a/tvm_assembler/src/instructions_tests/zk/test_zk_for_credenza3.rs
+++ b/tvm_assembler/src/instructions_tests/zk/test_zk_for_credenza3.rs
@@ -62,7 +62,7 @@ mod tests {
             content,
         );
 
-        println!("all_jwk = {:?}", all_jwk);
+        println!("all_jwk = {all_jwk:?}");
 
         let max_epoch = 10;
         // let jwt_randomness = "100681567828351849884072155819400689117";
@@ -79,13 +79,13 @@ mod tests {
         // "84029355920633174015103288781128426107680789454168570548782290541079926444544"
         // ;
 
-        println!("kp_bigint = {:?} ", kp_bigint);
+        println!("kp_bigint = {kp_bigint:?} ");
 
         let jwt_data_vector: Vec<&str> = parsed_token.split(".").collect();
         let jwt_data_1 = decode(jwt_data_vector[0]).expect("Base64 decoding failed");
 
         let jwt_string_1 = String::from_utf8(jwt_data_1).expect("UTF-8 conversion failed");
-        println!("jwt_string_1 is {:?}", jwt_string_1); // jwt_string_1 is
+        println!("jwt_string_1 is {jwt_string_1:?}"); // jwt_string_1 is
 
         // JwtDataDecodedPart1
         let jwt_data_decoded1: JwtDataDecodedPart1 = serde_json::from_str(&jwt_string_1).unwrap();
@@ -94,7 +94,7 @@ mod tests {
 
         let jwt_data_2 = decode(jwt_data_vector[1]).expect("Base64 decoding failed");
         let jwt_string_2 = String::from_utf8(jwt_data_2).expect("UTF-8 conversion failed");
-        println!("jwt_string_2 is {:?}", jwt_string_2);
+        println!("jwt_string_2 is {jwt_string_2:?}");
 
         let jwt_data_decoded2: JwtDataDecodedPart2 = serde_json::from_str(&jwt_string_2).unwrap();
 

--- a/tvm_assembler/src/instructions_tests/zk/test_zk_for_facebook.rs
+++ b/tvm_assembler/src/instructions_tests/zk/test_zk_for_facebook.rs
@@ -82,17 +82,17 @@ mod tests {
             let mut eph_pubkey = Vec::new(); // vec![0x00];
             eph_pubkey.extend(ephemeral_kp.public().as_ref());
 
-            println!("ephemeral secret_key is {:?}", eph_secret_key);
-            println!("ephemeral public_key is {:?}", eph_pubkey);
+            println!("ephemeral secret_key is {eph_secret_key:?}");
+            println!("ephemeral public_key is {eph_pubkey:?}");
 
             let eph_pubkey_len = eph_pubkey.clone().len();
-            println!("len eph_pubkey: {:?}", eph_pubkey_len);
+            println!("len eph_pubkey: {eph_pubkey_len:?}");
 
             let jwt_data_vector: Vec<&str> = jwt_data.jwt.split(".").collect();
             let jwt_data_1 = decode(jwt_data_vector[0]).expect("Base64 decoding failed");
 
             let jwt_string_1 = String::from_utf8(jwt_data_1).expect("UTF-8 conversion failed");
-            println!("jwt_string_1 is {:?}", jwt_string_1); // jwt_string_1 is
+            println!("jwt_string_1 is {jwt_string_1:?}"); // jwt_string_1 is
 
             // JwtDataDecodedPart1
             let jwt_data_decoded1: JwtDataDecodedPart1 =
@@ -101,7 +101,7 @@ mod tests {
 
             let jwt_data_2 = decode(jwt_data_vector[1]).expect("Base64 decoding failed");
             let jwt_string_2 = String::from_utf8(jwt_data_2).expect("UTF-8 conversion failed");
-            println!("jwt_string_2 is {:?}", jwt_string_2); // "{\"iss\":\"https://accounts.google.com\",\"azp\":\"232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com\",\"aud\":\"232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com\",\"sub\":\"112897468626716626103\",\"nonce\":\"bxmnJW31ruzKMGir01YPGYL0xDY\",\"nbf\":1715687036,\"iat\":1715687336,\"exp\":1715690936,\"jti\":\"9b601d25f003640c2889a2a047789382cb1cfe87\"}"
+            println!("jwt_string_2 is {jwt_string_2:?}"); // "{\"iss\":\"https://accounts.google.com\",\"azp\":\"232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com\",\"aud\":\"232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com\",\"sub\":\"112897468626716626103\",\"nonce\":\"bxmnJW31ruzKMGir01YPGYL0xDY\",\"nbf\":1715687036,\"iat\":1715687336,\"exp\":1715690936,\"jti\":\"9b601d25f003640c2889a2a047789382cb1cfe87\"}"
 
             // JwtDataDecodedPart2
             let jwt_data_decoded2: JwtDataDecodedPart2 =

--- a/tvm_assembler/src/instructions_tests/zk/test_zk_for_google.rs
+++ b/tvm_assembler/src/instructions_tests/zk/test_zk_for_google.rs
@@ -174,9 +174,7 @@ mod tests {
             (zk_login_inputs.get_iss().to_string(), zk_login_inputs.get_kid().to_string());
         let jwk = all_jwk
             .get(&JwkId::new(iss.clone(), kid.clone()))
-            .ok_or_else(|| {
-                ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})"))
-            })
+            .ok_or_else(|| ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})")))
             .unwrap();
 
         let max_epoch = 142; // data from the react test
@@ -309,9 +307,7 @@ mod tests {
 
         let jwk = all_jwk
             .get(&JwkId::new(iss.clone(), kid.clone()))
-            .ok_or_else(|| {
-                ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})"))
-            })
+            .ok_or_else(|| ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})")))
             .unwrap();
 
         // Decode modulus to bytes.
@@ -693,9 +689,7 @@ mod tests {
             (zk_login_inputs.get_iss().to_string(), zk_login_inputs.get_kid().to_string());
         let jwk = all_jwk
             .get(&JwkId::new(iss.clone(), kid.clone()))
-            .ok_or_else(|| {
-                ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})"))
-            })
+            .ok_or_else(|| ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})")))
             .unwrap();
 
         let max_epoch = 142; // data from the react test
@@ -822,9 +816,7 @@ mod tests {
 
         let jwk = all_jwk
             .get(&JwkId::new(iss.clone(), kid.clone()))
-            .ok_or_else(|| {
-                ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})"))
-            })
+            .ok_or_else(|| ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})")))
             .unwrap();
 
         // Decode modulus to bytes.
@@ -941,9 +933,7 @@ mod tests {
 
         let jwk = all_jwk
             .get(&JwkId::new(iss.clone(), kid.clone()))
-            .ok_or_else(|| {
-                ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})"))
-            })
+            .ok_or_else(|| ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})")))
             .unwrap();
 
         // Decode modulus to bytes.
@@ -1051,9 +1041,7 @@ mod tests {
 
         let jwk = all_jwk
             .get(&JwkId::new(iss.clone(), kid.clone()))
-            .ok_or_else(|| {
-                ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})"))
-            })
+            .ok_or_else(|| ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})")))
             .unwrap();
 
         let max_epoch = 10;
@@ -1211,9 +1199,7 @@ mod tests {
             (zk_login_inputs.get_iss().to_string(), zk_login_inputs.get_kid().to_string());
         let jwk = all_jwk
             .get(&JwkId::new(iss.clone(), kid.clone()))
-            .ok_or_else(|| {
-                ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})"))
-            })
+            .ok_or_else(|| ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})")))
             .unwrap();
 
         let max_epoch = 142; // data from the react test

--- a/tvm_assembler/src/instructions_tests/zk/test_zk_for_google.rs
+++ b/tvm_assembler/src/instructions_tests/zk/test_zk_for_google.rs
@@ -109,11 +109,11 @@ mod tests {
         // replace by Alina's data (ephemeral public key place to byte array ), depends
         // on iteration
         eph_pubkey.extend(ephemeral_kp.public().as_ref());
-        println!("eph_pubkey: {:?}", eph_pubkey);
+        println!("eph_pubkey: {eph_pubkey:?}");
         println!("len eph_pubkey: {:?}", eph_pubkey.len());
 
         let eph_pubkey_hex_number = "0x".to_owned() + &hex::encode(eph_pubkey.clone());
-        println!("eph_pubkey_hex_number: {:?}", eph_pubkey_hex_number);
+        println!("eph_pubkey_hex_number: {eph_pubkey_hex_number:?}");
 
         // Get the zklogin seed.
         // This stuff is a kind of bound between  smart contract and email (some
@@ -127,7 +127,7 @@ mod tests {
         )
         .unwrap();
 
-        println!("zk_seed = {:?}", zk_seed);
+        println!("zk_seed = {zk_seed:?}");
 
         let proof_and_jwt = "{\"proofPoints\":{\"a\":[\"2352077003566407045854435506409565889408960755152253285189640818725808263237\",\
     \"9548308350778027075240385782578683112366097953461273569343148999989145049123\",\"1\"],\
@@ -140,13 +140,13 @@ mod tests {
     \"issBase64Details\":{\"value\":\"yJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLC\",\"indexMod4\":1},\
     \"headerBase64\":\"eyJhbGciOiJSUzI1NiIsImtpZCI6ImEzYjc2MmY4NzFjZGIzYmFlMDA0NGM2NDk2MjJmYzEzOTZlZGEzZTMiLCJ0eXAiOiJKV1QifQ\"}";
         let len = proof_and_jwt.bytes().len();
-        println!(" proof_and_jwt_bytes len (in bytes) = {:?}", len);
+        println!(" proof_and_jwt_bytes len (in bytes) = {len:?}");
 
-        println!("proof_and_jwt: {}", proof_and_jwt);
+        println!("proof_and_jwt: {proof_and_jwt}");
 
         let iss_and_header_base64details = "{\"issBase64Details\":{\"value\":\"yJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLC\",\"indexMod4\":1},\"headerBase64\":\"eyJhbGciOiJSUzI1NiIsImtpZCI6ImEzYjc2MmY4NzFjZGIzYmFlMDA0NGM2NDk2MjJmYzEzOTZlZGEzZTMiLCJ0eXAiOiJKV1QifQ\"}";
 
-        println!("iss_and_header_base64details: {}", iss_and_header_base64details);
+        println!("iss_and_header_base64details: {iss_and_header_base64details}");
 
         let header_base_64 = "eyJhbGciOiJSUzI1NiIsImtpZCI6ImEzYjc2MmY4NzFjZGIzYmFlMDA0NGM2NDk2MjJmYzEzOTZlZGEzZTMiLCJ0eXAiOiJKV1QifQ";
         let iss_base_64 = "yJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLC";
@@ -175,7 +175,7 @@ mod tests {
         let jwk = all_jwk
             .get(&JwkId::new(iss.clone(), kid.clone()))
             .ok_or_else(|| {
-                ZkCryptoError::GeneralError(format!("JWK not found ({} - {})", iss, kid))
+                ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})"))
             })
             .unwrap();
 
@@ -193,7 +193,7 @@ mod tests {
 
         let mut public_inputs_as_bytes = vec![];
         public_inputs.serialize_compressed(&mut public_inputs_as_bytes).unwrap();
-        println!("HERE public_inputs_as_bytes : {:?}", public_inputs_as_bytes);
+        println!("HERE public_inputs_as_bytes : {public_inputs_as_bytes:?}");
         println!("HERE public_inputs_as_bytes len : {:?}", public_inputs_as_bytes.len());
 
         let public_inputs_cell = pack_data_to_cell(&public_inputs_as_bytes, &mut 0).unwrap();
@@ -231,7 +231,7 @@ mod tests {
         let proof = &zk_login_inputs.get_proof().as_arkworks().unwrap();
         let mut proof_as_bytes = vec![];
         proof.serialize_compressed(&mut proof_as_bytes).unwrap();
-        println!("proof_as_bytes : {:?}", proof_as_bytes);
+        println!("proof_as_bytes : {proof_as_bytes:?}");
         println!("proof_as_bytes len: {:?}", proof_as_bytes.len());
 
         let proof_cell = pack_data_to_cell(&proof_as_bytes, &mut 0).unwrap();
@@ -258,11 +258,11 @@ mod tests {
         let mut eph_pubkey = Vec::new();
         eph_pubkey.extend(ephemeral_kp.public().as_ref());
 
-        println!("eph_pubkey: {:?}", eph_pubkey);
+        println!("eph_pubkey: {eph_pubkey:?}");
         println!("len eph_pubkey: {:?}", eph_pubkey.len());
 
         let eph_pubkey_hex_number = "0x".to_owned() + &hex::encode(eph_pubkey.clone());
-        println!("eph_pubkey_hex_number: {:?}", eph_pubkey_hex_number);
+        println!("eph_pubkey_hex_number: {eph_pubkey_hex_number:?}");
 
         let zk_seed = gen_address_seed(
             user_pass_salt,
@@ -272,14 +272,14 @@ mod tests {
         )
         .unwrap();
 
-        println!("zk_seed: {}", zk_seed);
+        println!("zk_seed: {zk_seed}");
 
         let proof_and_jwt = "{\"proofPoints\":{\"a\":[\"8247215875293406890829839156897863742504615191361518281091302475904551111016\",\"6872980335748205979379321982220498484242209225765686471076081944034292159666\",\"1\"],\"b\":[[\"21419680064642047510915171723230639588631899775315750803416713283740137406807\",\"21566716915562037737681888858382287035712341650647439119820808127161946325890\"],[\"17867714710686394159919998503724240212517838710399045289784307078087926404555\",\"21812769875502013113255155836896615164559280911997219958031852239645061854221\"],[\"1\",\"0\"]],\"c\":[\"7530826803702928198368421787278524256623871560746240215547076095911132653214\",\"16244547936249959771862454850485726883972969173921727256151991751860694123976\",\"1\"]},\"issBase64Details\":{\"value\":\"yJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLC\",\"indexMod4\":1},\"headerBase64\":\"eyJhbGciOiJSUzI1NiIsImtpZCI6IjZmNzI1NDEwMWY1NmU0MWNmMzVjOTkyNmRlODRhMmQ1NTJiNGM2ZjEiLCJ0eXAiOiJKV1QifQ\"}";
 
-        println!("proof_and_jwt: {}", proof_and_jwt);
+        println!("proof_and_jwt: {proof_and_jwt}");
 
         let iss_and_header_base64details = "{\"issBase64Details\":{\"value\":\"yJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLC\",\"indexMod4\":1},\"headerBase64\":\"eyJhbGciOiJSUzI1NiIsImtpZCI6IjZmNzI1NDEwMWY1NmU0MWNmMzVjOTkyNmRlODRhMmQ1NTJiNGM2ZjEiLCJ0eXAiOiJKV1QifQ\"}";
-        println!("iss_and_header_base64details: {}", iss_and_header_base64details);
+        println!("iss_and_header_base64details: {iss_and_header_base64details}");
 
         let header_base_64 = "eyJhbGciOiJSUzI1NiIsImtpZCI6IjZmNzI1NDEwMWY1NmU0MWNmMzVjOTkyNmRlODRhMmQ1NTJiNGM2ZjEiLCJ0eXAiOiJKV1QifQ";
         let iss_base_64 = "yJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLC";
@@ -310,7 +310,7 @@ mod tests {
         let jwk = all_jwk
             .get(&JwkId::new(iss.clone(), kid.clone()))
             .ok_or_else(|| {
-                ZkCryptoError::GeneralError(format!("JWK not found ({} - {})", iss, kid))
+                ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})"))
             })
             .unwrap();
 
@@ -321,7 +321,7 @@ mod tests {
             })
             .unwrap();
 
-        println!("modulus: {:?}", modulus);
+        println!("modulus: {modulus:?}");
 
         println!("modulus hex: {:?}", hex::encode(&modulus));
 
@@ -364,7 +364,7 @@ mod tests {
 
         let mut proof_as_bytes = vec![];
         proof.serialize_compressed(&mut proof_as_bytes).unwrap();
-        println!("proof_as_bytes : {:?}", proof_as_bytes);
+        println!("proof_as_bytes : {proof_as_bytes:?}");
         println!("proof_as_bytes len: {:?}", proof_as_bytes.len());
         println!("proof_as_bytes hex: {:?}", hex::encode(&proof_as_bytes));
 
@@ -382,12 +382,12 @@ mod tests {
 
         println!("proof.a.x.0.to_string(): {:?}", proof.a.x.0.to_string());
 
-        println!("y1: {:?}", y1);
+        println!("y1: {y1:?}");
         for i in 0..y1.len() {
             print!("{}", y1[i] as i32);
         }
         println!("");
-        println!("y2: {:?}", y2);
+        println!("y2: {y2:?}");
         for i in 0..y2.len() {
             print!("{}", y2[i] as i32);
         }
@@ -398,7 +398,7 @@ mod tests {
 
         let mut public_inputs_as_bytes = vec![];
         public_inputs.serialize_compressed(&mut public_inputs_as_bytes).unwrap();
-        println!("public_inputs_as_bytes : {:?}", public_inputs_as_bytes);
+        println!("public_inputs_as_bytes : {public_inputs_as_bytes:?}");
         println!("public_inputs_as_bytes len : {:?}", public_inputs_as_bytes.len());
         println!("public_inputs_as_bytes hex: {:?}", hex::encode(&public_inputs_as_bytes));
 
@@ -454,11 +454,11 @@ mod tests {
             let mut eph_pubkey = Vec::new(); // vec![0x00];
             eph_pubkey.extend(ephemeral_kp.public().as_ref());
 
-            println!("ephemeral secret_key is {:?}", eph_secret_key);
-            println!("ephemeral public_key is {:?}", eph_pubkey);
+            println!("ephemeral secret_key is {eph_secret_key:?}");
+            println!("ephemeral public_key is {eph_pubkey:?}");
 
             let eph_pubkey_len = eph_pubkey.clone().len();
-            println!("len eph_pubkey: {:?}", eph_pubkey_len);
+            println!("len eph_pubkey: {eph_pubkey_len:?}");
 
             let jwt_data_vector: Vec<&str> = jwt_data.jwt.split(".").collect();
             println!("jwt_data_vector[0] {:?}", jwt_data_vector[0]);
@@ -466,7 +466,7 @@ mod tests {
             let jwt_data_1 = decode(jwt_data_vector[0]).expect("Base64 decoding failed");
 
             let jwt_string_1 = String::from_utf8(jwt_data_1).expect("UTF-8 conversion failed");
-            println!("jwt_string_1 is {:?}", jwt_string_1);
+            println!("jwt_string_1 is {jwt_string_1:?}");
 
             // JwtDataDecodedPart1
             let jwt_data_decoded1: JwtDataDecodedPart1 =
@@ -475,7 +475,7 @@ mod tests {
 
             let jwt_data_2 = decode(jwt_data_vector[1]).expect("Base64 decoding failed");
             let jwt_string_2 = String::from_utf8(jwt_data_2).expect("UTF-8 conversion failed");
-            println!("jwt_string_2 is {:?}", jwt_string_2);
+            println!("jwt_string_2 is {jwt_string_2:?}");
 
             // JwtDataDecodedPart2
             let jwt_data_decoded2: JwtDataDecodedPart2 =
@@ -557,14 +557,14 @@ mod tests {
             let mut eph_pubkey = Vec::new(); // vec![0x00];
             eph_pubkey.extend(ephemeral_kp.public().as_ref());
 
-            println!("ephemeral secret_key is {:?}", eph_secret_key);
-            println!("ephemeral public_key is {:?}", eph_pubkey);
+            println!("ephemeral secret_key is {eph_secret_key:?}");
+            println!("ephemeral public_key is {eph_pubkey:?}");
 
             let eph_pubkey_hex_number = "0x".to_owned() + &hex::encode(eph_pubkey.clone());
-            println!("eph_pubkey_hex_number: {:?}", eph_pubkey_hex_number);
+            println!("eph_pubkey_hex_number: {eph_pubkey_hex_number:?}");
 
             let eph_pubkey_len = eph_pubkey.clone().len();
-            println!("len eph_pubkey: {:?}", eph_pubkey_len);
+            println!("len eph_pubkey: {eph_pubkey_len:?}");
 
             let jwt_data_vector: Vec<&str> = jwt_data.jwt.split(".").collect();
             println!("jwt_data_vector[0] {:?}", jwt_data_vector[0]);
@@ -572,7 +572,7 @@ mod tests {
             let jwt_data_1 = decode(jwt_data_vector[0]).expect("Base64 decoding failed");
 
             let jwt_string_1 = String::from_utf8(jwt_data_1).expect("UTF-8 conversion failed");
-            println!("jwt_string_1 is {:?}", jwt_string_1);
+            println!("jwt_string_1 is {jwt_string_1:?}");
 
             // JwtDataDecodedPart1
             let jwt_data_decoded1: JwtDataDecodedPart1 =
@@ -581,7 +581,7 @@ mod tests {
 
             let jwt_data_2 = decode(jwt_data_vector[1]).expect("Base64 decoding failed");
             let jwt_string_2 = String::from_utf8(jwt_data_2).expect("UTF-8 conversion failed");
-            println!("jwt_string_2 is {:?}", jwt_string_2);
+            println!("jwt_string_2 is {jwt_string_2:?}");
 
             // JwtDataDecodedPart2
             let jwt_data_decoded2: JwtDataDecodedPart2 =
@@ -640,10 +640,10 @@ mod tests {
         let mut eph_pubkey = Vec::new(); // vec![0x00];
 
         eph_pubkey.extend(ephemeral_kp.public().as_ref());
-        println!("eph_pubkey: {:?}", eph_pubkey);
+        println!("eph_pubkey: {eph_pubkey:?}");
         println!("eph_pubkey: {:?}", hex::encode(eph_pubkey.clone()));
         let len = eph_pubkey.clone().len();
-        println!("len eph_pubkey: {:?}", len);
+        println!("len eph_pubkey: {len:?}");
 
         let zk_seed = gen_address_seed(
             user_pass_salt,
@@ -653,7 +653,7 @@ mod tests {
         )
         .unwrap();
 
-        println!("zk_seed = {:?}", zk_seed);
+        println!("zk_seed = {zk_seed:?}");
 
         let proof_and_jwt = "{\"proofPoints\":{\"a\":[\"2352077003566407045854435506409565889408960755152253285189640818725808263237\",\
     \"9548308350778027075240385782578683112366097953461273569343148999989145049123\",\"1\"],\
@@ -666,7 +666,7 @@ mod tests {
     \"issBase64Details\":{\"value\":\"yJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLC\",\"indexMod4\":1},\
     \"headerBase64\":\"eyJhbGciOiJSUzI1NiIsImtpZCI6ImEzYjc2MmY4NzFjZGIzYmFlMDA0NGM2NDk2MjJmYzEzOTZlZGEzZTMiLCJ0eXAiOiJKV1QifQ\"}";
         let len = proof_and_jwt.bytes().len();
-        println!(" proof_and_jwt_bytes len (in bytes) = {:?}", len);
+        println!(" proof_and_jwt_bytes len (in bytes) = {len:?}");
 
         let zk_login_inputs =
             ZkLoginInputs::from_json(&*proof_and_jwt, &*zk_seed.to_string()).unwrap();
@@ -694,7 +694,7 @@ mod tests {
         let jwk = all_jwk
             .get(&JwkId::new(iss.clone(), kid.clone()))
             .ok_or_else(|| {
-                ZkCryptoError::GeneralError(format!("JWK not found ({} - {})", iss, kid))
+                ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})"))
             })
             .unwrap();
 
@@ -713,14 +713,14 @@ mod tests {
 
         let mut proof_as_bytes = vec![];
         proof.serialize_compressed(&mut proof_as_bytes).unwrap();
-        println!("proof_as_bytes : {:?}", proof_as_bytes);
+        println!("proof_as_bytes : {proof_as_bytes:?}");
         println!("proof_as_bytes len: {:?}", proof_as_bytes.len());
 
         let proof_cell = pack_data_to_cell(&proof_as_bytes, &mut 0).unwrap();
 
         let mut public_inputs_as_bytes = vec![];
         public_inputs.serialize_compressed(&mut public_inputs_as_bytes).unwrap();
-        println!("public_inputs_as_bytes : {:?}", public_inputs_as_bytes);
+        println!("public_inputs_as_bytes : {public_inputs_as_bytes:?}");
         println!("public_inputs_as_bytes len : {:?}", public_inputs_as_bytes.len());
 
         let public_inputs_cell = pack_data_to_cell(&public_inputs_as_bytes, &mut 0).unwrap();
@@ -752,7 +752,7 @@ mod tests {
 
         let proof_and_jwt = "{\"proofPoints\":{\"a\":[\"8247215875293406890829839156897863742504615191361518281091302475904551111016\",\"6872980335748205979379321982220498484242209225765686471076081944034292159666\",\"1\"],\"b\":[[\"21419680064642047510915171723230639588631899775315750803416713283740137406807\",\"21566716915562037737681888858382287035712341650647439119820808127161946325890\"],[\"17867714710686394159919998503724240212517838710399045289784307078087926404555\",\"21812769875502013113255155836896615164559280911997219958031852239645061854221\"],[\"1\",\"0\"]],\"c\":[\"7530826803702928198368421787278524256623871560746240215547076095911132653214\",\"16244547936249959771862454850485726883972969173921727256151991751860694123976\",\"1\"]},\"issBase64Details\":{\"value\":\"yJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLC\",\"indexMod4\":1},\"headerBase64\":\"eyJhbGciOiJSUzI1NiIsImtpZCI6IjZmNzI1NDEwMWY1NmU0MWNmMzVjOTkyNmRlODRhMmQ1NTJiNGM2ZjEiLCJ0eXAiOiJKV1QifQ\"}";
 
-        println!("proof_and_jwt: {}", proof_and_jwt);
+        println!("proof_and_jwt: {proof_and_jwt}");
 
         let zk_login_inputs = tvm_vm::executor::zk_stuff::zk_login::ZkLoginInputs::from_json(
             &*proof_and_jwt,
@@ -760,7 +760,7 @@ mod tests {
         )
         .unwrap();
 
-        println!("zk_login_inputs: {:?}", zk_login_inputs);
+        println!("zk_login_inputs: {zk_login_inputs:?}");
 
         let proof = &zk_login_inputs.get_proof().as_arkworks().unwrap();
 
@@ -793,10 +793,10 @@ mod tests {
 
         let proof_and_jwt = "{\"proofPoints\":{\"a\":[\"20032491544466004395942516676927853848812757556091814296260914209848471949133\",\"2383319895045368406863089991961299436327009667970727469594098906910899823518\",\"1\"],\"b\":[[\"17524079199473031626933714849790290610990375813469214348846178898325828270802\",\"14967860363718375858883445892553389848174133418448836833724123534259346456965\"],[\"8012103671455598651673212917030479015077366694912593401917441922282850889728\",\"9619406946838713340504188077859322423191842838375117333667670119492063405148\"],[\"1\",\"0\"]],\"c\":[\"1155327534990006564455106296492790109069125857506281397147103620914309288350\",\"11642927414888703901346255147864200862372140915112720472429308471936285279899\",\"1\"]},\"issBase64Details\":{\"value\":\"yJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLC\",\"indexMod4\":1},\"headerBase64\":\"eyJhbGciOiJSUzI1NiIsImtpZCI6ImIyNjIwZDVlN2YxMzJiNTJhZmU4ODc1Y2RmMzc3NmMwNjQyNDlkMDQiLCJ0eXAiOiJKV1QifQ\"}";
 
-        println!("proof_and_jwt: {}", proof_and_jwt);
+        println!("proof_and_jwt: {proof_and_jwt}");
 
         let iss_and_header_base64details = "\"issBase64Details\":{\"value\":\"yJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLC\",\"indexMod4\":1},\"headerBase64\":\"eyJhbGciOiJSUzI1NiIsImtpZCI6ImIyNjIwZDVlN2YxMzJiNTJhZmU4ODc1Y2RmMzc3NmMwNjQyNDlkMDQiLCJ0eXAiOiJKV1QifQ\"";
-        println!("iss_and_header_base64details: {}", iss_and_header_base64details);
+        println!("iss_and_header_base64details: {iss_and_header_base64details}");
 
         let zk_login_inputs =
             ZkLoginInputs::from_json(&*proof_and_jwt, &*zk_seed.to_string()).unwrap();
@@ -823,7 +823,7 @@ mod tests {
         let jwk = all_jwk
             .get(&JwkId::new(iss.clone(), kid.clone()))
             .ok_or_else(|| {
-                ZkCryptoError::GeneralError(format!("JWK not found ({} - {})", iss, kid))
+                ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})"))
             })
             .unwrap();
 
@@ -834,7 +834,7 @@ mod tests {
             })
             .unwrap();
 
-        println!("modulus: {:?}", modulus);
+        println!("modulus: {modulus:?}");
 
         println!("modulus hex: {:?}", hex::encode(&modulus));
 
@@ -847,7 +847,7 @@ mod tests {
             143, 3, 173, 66, 156, 56, 155, 83, 21, 226, 161, 63,
         ];
 
-        println!("eph_pubkey : {:?}", eph_pubkey);
+        println!("eph_pubkey : {eph_pubkey:?}");
         println!("eph_pubkey len : {:?}", eph_pubkey.len());
 
         let proof = &zk_login_inputs.get_proof().as_arkworks().unwrap();
@@ -856,7 +856,7 @@ mod tests {
 
         let mut proof_as_bytes = vec![];
         proof.serialize_compressed(&mut proof_as_bytes).unwrap();
-        println!("proof_as_bytes : {:?}", proof_as_bytes);
+        println!("proof_as_bytes : {proof_as_bytes:?}");
         println!("proof_as_bytes len: {:?}", proof_as_bytes.len());
         println!("proof_as_bytes hex: {:?}", hex::encode(&proof_as_bytes));
 
@@ -864,7 +864,7 @@ mod tests {
 
         let mut public_inputs_as_bytes = vec![];
         public_inputs.serialize_compressed(&mut public_inputs_as_bytes).unwrap();
-        println!("public_inputs_as_bytes : {:?}", public_inputs_as_bytes);
+        println!("public_inputs_as_bytes : {public_inputs_as_bytes:?}");
         println!("public_inputs_as_bytes len : {:?}", public_inputs_as_bytes.len());
         println!("public_inputs_as_bytes hex: {:?}", hex::encode(&public_inputs_as_bytes));
 
@@ -890,11 +890,11 @@ mod tests {
         let ephemeral_kp = Ed25519KeyPair::generate(&mut StdRng::from_seed([0; 32]));
         let mut eph_pubkey = Vec::new();
         eph_pubkey.extend(ephemeral_kp.public().as_ref());
-        println!("eph_pubkey: {:?}", eph_pubkey);
+        println!("eph_pubkey: {eph_pubkey:?}");
         println!("len eph_pubkey: {:?}", eph_pubkey.len());
 
         let eph_pubkey_hex_number = "0x".to_owned() + &hex::encode(eph_pubkey.clone());
-        println!("eph_pubkey_hex_number: {:?}", eph_pubkey_hex_number);
+        println!("eph_pubkey_hex_number: {eph_pubkey_hex_number:?}");
 
         let zk_seed = gen_address_seed(
             user_pass_salt,
@@ -904,14 +904,14 @@ mod tests {
         )
         .unwrap();
 
-        println!("zk_seed: {}", zk_seed);
+        println!("zk_seed: {zk_seed}");
 
         let proof_and_jwt = "{\"proofPoints\":{\"a\":[\"8247215875293406890829839156897863742504615191361518281091302475904551111016\",\"6872980335748205979379321982220498484242209225765686471076081944034292159666\",\"1\"],\"b\":[[\"21419680064642047510915171723230639588631899775315750803416713283740137406807\",\"21566716915562037737681888858382287035712341650647439119820808127161946325890\"],[\"17867714710686394159919998503724240212517838710399045289784307078087926404555\",\"21812769875502013113255155836896615164559280911997219958031852239645061854221\"],[\"1\",\"0\"]],\"c\":[\"7530826803702928198368421787278524256623871560746240215547076095911132653214\",\"16244547936249959771862454850485726883972969173921727256151991751860694123976\",\"1\"]},\"issBase64Details\":{\"value\":\"yJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLC\",\"indexMod4\":1},\"headerBase64\":\"eyJhbGciOiJSUzI1NiIsImtpZCI6IjZmNzI1NDEwMWY1NmU0MWNmMzVjOTkyNmRlODRhMmQ1NTJiNGM2ZjEiLCJ0eXAiOiJKV1QifQ\"}";
 
-        println!("proof_and_jwt: {}", proof_and_jwt);
+        println!("proof_and_jwt: {proof_and_jwt}");
 
         let iss_and_header_base64details = "{\"issBase64Details\":{\"value\":\"yJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLC\",\"indexMod4\":1},\"headerBase64\":\"eyJhbGciOiJSUzI1NiIsImtpZCI6IjZmNzI1NDEwMWY1NmU0MWNmMzVjOTkyNmRlODRhMmQ1NTJiNGM2ZjEiLCJ0eXAiOiJKV1QifQ\"}";
-        println!("iss_and_header_base64details: {}", iss_and_header_base64details);
+        println!("iss_and_header_base64details: {iss_and_header_base64details}");
 
         let header_base_64 = "eyJhbGciOiJSUzI1NiIsImtpZCI6IjZmNzI1NDEwMWY1NmU0MWNmMzVjOTkyNmRlODRhMmQ1NTJiNGM2ZjEiLCJ0eXAiOiJKV1QifQ";
         let iss_base_64 = "yJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLC";
@@ -942,7 +942,7 @@ mod tests {
         let jwk = all_jwk
             .get(&JwkId::new(iss.clone(), kid.clone()))
             .ok_or_else(|| {
-                ZkCryptoError::GeneralError(format!("JWK not found ({} - {})", iss, kid))
+                ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})"))
             })
             .unwrap();
 
@@ -953,7 +953,7 @@ mod tests {
             })
             .unwrap();
 
-        println!("modulus: {:?}", modulus);
+        println!("modulus: {modulus:?}");
 
         println!("modulus hex: {:?}", hex::encode(&modulus));
 
@@ -1012,7 +1012,7 @@ mod tests {
 
         println!("eph_pubkey: {:?}", hex::encode(eph_pubkey.clone()));
         let len = eph_pubkey.clone().len();
-        println!("len eph_pubkey: {:?}", len);
+        println!("len eph_pubkey: {len:?}");
         let zk_seed = gen_address_seed(
             user_pass_salt,
             "sub",
@@ -1021,11 +1021,11 @@ mod tests {
         )
         .unwrap();
 
-        println!("zk_seed = {:?}", zk_seed);
+        println!("zk_seed = {zk_seed:?}");
 
         let proof_and_jwt = "{\"proofPoints\":{\"a\":[\"8247215875293406890829839156897863742504615191361518281091302475904551111016\",\"6872980335748205979379321982220498484242209225765686471076081944034292159666\",\"1\"],\"b\":[[\"21419680064642047510915171723230639588631899775315750803416713283740137406807\",\"21566716915562037737681888858382287035712341650647439119820808127161946325890\"],[\"17867714710686394159919998503724240212517838710399045289784307078087926404555\",\"21812769875502013113255155836896615164559280911997219958031852239645061854221\"],[\"1\",\"0\"]],\"c\":[\"7530826803702928198368421787278524256623871560746240215547076095911132653214\",\"16244547936249959771862454850485726883972969173921727256151991751860694123976\",\"1\"]},\"issBase64Details\":{\"value\":\"yJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLC\",\"indexMod4\":1},\"headerBase64\":\"eyJhbGciOiJSUzI1NiIsImtpZCI6IjZmNzI1NDEwMWY1NmU0MWNmMzVjOTkyNmRlODRhMmQ1NTJiNGM2ZjEiLCJ0eXAiOiJKV1QifQ\"}";
         let len = proof_and_jwt.bytes().len();
-        println!(" proof_and_jwt_bytes len (in bytes) = {:?}", len);
+        println!(" proof_and_jwt_bytes len (in bytes) = {len:?}");
 
         let zk_login_inputs =
             ZkLoginInputs::from_json(&*proof_and_jwt, &*zk_seed.to_string()).unwrap();
@@ -1052,7 +1052,7 @@ mod tests {
         let jwk = all_jwk
             .get(&JwkId::new(iss.clone(), kid.clone()))
             .ok_or_else(|| {
-                ZkCryptoError::GeneralError(format!("JWK not found ({} - {})", iss, kid))
+                ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})"))
             })
             .unwrap();
 
@@ -1071,14 +1071,14 @@ mod tests {
 
         let mut proof_as_bytes = vec![];
         proof.serialize_compressed(&mut proof_as_bytes).unwrap();
-        println!("proof_as_bytes : {:?}", proof_as_bytes);
+        println!("proof_as_bytes : {proof_as_bytes:?}");
         println!("proof_as_bytes len: {:?}", proof_as_bytes.len());
 
         let proof_cell = pack_data_to_cell(&proof_as_bytes, &mut 0).unwrap();
 
         let mut public_inputs_as_bytes = vec![];
         public_inputs.serialize_compressed(&mut public_inputs_as_bytes).unwrap();
-        println!("public_inputs_as_bytes : {:?}", public_inputs_as_bytes);
+        println!("public_inputs_as_bytes : {public_inputs_as_bytes:?}");
         println!("public_inputs_as_bytes len : {:?}", public_inputs_as_bytes.len());
 
         let public_inputs_cell = pack_data_to_cell(&public_inputs_as_bytes, &mut 0).unwrap();
@@ -1158,7 +1158,7 @@ mod tests {
 
         println!("eph_pubkey: {:?}", hex::encode(eph_pubkey.clone()));
         let len = eph_pubkey.clone().len();
-        println!("len eph_pubkey: {:?}", len);
+        println!("len eph_pubkey: {len:?}");
 
         // Get the zklogin seed.
         // This stuff is a kind of bound between  smart contract and email (some
@@ -1171,7 +1171,7 @@ mod tests {
             "232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com", // Alina's data (fixed by app id ) from jwt
         ).unwrap();
 
-        println!("zk_seed = {:?}", zk_seed);
+        println!("zk_seed = {zk_seed:?}");
 
         let proof_and_jwt = "{\"proofPoints\":{\"a\":[\"2352077003566407045854435506409565889408960755152253285189640818725808263237\",\
     \"9548308350778027075240385782578683112366097953461273569343148999989145049123\",\"1\"],\
@@ -1184,7 +1184,7 @@ mod tests {
     \"issBase64Details\":{\"value\":\"yJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLC\",\"indexMod4\":1},\
     \"headerBase64\":\"eyJhbGciOiJSUzI1NiIsImtpZCI6ImEzYjc2MmY4NzFjZGIzYmFlMDA0NGM2NDk2MjJmYzEzOTZlZGEzZTMiLCJ0eXAiOiJKV1QifQ\"}";
         let len = proof_and_jwt.bytes().len();
-        println!(" proof_and_jwt_bytes len (in bytes) = {:?}", len);
+        println!(" proof_and_jwt_bytes len (in bytes) = {len:?}");
 
         let zk_login_inputs =
             ZkLoginInputs::from_json(&*proof_and_jwt, &*zk_seed.to_string()).unwrap();
@@ -1212,7 +1212,7 @@ mod tests {
         let jwk = all_jwk
             .get(&JwkId::new(iss.clone(), kid.clone()))
             .ok_or_else(|| {
-                ZkCryptoError::GeneralError(format!("JWK not found ({} - {})", iss, kid))
+                ZkCryptoError::GeneralError(format!("JWK not found ({iss} - {kid})"))
             })
             .unwrap();
 
@@ -1231,14 +1231,14 @@ mod tests {
 
         let mut proof_as_bytes = vec![];
         proof.serialize_compressed(&mut proof_as_bytes).unwrap();
-        println!("proof_as_bytes : {:?}", proof_as_bytes);
+        println!("proof_as_bytes : {proof_as_bytes:?}");
         println!("proof_as_bytes len: {:?}", proof_as_bytes.len());
 
         let proof_cell = pack_data_to_cell(&proof_as_bytes, &mut 0).unwrap();
 
         let mut public_inputs_as_bytes = vec![];
         public_inputs.serialize_compressed(&mut public_inputs_as_bytes).unwrap();
-        println!("public_inputs_as_bytes : {:?}", public_inputs_as_bytes);
+        println!("public_inputs_as_bytes : {public_inputs_as_bytes:?}");
         println!("public_inputs_as_bytes len : {:?}", public_inputs_as_bytes.len());
 
         let public_inputs_cell = pack_data_to_cell(&public_inputs_as_bytes, &mut 0).unwrap();
@@ -1299,7 +1299,7 @@ mod tests {
 
         // Преобразуем массив байтов в hex-строку
         let hex_string =
-            reversed_byte_array.iter().map(|byte| format!("{:02x}", byte)).collect::<String>();
+            reversed_byte_array.iter().map(|byte| format!("{byte:02x}")).collect::<String>();
 
         hex_string
     }
@@ -1334,7 +1334,7 @@ mod tests {
         for i in 0..data.len() {
             let jwt_data: JwtData = serde_json::from_str(&data[i]).unwrap();
             let json_string = serde_json::to_string(&jwt_data.zk_proofs).unwrap();
-            print!("{:?}, \n", json_string);
+            print!("{json_string:?}, \n");
             print!("{:?}, \n", jwt_data.zk_addr);
             print!("{:?}, \n", jwt_data.extended_ephemeral_public_key);
         }
@@ -1351,7 +1351,7 @@ mod tests {
             let jwt_data_1 = decode(jwt_data_vector[0]).expect("Base64 decoding failed");
 
             let jwt_string_1 = String::from_utf8(jwt_data_1).expect("UTF-8 conversion failed");
-            println!("jwt_string_1 is {:?}", jwt_string_1); // jwt_string_1 is
+            println!("jwt_string_1 is {jwt_string_1:?}"); // jwt_string_1 is
             // "{\"alg\":\"RS256\",\"kid\":\"323b214ae6975a0f034ea77354dc0c25d03642dc\",\"
             // typ\":\"JWT\"}"
 
@@ -1364,7 +1364,7 @@ mod tests {
 
             let jwt_data_2 = decode(jwt_data_vector[1]).expect("Base64 decoding failed");
             let jwt_string_2 = String::from_utf8(jwt_data_2).expect("UTF-8 conversion failed");
-            println!("jwt_string_2 is {:?}", jwt_string_2); // "{\"iss\":\"https://accounts.google.com\",\"azp\":\"232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com\",\"aud\":\"232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com\",\"sub\":\"112897468626716626103\",\"nonce\":\"bxmnJW31ruzKMGir01YPGYL0xDY\",\"nbf\":1715687036,\"iat\":1715687336,\"exp\":1715690936,\"jti\":\"9b601d25f003640c2889a2a047789382cb1cfe87\"}"
+            println!("jwt_string_2 is {jwt_string_2:?}"); // "{\"iss\":\"https://accounts.google.com\",\"azp\":\"232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com\",\"aud\":\"232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com\",\"sub\":\"112897468626716626103\",\"nonce\":\"bxmnJW31ruzKMGir01YPGYL0xDY\",\"nbf\":1715687036,\"iat\":1715687336,\"exp\":1715690936,\"jti\":\"9b601d25f003640c2889a2a047789382cb1cfe87\"}"
 
             // JwtDataDecodedPart2
             let jwt_data_decoded2: JwtDataDecodedPart2 =
@@ -1392,24 +1392,24 @@ mod tests {
 
             let mut proof_as_bytes = vec![];
             proof.serialize_compressed(&mut proof_as_bytes).unwrap();
-            println!("proof_as_bytes : {:?}", proof_as_bytes);
+            println!("proof_as_bytes : {proof_as_bytes:?}");
             println!("proof_as_bytes len: {:?}", proof_as_bytes.len());
             println!("----------------------------------");
 
             ///////////
 
             let json_string = serde_json::to_string(&jwt_data.zk_proofs).unwrap();
-            println!("json_string ={:?}", json_string); // jwt_data.zk_proofs);
+            println!("json_string ={json_string:?}"); // jwt_data.zk_proofs);
 
             let data: Value = serde_json::from_str(&*json_string).unwrap();
-            println!("data = {:?}", data);
+            println!("data = {data:?}");
 
             let a_x = data["proofPoints"]["a"][0].as_str().unwrap();
             let a_y =
                 BigUint::parse_bytes(data["proofPoints"]["a"][1].as_str().unwrap().as_bytes(), 10)
                     .unwrap();
-            println!("a_x = {:?}", a_x);
-            println!("a_y = {:?}", a_y);
+            println!("a_x = {a_x:?}");
+            println!("a_y = {a_y:?}");
 
             let b0_x = data["proofPoints"]["b"][0][0].as_str().unwrap();
             let b1_x = data["proofPoints"]["b"][0][1].as_str().unwrap();
@@ -1418,25 +1418,25 @@ mod tests {
                 10,
             )
             .unwrap();
-            println!("b0_x = {:?}", b0_x);
-            println!("b1_x = {:?}", b1_x);
-            println!("b1_y = {:?}", b1_y);
+            println!("b0_x = {b0_x:?}");
+            println!("b1_x = {b1_x:?}");
+            println!("b1_y = {b1_y:?}");
 
             let c_x = data["proofPoints"]["c"][0].as_str().unwrap();
             let c_y =
                 BigUint::parse_bytes(data["proofPoints"]["c"][1].as_str().unwrap().as_bytes(), 10)
                     .unwrap();
-            println!("c_x = {:?}", c_x);
-            println!("c_y = {:?}", c_y);
+            println!("c_x = {c_x:?}");
+            println!("c_y = {c_y:?}");
 
             let hex_ax = prepare_hex_representation(a_x, a_y);
             let hex_b0x = prepare_hex_representation(b0_x, BigUint::zero());
             let hex_b1x = prepare_hex_representation(b1_x, b1_y);
             let hex_cx = prepare_hex_representation(c_x, c_y);
 
-            let result = format!("{}{}{}{}", hex_ax, hex_b0x, hex_b1x, hex_cx);
+            let result = format!("{hex_ax}{hex_b0x}{hex_b1x}{hex_cx}");
 
-            println!("Serialized proof _ 0: {:?}", result);
+            println!("Serialized proof _ 0: {result:?}");
 
             println!("Serialized proof _ 1: {:?}", hex::encode(&proof_as_bytes));
 
@@ -1508,17 +1508,17 @@ mod tests {
             let mut eph_pubkey = Vec::new(); // vec![0x00];
             eph_pubkey.extend(ephemeral_kp.public().as_ref());
 
-            println!("ephemeral secret_key is {:?}", eph_secret_key);
-            println!("ephemeral public_key is {:?}", eph_pubkey);
+            println!("ephemeral secret_key is {eph_secret_key:?}");
+            println!("ephemeral public_key is {eph_pubkey:?}");
 
             let eph_pubkey_len = eph_pubkey.clone().len();
-            println!("len eph_pubkey: {:?}", eph_pubkey_len);
+            println!("len eph_pubkey: {eph_pubkey_len:?}");
 
             let jwt_data_vector: Vec<&str> = jwt_data.jwt.split(".").collect();
             let jwt_data_1 = decode(jwt_data_vector[0]).expect("Base64 decoding failed");
 
             let jwt_string_1 = String::from_utf8(jwt_data_1).expect("UTF-8 conversion failed");
-            println!("jwt_string_1 is {:?}", jwt_string_1); // jwt_string_1 is
+            println!("jwt_string_1 is {jwt_string_1:?}"); // jwt_string_1 is
             // "{\"alg\":\"RS256\",\"kid\":\"323b214ae6975a0f034ea77354dc0c25d03642dc\",\"
             // typ\":\"JWT\"}"
 
@@ -1529,7 +1529,7 @@ mod tests {
 
             let jwt_data_2 = decode(jwt_data_vector[1]).expect("Base64 decoding failed");
             let jwt_string_2 = String::from_utf8(jwt_data_2).expect("UTF-8 conversion failed");
-            println!("jwt_string_2 is {:?}", jwt_string_2); // "{\"iss\":\"https://accounts.google.com\",\"azp\":\"232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com\",\"aud\":\"232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com\",\"sub\":\"112897468626716626103\",\"nonce\":\"bxmnJW31ruzKMGir01YPGYL0xDY\",\"nbf\":1715687036,\"iat\":1715687336,\"exp\":1715690936,\"jti\":\"9b601d25f003640c2889a2a047789382cb1cfe87\"}"
+            println!("jwt_string_2 is {jwt_string_2:?}"); // "{\"iss\":\"https://accounts.google.com\",\"azp\":\"232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com\",\"aud\":\"232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com\",\"sub\":\"112897468626716626103\",\"nonce\":\"bxmnJW31ruzKMGir01YPGYL0xDY\",\"nbf\":1715687036,\"iat\":1715687336,\"exp\":1715690936,\"jti\":\"9b601d25f003640c2889a2a047789382cb1cfe87\"}"
 
             // JwtDataDecodedPart2
             let jwt_data_decoded2: JwtDataDecodedPart2 =

--- a/tvm_assembler/src/instructions_tests/zk/test_zk_for_kakao.rs
+++ b/tvm_assembler/src/instructions_tests/zk/test_zk_for_kakao.rs
@@ -81,17 +81,17 @@ mod tests {
             let mut eph_pubkey = Vec::new(); // vec![0x00];
             eph_pubkey.extend(ephemeral_kp.public().as_ref());
 
-            println!("ephemeral secret_key is {:?}", eph_secret_key);
-            println!("ephemeral public_key is {:?}", eph_pubkey);
+            println!("ephemeral secret_key is {eph_secret_key:?}");
+            println!("ephemeral public_key is {eph_pubkey:?}");
 
             let eph_pubkey_len = eph_pubkey.clone().len();
-            println!("len eph_pubkey: {:?}", eph_pubkey_len);
+            println!("len eph_pubkey: {eph_pubkey_len:?}");
 
             let jwt_data_vector: Vec<&str> = jwt_data.jwt.split(".").collect();
             let jwt_data_1 = decode(jwt_data_vector[0]).expect("Base64 decoding failed");
 
             let jwt_string_1 = String::from_utf8(jwt_data_1).expect("UTF-8 conversion failed");
-            println!("jwt_string_1 is {:?}", jwt_string_1); // jwt_string_1 is
+            println!("jwt_string_1 is {jwt_string_1:?}"); // jwt_string_1 is
 
             // JwtDataDecodedPart1
             let jwt_data_decoded1: JwtDataDecodedPart1 =
@@ -100,7 +100,7 @@ mod tests {
 
             let jwt_data_2 = decode(jwt_data_vector[1]).expect("Base64 decoding failed");
             let jwt_string_2 = String::from_utf8(jwt_data_2).expect("UTF-8 conversion failed");
-            println!("jwt_string_2 is {:?}", jwt_string_2); // "{\"iss\":\"https://accounts.google.com\",\"azp\":\"232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com\",\"aud\":\"232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com\",\"sub\":\"112897468626716626103\",\"nonce\":\"bxmnJW31ruzKMGir01YPGYL0xDY\",\"nbf\":1715687036,\"iat\":1715687336,\"exp\":1715690936,\"jti\":\"9b601d25f003640c2889a2a047789382cb1cfe87\"}"
+            println!("jwt_string_2 is {jwt_string_2:?}"); // "{\"iss\":\"https://accounts.google.com\",\"azp\":\"232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com\",\"aud\":\"232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com\",\"sub\":\"112897468626716626103\",\"nonce\":\"bxmnJW31ruzKMGir01YPGYL0xDY\",\"nbf\":1715687036,\"iat\":1715687336,\"exp\":1715690936,\"jti\":\"9b601d25f003640c2889a2a047789382cb1cfe87\"}"
 
             // JwtDataDecodedPart2
             let jwt_data_decoded2: JwtDataDecodedPart2 =

--- a/tvm_assembler/src/instructions_tests/zk/test_zk_for_karrier_one.rs
+++ b/tvm_assembler/src/instructions_tests/zk/test_zk_for_karrier_one.rs
@@ -64,7 +64,7 @@ mod tests {
             content,
         );
 
-        println!("all_jwk = {:?}", all_jwk);
+        println!("all_jwk = {all_jwk:?}");
 
         let max_epoch = 10;
         // let jwt_randomness = "100681567828351849884072155819400689117";
@@ -81,13 +81,13 @@ mod tests {
         // "84029355920633174015103288781128426107680789454168570548782290541079926444544"
         // ;
 
-        println!("kp_bigint = {:?} ", kp_bigint);
+        println!("kp_bigint = {kp_bigint:?} ");
 
         let jwt_data_vector: Vec<&str> = parsed_token.split(".").collect();
         let jwt_data_1 = decode(jwt_data_vector[0]).expect("Base64 decoding failed");
 
         let jwt_string_1 = String::from_utf8(jwt_data_1).expect("UTF-8 conversion failed");
-        println!("jwt_string_1 is {:?}", jwt_string_1); // jwt_string_1 is
+        println!("jwt_string_1 is {jwt_string_1:?}"); // jwt_string_1 is
 
         // JwtDataDecodedPart1
         let jwt_data_decoded1: JwtDataDecodedPart1 = serde_json::from_str(&jwt_string_1).unwrap();
@@ -96,7 +96,7 @@ mod tests {
 
         let jwt_data_2 = decode(jwt_data_vector[1]).expect("Base64 decoding failed");
         let jwt_string_2 = String::from_utf8(jwt_data_2).expect("UTF-8 conversion failed");
-        println!("jwt_string_2 is {:?}", jwt_string_2);
+        println!("jwt_string_2 is {jwt_string_2:?}");
 
         let jwt_data_decoded2: JwtDataDecodedPart2 = serde_json::from_str(&jwt_string_2).unwrap();
 

--- a/tvm_assembler/src/instructions_tests/zk/test_zk_for_microsoft.rs
+++ b/tvm_assembler/src/instructions_tests/zk/test_zk_for_microsoft.rs
@@ -86,17 +86,17 @@ mod tests {
             let mut eph_pubkey = Vec::new(); // vec![0x00];
             eph_pubkey.extend(ephemeral_kp.public().as_ref());
 
-            println!("ephemeral secret_key is {:?}", eph_secret_key);
-            println!("ephemeral public_key is {:?}", eph_pubkey);
+            println!("ephemeral secret_key is {eph_secret_key:?}");
+            println!("ephemeral public_key is {eph_pubkey:?}");
 
             let eph_pubkey_len = eph_pubkey.clone().len();
-            println!("len eph_pubkey: {:?}", eph_pubkey_len);
+            println!("len eph_pubkey: {eph_pubkey_len:?}");
 
             let jwt_data_vector: Vec<&str> = jwt_data.jwt.split(".").collect();
             let jwt_data_1 = decode(jwt_data_vector[0]).expect("Base64 decoding failed");
 
             let jwt_string_1 = String::from_utf8(jwt_data_1).expect("UTF-8 conversion failed");
-            println!("jwt_string_1 is {:?}", jwt_string_1); // jwt_string_1 is
+            println!("jwt_string_1 is {jwt_string_1:?}"); // jwt_string_1 is
 
             // JwtDataDecodedPart1
             let jwt_data_decoded1: JwtDataDecodedPart1 =
@@ -105,7 +105,7 @@ mod tests {
 
             let jwt_data_2 = decode(jwt_data_vector[1]).expect("Base64 decoding failed");
             let jwt_string_2 = String::from_utf8(jwt_data_2).expect("UTF-8 conversion failed");
-            println!("jwt_string_2 is {:?}", jwt_string_2); // "{\"iss\":\"https://accounts.google.com\",\"azp\":\"232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com\",\"aud\":\"232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com\",\"sub\":\"112897468626716626103\",\"nonce\":\"bxmnJW31ruzKMGir01YPGYL0xDY\",\"nbf\":1715687036,\"iat\":1715687336,\"exp\":1715690936,\"jti\":\"9b601d25f003640c2889a2a047789382cb1cfe87\"}"
+            println!("jwt_string_2 is {jwt_string_2:?}"); // "{\"iss\":\"https://accounts.google.com\",\"azp\":\"232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com\",\"aud\":\"232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com\",\"sub\":\"112897468626716626103\",\"nonce\":\"bxmnJW31ruzKMGir01YPGYL0xDY\",\"nbf\":1715687036,\"iat\":1715687336,\"exp\":1715690936,\"jti\":\"9b601d25f003640c2889a2a047789382cb1cfe87\"}"
 
             // JwtDataDecodedPart2
             let jwt_data_decoded2: JwtDataDecodedPart2 =

--- a/tvm_assembler/src/instructions_tests/zk/test_zk_for_slack.rs
+++ b/tvm_assembler/src/instructions_tests/zk/test_zk_for_slack.rs
@@ -59,7 +59,7 @@ mod tests {
             content,
         );
 
-        println!("all_jwk = {:?}", all_jwk);
+        println!("all_jwk = {all_jwk:?}");
 
         let max_epoch = 10;
         // let jwt_randomness = "100681567828351849884072155819400689117";
@@ -76,13 +76,13 @@ mod tests {
         // "84029355920633174015103288781128426107680789454168570548782290541079926444544"
         // ;
 
-        println!("kp_bigint = {:?} ", kp_bigint);
+        println!("kp_bigint = {kp_bigint:?} ");
 
         let jwt_data_vector: Vec<&str> = parsed_token.split(".").collect();
         let jwt_data_1 = decode(jwt_data_vector[0]).expect("Base64 decoding failed");
 
         let jwt_string_1 = String::from_utf8(jwt_data_1).expect("UTF-8 conversion failed");
-        println!("jwt_string_1 is {:?}", jwt_string_1); // jwt_string_1 is
+        println!("jwt_string_1 is {jwt_string_1:?}"); // jwt_string_1 is
 
         // JwtDataDecodedPart1
         let jwt_data_decoded1: JwtDataDecodedPart1 = serde_json::from_str(&jwt_string_1).unwrap();

--- a/tvm_assembler/src/instructions_tests/zk/test_zk_for_twitch.rs
+++ b/tvm_assembler/src/instructions_tests/zk/test_zk_for_twitch.rs
@@ -76,17 +76,17 @@ mod tests {
             let mut eph_pubkey = Vec::new(); // vec![0x00];
             eph_pubkey.extend(ephemeral_kp.public().as_ref());
 
-            println!("ephemeral secret_key is {:?}", eph_secret_key);
-            println!("ephemeral public_key is {:?}", eph_pubkey);
+            println!("ephemeral secret_key is {eph_secret_key:?}");
+            println!("ephemeral public_key is {eph_pubkey:?}");
 
             let eph_pubkey_len = eph_pubkey.clone().len();
-            println!("len eph_pubkey: {:?}", eph_pubkey_len);
+            println!("len eph_pubkey: {eph_pubkey_len:?}");
 
             let jwt_data_vector: Vec<&str> = jwt_data.jwt.split(".").collect();
             let jwt_data_1 = decode(jwt_data_vector[0]).expect("Base64 decoding failed");
 
             let jwt_string_1 = String::from_utf8(jwt_data_1).expect("UTF-8 conversion failed");
-            println!("jwt_string_1 is {:?}", jwt_string_1); // jwt_string_1 is
+            println!("jwt_string_1 is {jwt_string_1:?}"); // jwt_string_1 is
 
             // JwtDataDecodedPart1
             let jwt_data_decoded1: JwtDataDecodedPart1 =
@@ -95,7 +95,7 @@ mod tests {
 
             let jwt_data_2 = decode(jwt_data_vector[1]).expect("Base64 decoding failed");
             let jwt_string_2 = String::from_utf8(jwt_data_2).expect("UTF-8 conversion failed");
-            println!("jwt_string_2 is {:?}", jwt_string_2); // "{\"iss\":\"https://accounts.google.com\",\"azp\":\"232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com\",\"aud\":\"232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com\",\"sub\":\"112897468626716626103\",\"nonce\":\"bxmnJW31ruzKMGir01YPGYL0xDY\",\"nbf\":1715687036,\"iat\":1715687336,\"exp\":1715690936,\"jti\":\"9b601d25f003640c2889a2a047789382cb1cfe87\"}"
+            println!("jwt_string_2 is {jwt_string_2:?}"); // "{\"iss\":\"https://accounts.google.com\",\"azp\":\"232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com\",\"aud\":\"232624085191-v1tq20fg1kdhhgvat6saj7jf0hd8233r.apps.googleusercontent.com\",\"sub\":\"112897468626716626103\",\"nonce\":\"bxmnJW31ruzKMGir01YPGYL0xDY\",\"nbf\":1715687036,\"iat\":1715687336,\"exp\":1715690936,\"jti\":\"9b601d25f003640c2889a2a047789382cb1cfe87\"}"
 
             // JwtDataDecodedPart2
             let jwt_data_decoded2: JwtDataDecodedPart2 =

--- a/tvm_assembler/src/lib.rs
+++ b/tvm_assembler/src/lib.rs
@@ -355,7 +355,7 @@ impl Engine {
             }
             // Token extracted
             let token = source[s0..s1].to_ascii_uppercase();
-            log::trace!(target: "tvm", "--> {}\n", token);
+            log::trace!(target: "tvm", "--> {token}\n");
             x -= token.chars().count();
             let rule = if was_dot_inline {
                 // Do not try matching the token if the previous one is .inline,

--- a/tvm_assembler/src/simple.rs
+++ b/tvm_assembler/src/simple.rs
@@ -861,7 +861,7 @@ impl Engine {
         // Add automatic commands
         for (command, handler) in iter {
             if self.handlers.insert(command, *handler).is_some() {
-                panic!("Token {} was already registered.", command);
+                panic!("Token {command} was already registered.");
             }
         }
     }

--- a/tvm_block/build.rs
+++ b/tvm_block/build.rs
@@ -16,9 +16,9 @@ fn main() {
     let build_time = get_value("date", &["+%Y-%m-%d %T %z"]);
     let rust_version = get_value("rustc", &["--version"]);
 
-    println!("cargo:rustc-env=BUILD_GIT_BRANCH={}", git_branch);
-    println!("cargo:rustc-env=BUILD_GIT_COMMIT={}", git_commit);
-    println!("cargo:rustc-env=BUILD_GIT_DATE={}", commit_date);
-    println!("cargo:rustc-env=BUILD_TIME={}", build_time);
-    println!("cargo:rustc-env=BUILD_RUST_VERSION={}", rust_version);
+    println!("cargo:rustc-env=BUILD_GIT_BRANCH={git_branch}");
+    println!("cargo:rustc-env=BUILD_GIT_COMMIT={git_commit}");
+    println!("cargo:rustc-env=BUILD_GIT_DATE={commit_date}");
+    println!("cargo:rustc-env=BUILD_TIME={build_time}");
+    println!("cargo:rustc-env=BUILD_RUST_VERSION={rust_version}");
 }

--- a/tvm_block/src/accounts.rs
+++ b/tvm_block/src/accounts.rs
@@ -535,7 +535,7 @@ impl Deserializable for AccountState {
 
 impl fmt::Display for AccountState {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "AccountStorage[{:?}]", self)
+        write!(f, "AccountStorage[{self:?}]")
     }
 }
 
@@ -1199,7 +1199,7 @@ impl Deserializable for Account {
                     Err(err) => fail!("cannot deserialize account with tag {}, err {}", tag, err),
                 },
                 t => {
-                    let s = format!("wrong tag {} deserializing account", tag);
+                    let s = format!("wrong tag {tag} deserializing account");
                     fail!(BlockError::InvalidConstructorTag { t, s })
                 }
             }
@@ -1209,7 +1209,7 @@ impl Deserializable for Account {
 
 impl fmt::Display for Account {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Account[{:?}]", self)
+        write!(f, "Account[{self:?}]")
     }
 }
 

--- a/tvm_block/src/blocks.rs
+++ b/tvm_block/src/blocks.rs
@@ -1124,10 +1124,10 @@ impl CopyleftRewards {
     pub fn debug(&self) -> Result<String> {
         let mut str = "".to_string();
         self.iterate_with_keys(|key: AccountId, value| {
-            str = format!("{} key: {:?}, value: {}; ", str, key, value);
+            str = format!("{str} key: {key:?}, value: {value}; ");
             Ok(true)
         })?;
-        str = format!("{}.", str);
+        str = format!("{str}.");
         Ok(str)
     }
 }
@@ -1492,8 +1492,7 @@ impl Deserializable for ProofChain {
         let len = slice.get_next_int(8)? as usize;
         if !(1..=MAX_PROOF_CHAIN_LEN).contains(&len) {
             fail!(BlockError::InvalidData(format!(
-                "Failed check: `{} >= 1 && {} <= {}`",
-                len, len, MAX_PROOF_CHAIN_LEN
+                "Failed check: `{len} >= 1 && {len} <= {MAX_PROOF_CHAIN_LEN}`"
             )))
         }
 

--- a/tvm_block/src/config_params.rs
+++ b/tvm_block/src/config_params.rs
@@ -499,8 +499,8 @@ impl ConfigParams {
         // previously was not 9 parameter in config params
         for index in &MANDATORY_CONFIG_PARAMS {
             if self.config(*index)?.is_none() {
-                log::error!(target: "block", "configuration parameter #{} \
-                    (hardcoded as mandatory) is missing)", index);
+                log::error!(target: "block", "configuration parameter #{index} \
+                    (hardcoded as mandatory) is missing)");
                 return Ok(false);
             }
         }
@@ -522,8 +522,8 @@ impl ConfigParams {
             Some(params) => params.iterate_keys(|index: u32| match self.config(index) {
                 Ok(Some(_)) => Ok(true),
                 _ => {
-                    log::error!(target: "block", "configuration parameter #{} \
-                        (declared as mandatory in configuration parameter #9) is missing)", index);
+                    log::error!(target: "block", "configuration parameter #{index} \
+                        (declared as mandatory in configuration parameter #9) is missing)");
                     Ok(false)
                 }
             }),
@@ -2922,7 +2922,7 @@ impl ConfigParam39 {
     pub fn get(&self, key: &UInt256) -> Result<ValidatorSignedTempKey> {
         self.validator_keys
             .get(key)?
-            .ok_or_else(|| error!(BlockError::InvalidArg(format!("{:x}", key))))
+            .ok_or_else(|| error!(BlockError::InvalidArg(format!("{key:x}"))))
     }
 
     /// insert value
@@ -3339,17 +3339,17 @@ pub(crate) fn dump_config(params: &HashmapE) {
                 ConfigParamEnum::ConfigParam31(ref mut cfg) => {
                     println!("\tConfigParam31.fundamental_smc_addr");
                     cfg.fundamental_smc_addr.iterate_keys(|addr: UInt256| -> Result<bool> {
-                        println!("\t\t{}", addr);
+                        println!("\t\t{addr}");
                         Ok(true)
                     })?;
                 }
                 ConfigParamEnum::ConfigParam34(ref mut cfg) => {
                     println!("\tConfigParam34.cur_validators");
                     for validator in cfg.cur_validators.list() {
-                        println!("\t\t{:?}", validator);
+                        println!("\t\t{validator:?}");
                     }
                 }
-                x => println!("\t{:?}", x),
+                x => println!("\t{x:?}"),
             }
             Ok(true)
         })

--- a/tvm_block/src/envelope_message.rs
+++ b/tvm_block/src/envelope_message.rs
@@ -189,14 +189,14 @@ impl IntermediateAddressRegular {
 
     pub fn with_use_src_bits(use_src_bits: u8) -> Result<Self> {
         if use_src_bits > FULL_BITS {
-            fail!(BlockError::InvalidArg(format!("use_src_bits must be <= {}", FULL_BITS)))
+            fail!(BlockError::InvalidArg(format!("use_src_bits must be <= {FULL_BITS}")))
         }
         Ok(IntermediateAddressRegular { use_dest_bits: FULL_BITS - use_src_bits })
     }
 
     pub fn with_use_dest_bits(use_dest_bits: u8) -> Result<Self> {
         if use_dest_bits > FULL_BITS {
-            fail!(BlockError::InvalidArg(format!("use_dest_bits must be <= {}", FULL_BITS)))
+            fail!(BlockError::InvalidArg(format!("use_dest_bits must be <= {FULL_BITS}")))
         }
         Ok(IntermediateAddressRegular { use_dest_bits })
     }
@@ -211,7 +211,7 @@ impl IntermediateAddressRegular {
 
     pub fn set_use_src_bits(&mut self, use_src_bits: u8) -> Result<()> {
         if use_src_bits > FULL_BITS {
-            fail!(BlockError::InvalidArg(format!("use_src_bits must be <= {}", FULL_BITS)))
+            fail!(BlockError::InvalidArg(format!("use_src_bits must be <= {FULL_BITS}")))
         }
         self.use_dest_bits = FULL_BITS - use_src_bits;
         Ok(())
@@ -230,7 +230,7 @@ impl Deserializable for IntermediateAddressRegular {
     fn read_from(&mut self, cell: &mut SliceData) -> Result<()> {
         self.use_dest_bits = cell.get_next_bits(7)?[0] >> 1; // read 7 bit into use_dest_bits
         if self.use_dest_bits > FULL_BITS {
-            fail!(BlockError::InvalidArg(format!("use_dest_bits must be <= {}", FULL_BITS)))
+            fail!(BlockError::InvalidArg(format!("use_dest_bits must be <= {FULL_BITS}")))
         }
         Ok(())
     }

--- a/tvm_block/src/hashmapaug.rs
+++ b/tvm_block/src/hashmapaug.rs
@@ -713,9 +713,8 @@ pub trait HashmapAugType<
                 error @ (_, _, _) => {
                     log::error!(
                         target: "tvm",
-                        "If we hit this, there's certainly a bug. {:?}. \
-                         Passed: label: {}, key: {} ",
-                        error, label, key
+                        "If we hit this, there's certainly a bug. {error:?}. \
+                         Passed: label: {label}, key: {key} "
                     );
                     fail!(ExceptionCode::FatalError)
                 }

--- a/tvm_block/src/inbound_messages.rs
+++ b/tvm_block/src/inbound_messages.rs
@@ -154,10 +154,10 @@ impl fmt::Display for InMsg {
         let tr_hash = self.transaction_cell().unwrap_or_default().repr_hash();
         match self {
             InMsg::External(_x) => {
-                write!(f, "InMsg msg_import_ext$000 msg: {:x} tr: {:x}", msg_hash, tr_hash)
+                write!(f, "InMsg msg_import_ext$000 msg: {msg_hash:x} tr: {tr_hash:x}")
             }
             InMsg::IHR(_x) => {
-                write!(f, "InMsg msg_import_ihr$010 msg: {:x} tr: {:x}", msg_hash, tr_hash)
+                write!(f, "InMsg msg_import_ihr$010 msg: {msg_hash:x} tr: {tr_hash:x}")
             }
             InMsg::Immediate(x) => write!(
                 f,

--- a/tvm_block/src/lib.rs
+++ b/tvm_block/src/lib.rs
@@ -279,7 +279,7 @@ pub trait GetRepresentationHash: Serializable + std::fmt::Debug {
     fn hash(&self) -> Result<UInt256> {
         match self.serialize() {
             Err(err) => {
-                log::error!("err: {}, wrong hash calculation for {:?}", err, self);
+                log::error!("err: {err}, wrong hash calculation for {self:?}");
                 Err(err)
             }
             Ok(cell) => Ok(cell.repr_hash()),
@@ -349,7 +349,7 @@ where
 {
     let cell = s.write_to_new_cell().unwrap();
     let mut slice = SliceData::load_builder(cell).unwrap();
-    println!("slice: {}", slice);
+    println!("slice: {slice}");
     let s2 = T::construct_from(&mut slice).unwrap();
     s2.serialize().unwrap();
     pretty_assertions::assert_eq!(s, s2);

--- a/tvm_block/src/master.rs
+++ b/tvm_block/src/master.rs
@@ -1267,9 +1267,7 @@ impl Deserializable for McStateExtra {
         let mut flags = 0u16;
         flags.read_from(cell1)?; // 16 + 0
         if flags > 3 {
-            fail!(BlockError::InvalidData(format!(
-                "Invalid flags value ({flags}). Must be <= 3."
-            )))
+            fail!(BlockError::InvalidData(format!("Invalid flags value ({flags}). Must be <= 3.")))
         }
         self.validator_info.read_from(cell1)?; // 65 + 0
         self.prev_blocks.read_from(cell1)?; // 1 + 1

--- a/tvm_block/src/master.rs
+++ b/tvm_block/src/master.rs
@@ -346,9 +346,9 @@ impl ShardHashes {
 impl ShardHashes {
     pub fn dump(&self, heading: &str) -> usize {
         let mut count = 0;
-        println!("dumping shard records for: {}", heading);
+        println!("dumping shard records for: {heading}");
         self.iterate_with_keys(|workchain_id: i32, InRefValue(bintree)| {
-            println!("workchain: {}", workchain_id);
+            println!("workchain: {workchain_id}");
             bintree.iterate(|prefix, descr| {
                 let shard = ShardIdent::with_prefix_slice(workchain_id, prefix)?;
                 println!(
@@ -1268,8 +1268,7 @@ impl Deserializable for McStateExtra {
         flags.read_from(cell1)?; // 16 + 0
         if flags > 3 {
             fail!(BlockError::InvalidData(format!(
-                "Invalid flags value ({}). Must be <= 3.",
-                flags
+                "Invalid flags value ({flags}). Must be <= 3."
             )))
         }
         self.validator_info.read_from(cell1)?; // 65 + 0
@@ -1433,14 +1432,14 @@ impl fmt::Display for ShardCollators {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "prev: {}", self.prev)?;
         if let Some(prev2) = &self.prev2 {
-            writeln!(f, "prev2: {}", prev2)?;
+            writeln!(f, "prev2: {prev2}")?;
         } else {
             writeln!(f, "prev2: none")?;
         }
         writeln!(f, "current: {}", self.current)?;
         writeln!(f, "next: {}", self.next)?;
         if let Some(next2) = &self.next2 {
-            write!(f, "next2: {}", next2)?;
+            write!(f, "next2: {next2}")?;
         } else {
             write!(f, "next2: none")?;
         }

--- a/tvm_block/src/merkle_proof.rs
+++ b/tvm_block/src/merkle_proof.rs
@@ -215,7 +215,7 @@ pub fn check_transaction_proof(
     block_id: &UInt256,
 ) -> Result<()> {
     let block: Block = proof.virtualize().map_err(|err| {
-        BlockError::WrongMerkleProof(format!("Error extracting block from proof: {}", err))
+        BlockError::WrongMerkleProof(format!("Error extracting block from proof: {err}"))
     })?;
 
     // check if block id in transaction is corresponds to block in proof
@@ -240,11 +240,11 @@ pub fn check_transaction_proof(
     // read account block from block and check it
 
     let block_extra = block.read_extra().map_err(|err| {
-        BlockError::WrongMerkleProof(format!("Error extracting block extra from proof: {}", err))
+        BlockError::WrongMerkleProof(format!("Error extracting block extra from proof: {err}"))
     })?;
 
     let account_blocks = block_extra.read_account_blocks().map_err(|err| {
-        BlockError::WrongMerkleProof(format!("Error extracting account blocks from proof: {}", err))
+        BlockError::WrongMerkleProof(format!("Error extracting account blocks from proof: {err}"))
     })?;
 
     let account_block = account_blocks
@@ -255,8 +255,7 @@ pub fn check_transaction_proof(
     let tr_parent_slice_opt =
         account_block.transactions().get_as_slice(&tr.logical_time()).map_err(|err| {
             BlockError::WrongMerkleProof(format!(
-                "Error extracting transaction from dictionary in proof: {}",
-                err
+                "Error extracting transaction from dictionary in proof: {err}"
             ))
         })?;
     if let Some(mut tr_parent_slice) = tr_parent_slice_opt {
@@ -308,7 +307,7 @@ pub fn check_message_proof(
     tr_id: Option<UInt256>,
 ) -> Result<()> {
     let block: Block = proof.virtualize().map_err(|err| {
-        BlockError::WrongMerkleProof(format!("Error extracting block from proof: {}", err))
+        BlockError::WrongMerkleProof(format!("Error extracting block from proof: {err}"))
     })?;
 
     // check if block id in message is corresponds to block in proof
@@ -317,7 +316,7 @@ pub fn check_message_proof(
     // read message from block and check it
 
     let block_extra = block.read_extra().map_err(|err| {
-        BlockError::WrongMerkleProof(format!("Error extracting block extra from proof: {}", err))
+        BlockError::WrongMerkleProof(format!("Error extracting block extra from proof: {err}"))
     })?;
 
     let msg_hash = msg.hash()?;
@@ -344,7 +343,7 @@ pub fn check_message_proof(
     }
 
     let out_msg_descr = block_extra.read_out_msg_descr().map_err(|err| {
-        BlockError::WrongMerkleProof(format!("Error extracting out msg descr from proof: {}", err))
+        BlockError::WrongMerkleProof(format!("Error extracting out msg descr from proof: {err}"))
     })?;
     if let Ok(Some(out_msg)) = out_msg_descr.get(&msg_hash) {
         if let Ok(real_msg_hash) = out_msg.read_message_hash() {
@@ -376,7 +375,7 @@ pub fn check_account_proof(proof: &MerkleProof, acc: &Account) -> Result<BlockSe
     let ss: ShardStateUnsplit = proof.virtualize()?;
 
     let accounts = ss.read_accounts().map_err(|err| {
-        BlockError::WrongMerkleProof(format!("Error extracting accounts dict from proof: {}", err))
+        BlockError::WrongMerkleProof(format!("Error extracting accounts dict from proof: {err}"))
     })?;
 
     let shard_acc = accounts.account(&acc.get_addr().unwrap().get_address());

--- a/tvm_block/src/merkle_update.rs
+++ b/tvm_block/src/merkle_update.rs
@@ -546,8 +546,7 @@ impl MerkleUpdate {
             fail!(BlockError::InvalidArg("depth".to_string()))
         } else if mask & (1 << depth) != 0 {
             fail!(BlockError::InvalidOperation(format!(
-                "attempt to add hash with depth {} into mask {:03b}",
-                depth, mask
+                "attempt to add hash with depth {depth} into mask {mask:03b}"
             )))
         }
         Ok(LevelMask::with_mask(mask | (1 << depth)))

--- a/tvm_block/src/messages.rs
+++ b/tvm_block/src/messages.rs
@@ -229,7 +229,7 @@ impl fmt::Display for MsgAddressExt {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             MsgAddressExt::AddrNone => write!(f, ""),
-            MsgAddressExt::AddrExtern(addr) => write!(f, "{}", addr),
+            MsgAddressExt::AddrExtern(addr) => write!(f, "{addr}"),
         }
     }
 }
@@ -302,7 +302,7 @@ impl FromStr for MsgAddress {
             .map(|index| parts[index].parse::<i32>())
             .transpose()
             .map_err(|err| {
-                BlockError::InvalidArg(format!("workchain_id is not correct number: {}", err))
+                BlockError::InvalidArg(format!("workchain_id is not correct number: {err}"))
             })?
             .unwrap_or_default();
         let anycast = len
@@ -312,20 +312,19 @@ impl FromStr for MsgAddress {
                     Err(BlockError::InvalidArg("wrong format".to_string()))
                 } else {
                     SliceData::from_string(parts[index]).map_err(|err| {
-                        BlockError::InvalidArg(format!("anycast is not correct: {}", err))
+                        BlockError::InvalidArg(format!("anycast is not correct: {err}"))
                     })
                 }
             })
             .transpose()?
             .map(AnycastInfo::with_rewrite_pfx)
             .transpose()
-            .map_err(|err| BlockError::InvalidArg(format!("anycast is not correct: {}", err)))?;
+            .map_err(|err| BlockError::InvalidArg(format!("anycast is not correct: {err}")))?;
 
         if (-128..128).contains(&workchain_id) {
             if address.remaining_bits() != 256 {
                 fail!(BlockError::InvalidArg(format!(
-                    "account address should be 256 bits long in workchain {}",
-                    workchain_id
+                    "account address should be 256 bits long in workchain {workchain_id}"
                 )))
             }
             if parts[len - 1].len() == 64 {
@@ -343,9 +342,9 @@ impl fmt::Display for MsgAddress {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             MsgAddress::AddrNone => write!(f, ""),
-            MsgAddress::AddrExt(addr) => write!(f, "{}", addr),
-            MsgAddress::AddrStd(addr) => write!(f, "{}", addr),
-            MsgAddress::AddrVar(addr) => write!(f, "{}", addr),
+            MsgAddress::AddrExt(addr) => write!(f, "{addr}"),
+            MsgAddress::AddrStd(addr) => write!(f, "{addr}"),
+            MsgAddress::AddrVar(addr) => write!(f, "{addr}"),
         }
     }
 }
@@ -475,8 +474,8 @@ impl Serializable for MsgAddressInt {
 impl fmt::Display for MsgAddressInt {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            MsgAddressInt::AddrStd(addr) => write!(f, "{}", addr),
-            MsgAddressInt::AddrVar(addr) => write!(f, "{}", addr),
+            MsgAddressInt::AddrStd(addr) => write!(f, "{addr}"),
+            MsgAddressInt::AddrVar(addr) => write!(f, "{addr}"),
         }
     }
 }
@@ -551,7 +550,7 @@ impl fmt::Display for MsgAddressIntOrNone {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             MsgAddressIntOrNone::None => write!(f, ""),
-            MsgAddressIntOrNone::Some(addr) => write!(f, "{}", addr),
+            MsgAddressIntOrNone::Some(addr) => write!(f, "{addr}"),
         }
     }
 }
@@ -850,9 +849,9 @@ impl Deserializable for ExtOutMessageHeader {
 impl fmt::Display for CommonMsgInfo {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            CommonMsgInfo::IntMsgInfo(hdr) => write!(f, "{}", hdr),
-            CommonMsgInfo::ExtInMsgInfo(hdr) => write!(f, "{}", hdr),
-            CommonMsgInfo::ExtOutMsgInfo(hdr) => write!(f, "{}", hdr),
+            CommonMsgInfo::IntMsgInfo(hdr) => write!(f, "{hdr}"),
+            CommonMsgInfo::ExtInMsgInfo(hdr) => write!(f, "{hdr}"),
+            CommonMsgInfo::ExtOutMsgInfo(hdr) => write!(f, "{hdr}"),
         }
     }
 }
@@ -985,11 +984,11 @@ impl fmt::Display for Message {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Message {{header: {}", self.header)?;
         match &self.init {
-            Some(init) => write!(f, ", init: {:?}", init)?,
+            Some(init) => write!(f, ", init: {init:?}")?,
             None => write!(f, ", init: None")?,
         }
         match &self.body {
-            Some(body) => write!(f, ", body: {:x}", body)?,
+            Some(body) => write!(f, ", body: {body:x}")?,
             None => write!(f, ", body: None")?,
         }
         write!(f, "}}")

--- a/tvm_block/src/shard.rs
+++ b/tvm_block/src/shard.rs
@@ -283,8 +283,7 @@ impl ShardIdent {
     ) -> Result<Self> {
         if shard_pfx_len > MAX_SPLIT_DEPTH {
             fail!(BlockError::InvalidArg(format!(
-                "Shard prefix length can't greater than {}",
-                MAX_SPLIT_DEPTH
+                "Shard prefix length can't greater than {MAX_SPLIT_DEPTH}"
             )))
         }
         Self::check_workchain_id(workchain_id)?;
@@ -294,8 +293,7 @@ impl ShardIdent {
     pub fn with_tagged_prefix(workchain_id: i32, shard_prefix_tagged: u64) -> Result<Self> {
         if (shard_prefix_tagged & (!0 >> (MAX_SPLIT_DEPTH + 1))) != 0 {
             fail!(BlockError::InvalidArg(format!(
-                "Shard prefix {:16X} cannot be longer than {}",
-                shard_prefix_tagged, MAX_SPLIT_DEPTH
+                "Shard prefix {shard_prefix_tagged:16X} cannot be longer than {MAX_SPLIT_DEPTH}"
             )))
         }
         Self::check_workchain_id(workchain_id)?;
@@ -311,8 +309,7 @@ impl ShardIdent {
         }
         if shard_pfx_bits > MAX_SPLIT_DEPTH {
             fail!(BlockError::InvalidArg(format!(
-                "Shard prefix length can't greater than {}",
-                MAX_SPLIT_DEPTH
+                "Shard prefix length can't greater than {MAX_SPLIT_DEPTH}"
             )))
         }
         Self::check_workchain_id(workchain_id)?;
@@ -327,8 +324,7 @@ impl ShardIdent {
     pub fn check_workchain_id(workchain_id: i32) -> Result<()> {
         if workchain_id == INVALID_WORKCHAIN_ID {
             fail!(BlockError::InvalidArg(format!(
-                "Workchain id 0x{:x} is invalid",
-                INVALID_WORKCHAIN_ID
+                "Workchain id 0x{INVALID_WORKCHAIN_ID:x} is invalid"
             )))
         }
         Ok(())
@@ -629,8 +625,7 @@ impl Deserializable for ShardIdent {
         let shard_pfx_bits = constructor_and_pfx & 0x3F;
         if shard_pfx_bits > MAX_SPLIT_DEPTH {
             fail!(BlockError::InvalidArg(format!(
-                "Shard prefix bits {} cannot be longer than {}",
-                shard_pfx_bits, MAX_SPLIT_DEPTH
+                "Shard prefix bits {shard_pfx_bits} cannot be longer than {MAX_SPLIT_DEPTH}"
             )))
         }
         let workchain_id = cell.get_next_u32()? as i32;

--- a/tvm_block/src/signature.rs
+++ b/tvm_block/src/signature.rs
@@ -71,10 +71,10 @@ impl CryptoSignature {
     pub fn from_r_s_str(r: &str, s: &str) -> Result<Self> {
         let mut bytes = [0; ed25519_dalek::SIGNATURE_LENGTH];
         hex::decode_to_slice(r, &mut bytes[..ed25519_dalek::SIGNATURE_LENGTH / 2]).map_err(
-            |err| BlockError::InvalidData(format!("error parsing `r` hex string: {}", err)),
+            |err| BlockError::InvalidData(format!("error parsing `r` hex string: {err}")),
         )?;
         hex::decode_to_slice(s, &mut bytes[ed25519_dalek::SIGNATURE_LENGTH / 2..]).map_err(
-            |err| BlockError::InvalidData(format!("error parsing `s` hex string: {}", err)),
+            |err| BlockError::InvalidData(format!("error parsing `s` hex string: {err}")),
         )?;
         Self::from_bytes(&bytes)
     }
@@ -111,7 +111,7 @@ impl FromStr for CryptoSignature {
 
     fn from_str(s: &str) -> Result<Self> {
         let key_buf = hex::decode(s).map_err(|err| {
-            BlockError::InvalidData(format!("error parsing hex string {} : {}", s, err))
+            BlockError::InvalidData(format!("error parsing hex string {s} : {err}"))
         })?;
         Self::from_bytes(&key_buf)
     }

--- a/tvm_block/src/tests/test_accounts.rs
+++ b/tvm_block/src/tests/test_accounts.rs
@@ -489,14 +489,14 @@ fn test_account_account2() {
     let mut acc = Account::with_storage(&addr, &st_info, &acc_st);
     acc.update_storage_stat().unwrap();
 
-    println!("acc before update {}", acc);
+    println!("acc before update {acc}");
     let su1 = acc.get_storage_stat().unwrap();
-    println!("StorageUsed before {}", su1);
+    println!("StorageUsed before {su1}");
 
     let mut acc = write_read_and_assert(acc);
 
     let su2 = acc.get_storage_stat().unwrap();
-    println!("StorageUsed after {}", su2);
+    println!("StorageUsed after {su2}");
     assert_eq!(su1, su2);
 
     if let Some(acc_code) = acc.get_code() {
@@ -641,7 +641,7 @@ fn test_real_account_serde() {
         ["src/tests/data/7992DD77CEB677577A7D5A8B6F388CDA76B4D0DDE16FF5004C87215E6ADF84DD.boc"];
 
     for state_file in state_files {
-        println!("state file: {}", state_file);
+        println!("state file: {state_file}");
 
         let (state, _) = get_real_tvm_state(state_file);
 
@@ -655,8 +655,8 @@ fn test_real_account_serde() {
                 let cell = acc.serialize().unwrap();
                 let acc2 = Account::construct_from_cell(cell.clone()).unwrap();
 
-                println!("orig:\n{:#.1}\n\n", acc_cell);
-                println!("our:\n{:#.1}\n\n", cell);
+                println!("orig:\n{acc_cell:#.1}\n\n");
+                println!("our:\n{cell:#.1}\n\n");
 
                 assert_eq!(acc, acc2);
 

--- a/tvm_block/src/tests/test_bintree.rs
+++ b/tvm_block/src/tests/test_bintree.rs
@@ -71,14 +71,14 @@ mod test_bintree {
 
         assert!(tree.split(SliceData::default(), &22, &CurrencyCollection::with_grams(2)).unwrap());
         let tree2 = tree.get_data();
-        println!("{}", tree2);
+        println!("{tree2}");
         assert_eq!(tree.get(prepare_key(0, 1)).unwrap(), Some(11));
         assert_eq!(tree.get(prepare_key(1, 1)).unwrap(), Some(22));
         assert_eq!(tree.root_extra(), &CurrencyCollection::with_grams(3));
 
         assert!(tree.split(prepare_key(0, 1), &33, &CurrencyCollection::with_grams(4)).unwrap());
         let tree3 = tree.get_data();
-        println!("{}", tree3);
+        println!("{tree3}");
         assert_eq!(tree.get(prepare_key(0, 1)).unwrap(), None);
         assert_eq!(tree.get(prepare_key(0, 2)).unwrap(), Some(11));
         assert_eq!(tree.get(prepare_key(1, 2)).unwrap(), Some(33));

--- a/tvm_block/src/tests/test_blocks.rs
+++ b/tvm_block/src/tests/test_blocks.rs
@@ -275,7 +275,7 @@ fn test_value_flow() {
 
 fn read_file_de_and_serialise(filename: &Path) -> Cell {
     let boc =
-        read(Path::new(filename)).unwrap_or_else(|_| panic!("Error reading file {:?}", filename));
+        read(Path::new(filename)).unwrap_or_else(|_| panic!("Error reading file {filename:?}"));
     let mut cells =
         BocReader::new().read(&mut Cursor::new(&boc)).expect("Error deserializing BOC").roots;
     cells.remove(0)
@@ -294,7 +294,7 @@ fn test_real_tvm_boc() {
                 } {
                     continue;
                 }
-                println!("BOC file: {:?}", in_path);
+                println!("BOC file: {in_path:?}");
                 read_file_de_and_serialise(&in_path);
             }
         }
@@ -308,17 +308,17 @@ fn test_real_tvm_mgs() {
     // let in_path = Path::new("src/tests/data/send-to-query.boc");
     let in_path = Path::new("src/tests/data/int-msg-query.boc");
 
-    println!("MSG file: {:?}", in_path);
+    println!("MSG file: {in_path:?}");
     let root_cell = read_file_de_and_serialise(in_path);
 
-    println!("slice = {}", root_cell);
+    println!("slice = {root_cell}");
     let msg = Message::construct_from_cell(root_cell).unwrap();
-    println!("Message = {:?}", msg);
+    println!("Message = {msg:?}");
 }
 
 fn test_real_block(in_path: &Path) -> Block {
     println!();
-    println!("Block file: {:?}", in_path);
+    println!("Block file: {in_path:?}");
     let root_cell = read_file_de_and_serialise(in_path);
     // println!("slice = {}", root_cell);
 
@@ -374,7 +374,7 @@ fn test_real_block(in_path: &Path) -> Block {
         custom
             .fees()
             .iterate_with_keys(|key, shard_fees| {
-                println!("\n\nkey: {:?}, shard_fees: {:?}\n\n", key, shard_fees);
+                println!("\n\nkey: {key:?}, shard_fees: {shard_fees:?}\n\n");
                 Ok(true)
             })
             .unwrap();
@@ -385,7 +385,7 @@ fn test_real_block(in_path: &Path) -> Block {
         .unwrap()
         .iterate_objects(|in_msg| {
             println!();
-            println!("InMsg: {:?}", in_msg);
+            println!("InMsg: {in_msg:?}");
             Ok(true)
         })
         .unwrap();
@@ -395,7 +395,7 @@ fn test_real_block(in_path: &Path) -> Block {
         .unwrap()
         .iterate_objects(|out_msg| {
             println!();
-            println!("OutMsg: {:?}", out_msg);
+            println!("OutMsg: {out_msg:?}");
             Ok(true)
         })
         .unwrap();
@@ -408,7 +408,7 @@ fn test_real_block(in_path: &Path) -> Block {
             println!("AccountBlock ID: {:?}", account_block.account_id());
             account_block.transaction_iterate(|transaction| {
                 println!();
-                println!("\tTransaction: {:?}", transaction);
+                println!("\tTransaction: {transaction:?}");
                 Ok(true)
             })?;
             Ok(true)
@@ -462,9 +462,9 @@ fn test_all_real_tvm_block_with_transaction() {
 fn test_real_tvm_config() {
     // to get current config run lite_client with saveconfig config.boc
     let in_path = Path::new("src/tests/data/config.boc");
-    println!("Config file: {:?}", in_path);
+    println!("Config file: {in_path:?}");
     let root_cell = read_file_de_and_serialise(in_path);
-    println!("cell = {:#.2}", root_cell);
+    println!("cell = {root_cell:#.2}");
 
     crate::config_params::dump_config(&HashmapE::with_hashmap(32, Some(root_cell)));
 }
@@ -589,7 +589,7 @@ fn test_read_tob_block_descr() {
     let data = std::fs::read("src/tests/data/top_block_descr.boc").unwrap();
     let cell = read_single_root_boc(data).unwrap();
     let descr = TopBlockDescr::construct_from_cell(cell).unwrap();
-    println!("{:?}", descr);
+    println!("{descr:?}");
 }
 
 #[test]

--- a/tvm_block/src/tests/test_config_params.rs
+++ b/tvm_block/src/tests/test_config_params.rs
@@ -97,7 +97,7 @@ fn test_config_param_18() {
     cp18.write_to_new_cell().expect_err("Empty ConfigParam18 can't be serialized");
 
     for i in 0..10 {
-        cp18.get(i).expect_err(&format!("param with index {} must not be present yet", i));
+        cp18.get(i).expect_err(&format!("param with index {i} must not be present yet"));
         cp18.insert(&get_storage_prices()).unwrap();
         cp18.get(i).unwrap();
         assert_eq!(cp18.len().unwrap(), i as usize + 1);

--- a/tvm_block/src/tests/test_hashmapaug.rs
+++ b/tvm_block/src/tests/test_hashmapaug.rs
@@ -74,14 +74,14 @@ fn test_hashmapaug() {
     let mut tree = GramHashmap7::default();
     assert_eq!(&GramStruct::with_value(0), tree.root_extra());
     assert!(tree.is_empty());
-    println!("empty {}", tree);
+    println!("empty {tree}");
 
     // add first
     let key1 = SliceData::new(vec![0xFF]);
     let value1 = key1.clone();
     let extra1 = GramStruct::with_value(1);
     tree.set_serialized(key1.clone(), &value1, &extra1).unwrap();
-    println!("first {}", tree);
+    println!("first {tree}");
     assert_eq!(&GramStruct::with_value(1), tree.root_extra());
     assert_eq!(tree.get_serialized_as_slice(key1.clone()).unwrap(), Some(value1.clone()));
 
@@ -89,7 +89,7 @@ fn test_hashmapaug() {
     let value1 = SliceData::new(vec![0xFB]);
     let extra1 = GramStruct::with_value(2);
     tree.set_serialized(key1.clone(), &value1, &extra1).unwrap();
-    println!("replaced {}", tree);
+    println!("replaced {tree}");
     assert!(!tree.is_empty());
     assert_eq!(&GramStruct::with_value(2), tree.root_extra());
     assert_eq!(tree.get_serialized_as_slice(key1.clone()).unwrap(), Some(value1.clone()));
@@ -99,7 +99,7 @@ fn test_hashmapaug() {
     let value2 = key2.clone();
     let extra2 = GramStruct::with_value(3);
     tree.set_serialized(key2.clone(), &value2, &extra2).unwrap();
-    println!("second {}", tree);
+    println!("second {tree}");
     assert!(!tree.is_empty());
     assert_eq!(&GramStruct::with_value(5), tree.root_extra());
     assert_eq!(tree.get_serialized_as_slice(key1.clone()).unwrap(), Some(value1.clone()));
@@ -109,7 +109,7 @@ fn test_hashmapaug() {
     let value2 = SliceData::new(vec![0xF2]);
     let extra2 = GramStruct::with_value(4);
     tree.set_serialized(key2.clone(), &value2, &extra2).unwrap();
-    println!("second replaced {}", tree);
+    println!("second replaced {tree}");
     assert!(!tree.is_empty());
     assert_eq!(&GramStruct::with_value(6), tree.root_extra());
     assert_eq!(tree.get_serialized_as_slice(key1.clone()).unwrap(), Some(value1.clone()));
@@ -120,7 +120,7 @@ fn test_hashmapaug() {
     let value3 = key3.clone();
     let extra3 = GramStruct::with_value(5);
     tree.set_serialized(key3.clone(), &value3, &extra3).unwrap();
-    println!("third added {}", tree);
+    println!("third added {tree}");
     assert!(!tree.is_empty());
     assert_eq!(&GramStruct::with_value(11), tree.root_extra());
     assert_eq!(tree.get_serialized_as_slice(key1.clone()).unwrap(), Some(value1.clone()));
@@ -131,7 +131,7 @@ fn test_hashmapaug() {
     let value3 = SliceData::new(vec![0x0F]);
     let extra3 = GramStruct::with_value(6);
     tree.set_serialized(key3.clone(), &value3, &extra3).unwrap();
-    println!("third replaced {}", tree);
+    println!("third replaced {tree}");
     assert!(!tree.is_empty());
     assert_eq!(&GramStruct::with_value(12), tree.root_extra());
     assert_eq!(tree.get_serialized_as_slice(key1.clone()).unwrap(), Some(value1.clone()));
@@ -143,7 +143,7 @@ fn test_hashmapaug() {
     let value4 = key4.clone();
     let extra4 = GramStruct::with_value(7);
     tree.set_serialized(key4.clone(), &value4, &extra4).unwrap();
-    println!("fourth added {}", tree);
+    println!("fourth added {tree}");
     assert!(!tree.is_empty());
     assert_eq!(&GramStruct::with_value(19), tree.root_extra());
     assert_eq!(tree.get_serialized_as_slice(key1).unwrap(), Some(value1));
@@ -810,7 +810,7 @@ fn check_hashmap_fill_and_filter(mut keys: Vec<u8>, remove: &[u8], stop: usize, 
     }
     for i in 0..res1.len() {
         if i % 7 == 0 {
-            println!("{}", i);
+            println!("{i}");
             pretty_assertions::assert_eq!(res1[i], res2[i]);
         }
     }
@@ -841,9 +841,9 @@ fn test_hahsmap_rand_fill_and_filter() {
     }
     let stop = rand::Rng::gen::<usize>(&mut rng) % keys.len();
     let cancel = keys.len(); // rand::Rng::gen::<usize>(&mut rng) % keys.len();
-    println!("{:#?}", keys);
-    println!("{:#?}", remove);
-    println!("{} {}", stop, cancel);
+    println!("{keys:#?}");
+    println!("{remove:#?}");
+    println!("{stop} {cancel}");
     check_hashmap_fill_and_filter(keys, &remove, stop, cancel);
 }
 

--- a/tvm_block/src/tests/test_master.rs
+++ b/tvm_block/src/tests/test_master.rs
@@ -369,7 +369,7 @@ fn test_real_shard_hashes() {
     let extra = block.read_extra().unwrap().read_custom().unwrap().expect("need key block");
     let shards = extra.shards();
     let mut count = shards.dump("shards");
-    println!("total: {}", count);
+    println!("total: {count}");
 
     let mut result = vec![];
     println!("---- pairs ----");
@@ -524,7 +524,7 @@ fn test_get_next_prev_key_block() {
     prev_blocks
         .iterate_with_keys_and_aug(|seqno, id, aug| {
             if aug.key && seqno != 0 {
-                println!("{:?}", id);
+                println!("{id:?}");
                 all_key_blocks.insert(seqno, id);
             }
             Ok(true)
@@ -534,7 +534,7 @@ fn test_get_next_prev_key_block() {
     let mut seqno = 0;
     let mut key_blocks = vec![];
     while let Some(id) = prev_blocks.get_next_key_block(seqno + 1).unwrap() {
-        println!("{:?}", id);
+        println!("{id:?}");
         seqno = id.seq_no;
         key_blocks.push(id);
     }
@@ -550,7 +550,7 @@ fn test_get_next_prev_key_block() {
     let mut seqno = key_blocks[key_blocks.len() - 1].seq_no + 2;
     let mut key_blocks2 = vec![];
     while let Some(id) = prev_blocks.get_prev_key_block(seqno - 1).unwrap() {
-        println!("{:?}", id);
+        println!("{id:?}");
         seqno = id.seq_no;
         if seqno == 0 {
             break;

--- a/tvm_block/src/tests/test_merkle_proof.rs
+++ b/tvm_block/src/tests/test_merkle_proof.rs
@@ -231,8 +231,8 @@ fn test_merkle_proof_hi_hashes() {
     // construct proof BOC
     let proof_root = block_proof.serialize().unwrap();
 
-    println!("{:#.222}", proof_root);
-    println!("{:#.2}", block_root);
+    println!("{proof_root:#.222}");
+    println!("{block_root:#.2}");
 
     // check block's repr hash is equal proof's higher hash
     assert_eq!(
@@ -288,8 +288,8 @@ fn test_merkle_proof_hi_hashes2() {
     // construct proof BOC
     let proof_root = block_proof.write_to_new_cell().unwrap().into_cell().unwrap();
 
-    println!("{:#.222}", proof_root);
-    println!("{:#.222}", block_root);
+    println!("{proof_root:#.222}");
+    println!("{block_root:#.222}");
 
     // check block's repr hash is equal proof's higher hash
     assert_eq!(
@@ -395,10 +395,10 @@ fn test_check_wrong_transaction_proof() {
     ];
 
     for block_file in block_files {
-        println!("check wrong proof for {}", block_file);
+        println!("check wrong proof for {block_file}");
         match test_check_transaction_proof(true, block_file) {
-            Result::Err(err) => println!("{}", err),
-            res => panic!("unexpected result: {:?}", res),
+            Result::Err(err) => println!("{err}"),
+            res => panic!("unexpected result: {res:?}"),
         }
     }
 }
@@ -412,10 +412,10 @@ fn test_check_correct_transaction_proof() {
     ];
 
     for block_file in block_files {
-        println!("check correct proof, block: {}", block_file);
+        println!("check correct proof, block: {block_file}");
         match test_check_transaction_proof(false, block_file) {
             Result::Ok(_) => println!("OK"),
-            res => panic!("unexpected result: {:?}", res),
+            res => panic!("unexpected result: {res:?}"),
         }
     }
 }
@@ -449,7 +449,7 @@ fn get_out_msg_from_block(block: &Block) -> (Option<Message>, Option<UInt256>) {
         .unwrap()
         .iterate_with_keys(|key, out_msg| {
             if let Some(msg1) = out_msg.read_message().unwrap() {
-                println!("{}", key);
+                println!("{key}");
                 println!("{}", msg1.hash().unwrap());
                 msg = Some(msg1);
                 tr = out_msg.transaction_cell().map(|c| c.repr_hash());
@@ -517,7 +517,7 @@ fn test_check_correct_account_proof() {
         vec!["src/tests/data/7992DD77CEB677577A7D5A8B6F388CDA76B4D0DDE16FF5004C87215E6ADF84DD.boc"];
 
     for state_file in state_files {
-        println!("state file: {}", state_file);
+        println!("state file: {state_file}");
 
         let (state, state_root) = get_real_tvm_state(state_file);
 
@@ -549,7 +549,7 @@ fn test_check_wrong_account_proof() {
         vec!["src/tests/data/7992DD77CEB677577A7D5A8B6F388CDA76B4D0DDE16FF5004C87215E6ADF84DD.boc"];
 
     for state_file in state_files {
-        println!("state file: {}", state_file);
+        println!("state file: {state_file}");
 
         let (state, state_root) = get_real_tvm_state(state_file);
 
@@ -562,8 +562,8 @@ fn test_check_wrong_account_proof() {
                 println!("account: {}", account.get_id().unwrap());
 
                 match test_check_account_proof(true, account, &state_root) {
-                    Result::Err(err) => println!("{}", err),
-                    res => panic!("unexpected result: {:?}", res),
+                    Result::Err(err) => println!("{err}"),
+                    res => panic!("unexpected result: {res:?}"),
                 }
 
                 Ok(true)

--- a/tvm_block/src/tests/test_messages.rs
+++ b/tvm_block/src/tests/test_messages.rs
@@ -328,7 +328,7 @@ fn test_check_json_address() {
 
     addresses.iter().for_each(|addr| {
         let err = MsgAddressInt::from_str(addr).err();
-        println!("{:?}", err);
+        println!("{err:?}");
         assert!(err.is_some());
     });
 
@@ -380,9 +380,9 @@ fn test_check_json_address() {
     ];
     addresses_int.iter().for_each(|(addr, check)| {
         let real = MsgAddressInt::from_str(addr).unwrap();
-        println!("{}", real);
+        println!("{real}");
         assert_eq!(&real, check);
-        assert_eq!(&format!("{}", real), addr);
+        assert_eq!(&format!("{real}"), addr);
     });
 
     let addresses_ext = [
@@ -395,9 +395,9 @@ fn test_check_json_address() {
     ];
     addresses_ext.iter().for_each(|(addr, check)| {
         let real = MsgAddressExt::from_str(addr).unwrap();
-        println!("{}", real);
+        println!("{real}");
         assert_eq!(&real, check);
-        assert_eq!(&format!("{}", real), addr);
+        assert_eq!(&format!("{real}"), addr);
     });
 }
 
@@ -424,7 +424,7 @@ fn test_msg_address_int_or_none() {
     addr2.write_to(&mut b).unwrap();
     addr3.write_to(&mut b).unwrap();
     let mut s = SliceData::load_builder(b).unwrap();
-    println!("{:x}", s);
+    println!("{s:x}");
     let mut addr1_ = MsgAddressIntOrNone::default();
     addr1_.read_from(&mut s).unwrap();
     assert_eq!(addr1, addr1_);
@@ -441,7 +441,7 @@ fn test_msg_address_int_invalid() {
     let addr1 = MsgAddressIntOrNone::default();
     let b = addr1.write_to_new_cell().unwrap();
     let mut s = SliceData::load_builder(b).unwrap();
-    println!("{:x}", s);
+    println!("{s:x}");
     MsgAddressInt::construct_from(&mut s)
         .expect_err("MsgAddressInt should not be deserialized from None");
 }

--- a/tvm_block/src/tests/test_miscellaneous.rs
+++ b/tvm_block/src/tests/test_miscellaneous.rs
@@ -69,7 +69,7 @@ fn test_process_info() {
     write_read_and_assert(pi2.clone());
 
     pi2.iterate(|put| {
-        println!("{:?}", put);
+        println!("{put:?}");
         Ok(true)
     })
     .unwrap();
@@ -84,7 +84,7 @@ fn test_process_info() {
     write_read_and_assert(pi2.clone());
 
     pi2.iterate(|put| {
-        println!("{:?}", put);
+        println!("{put:?}");
         Ok(true)
     })
     .unwrap();
@@ -114,7 +114,7 @@ fn test_find_shards_by_routing_custom() {
     env.set_next_addr(IntermediateAddress::use_dest_bits(37).unwrap())
         .set_cur_addr(IntermediateAddress::use_dest_bits(32).unwrap());
     let (cur_prefix, next_prefix) = env.calc_cur_next_prefix().unwrap();
-    println!("cur: {}, next: {}", cur_prefix, next_prefix);
+    println!("cur: {cur_prefix}, next: {next_prefix}");
 
     assert_eq!(cur_prefix.prefix, 0xd78b3fd904191a09);
     assert_eq!(next_prefix.prefix, 0x9f8b3fd904191a09);

--- a/tvm_block/src/tests/test_out_actions.rs
+++ b/tvm_block/src/tests/test_out_actions.rs
@@ -97,7 +97,7 @@ fn test_outactions() {
     assert_eq!(oa.len(), 11);
 
     for a in oa.iter() {
-        println!("action {:?}", a);
+        println!("action {a:?}");
     }
 }
 
@@ -107,13 +107,13 @@ fn test_outactions_serialization() {
     let b = oa.serialize().unwrap();
     let mut s = SliceData::load_cell(b).unwrap();
 
-    println!("action send slice: {}", s);
+    println!("action send slice: {s}");
 
     let mut oa_restored = OutActions::new();
     oa_restored.read_from(&mut s).unwrap();
 
     for a in oa_restored.iter() {
-        println!("action {:?}", a);
+        println!("action {a:?}");
     }
     assert_eq!(oa, oa_restored);
 }

--- a/tvm_block/src/tests/test_out_msgs.rs
+++ b/tvm_block/src/tests/test_out_msgs.rs
@@ -101,7 +101,7 @@ fn test_out_msg_external_serialization() {
 
     let mut s = SliceData::load_builder(b).unwrap();
 
-    println!("out_msg slice = {}", s);
+    println!("out_msg slice = {s}");
 
     let mut out_msg_restored = OutMsg::None;
     out_msg_restored.read_from(&mut s).unwrap();
@@ -123,7 +123,7 @@ fn test_out_msg_immediately_serialization() {
 
     let mut s = SliceData::load_builder(b).unwrap();
 
-    println!("out_msg slice = {}", s);
+    println!("out_msg slice = {s}");
 
     let mut out_msg_restored = OutMsg::None;
     out_msg_restored.read_from(&mut s).unwrap();
@@ -152,7 +152,7 @@ fn test_out_msg_transit_serialization() {
 
     let mut s = SliceData::load_builder(b).unwrap();
 
-    println!("out_msg slice = {}", s);
+    println!("out_msg slice = {s}");
 
     let mut out_msg_restored = OutMsg::None;
     out_msg_restored.read_from(&mut s).unwrap();
@@ -172,7 +172,7 @@ fn test_out_msg_dequeue_serialization() {
 
     let mut s = SliceData::load_builder(b).unwrap();
 
-    println!("out_msg slice = {}", s);
+    println!("out_msg slice = {s}");
 
     let mut out_msg_restored = OutMsg::None;
     out_msg_restored.read_from(&mut s).unwrap();
@@ -197,7 +197,7 @@ fn test_out_msg_dequeue_short_serialization() {
 
     let mut s = SliceData::load_builder(b).unwrap();
 
-    println!("out_msg slice = {}", s);
+    println!("out_msg slice = {s}");
 
     let mut out_msg_restored = OutMsg::None;
     out_msg_restored.read_from(&mut s).unwrap();
@@ -226,7 +226,7 @@ fn test_serialization_out_msg_queue() {
         queue.insert(0, n, &out_msg_env, 11).unwrap();
     }
 
-    println!("{:?}", queue);
+    println!("{queue:?}");
     write_read_and_assert(queue);
 }
 

--- a/tvm_block/src/tests/test_shard.rs
+++ b/tvm_block/src/tests/test_shard.rs
@@ -25,12 +25,12 @@ fn parse_shard_state_unsplit(ss: ShardStateUnsplit) {
         .unwrap()
         .out_queue()
         .iterate_objects(|message| {
-            println!("message: {:?}", message);
+            println!("message: {message:?}");
             len += 1;
             Ok(true)
         })
         .unwrap();
-    println!("count: {}", len);
+    println!("count: {len}");
 
     println!("accounts");
     let mut len = 0;
@@ -45,7 +45,7 @@ fn parse_shard_state_unsplit(ss: ShardStateUnsplit) {
             Ok(true)
         })
         .unwrap();
-    println!("count: {}", len);
+    println!("count: {len}");
     println!();
 
     if let Some(custom) = ss.read_custom().unwrap() {
@@ -58,7 +58,7 @@ fn parse_shard_state_unsplit(ss: ShardStateUnsplit) {
         custom
             .prev_blocks
             .iterate_with_keys(|seq_no, blkref| -> Result<bool> {
-                println!("\tblock seq_no: {} | {:?}", seq_no, blkref);
+                println!("\tblock seq_no: {seq_no} | {blkref:?}");
                 i += 1;
                 Ok(i <= 5)
             })
@@ -72,10 +72,10 @@ fn parse_shard_state_unsplit(ss: ShardStateUnsplit) {
 fn test_real_tvm_shardstate() {
     // getstate (-1,8000000000000000,0)
     let in_path = "src/tests/data/shard_state.boc";
-    println!("ShardState file: {:?}", in_path);
+    println!("ShardState file: {in_path:?}");
     let bytes = std::fs::read(in_path).unwrap();
     let root_cell = read_single_root_boc(bytes).unwrap();
-    println!("cell = {:#.2}", root_cell);
+    println!("cell = {root_cell:#.2}");
 
     let ss = ShardState::construct_from_cell(root_cell).unwrap();
 

--- a/tvm_block/src/tests/test_types.rs
+++ b/tvm_block/src/tests/test_types.rs
@@ -52,11 +52,11 @@ fn test_varuinteger_with_zero() {
 fn test_varuinteger7_from_into() {
     let mut b1: SliceData = SliceData::new(vec![0b00100000, 0b01010000]);
 
-    println!("b1 = {}", b1);
+    println!("b1 = {b1}");
 
     let mut vui7: VarUInteger7 = VarUInteger7::default();
     vui7.read_from(&mut b1).unwrap();
-    println!("vui7 = {}", vui7);
+    println!("vui7 = {vui7}");
 
     assert_eq!(VarUInteger7::from(2), vui7);
 
@@ -72,8 +72,8 @@ fn test_varuinteger7_from_into() {
 
     let mut s1: BuilderData = BuilderData::new();
     v2.write_to(&mut s1).unwrap();
-    println!("s1 = {}", s1);
-    println!("v2 = {}", v2);
+    println!("s1 = {s1}");
+    println!("v2 = {v2}");
 }
 
 #[test]

--- a/tvm_block/src/tests/test_validators.rs
+++ b/tvm_block/src/tests/test_validators.rs
@@ -219,7 +219,7 @@ fn test_isolate_mc_validators() {
             )
             .unwrap();
 
-        println!("shard {} validators", shard);
+        println!("shard {shard} validators");
         for v in shard_validators.iter() {
             println!("{:x}", v.adnl_addr.as_ref().unwrap());
         }

--- a/tvm_block/src/types.rs
+++ b/tvm_block/src/types.rs
@@ -948,7 +948,7 @@ impl fmt::Display for CurrencyCollection {
                     Ok(true)
                 })
                 .ok();
-            write!(f, " count: {} }}", len)?;
+            write!(f, " count: {len} }}")?;
         }
         Ok(())
     }

--- a/tvm_block/src/validators.rs
+++ b/tvm_block/src/validators.rs
@@ -640,8 +640,7 @@ impl Deserializable for ValidatorSet {
             let mut val = validators.get(&i)?.ok_or_else(|| {
                 BlockError::InvalidData(format!(
                     "Validator's hash map doesn't \
-                    contain validator with index {}",
-                    i
+                    contain validator with index {i}"
                 ))
             })?;
             val.prev_weight_sum = total_weight;

--- a/tvm_block_json/build.rs
+++ b/tvm_block_json/build.rs
@@ -16,9 +16,9 @@ fn main() {
     let build_time = get_value("date", &["+%Y-%m-%d %T %z"]);
     let rust_version = get_value("rustc", &["--version"]);
 
-    println!("cargo:rustc-env=BUILD_GIT_BRANCH={}", git_branch);
-    println!("cargo:rustc-env=BUILD_GIT_COMMIT={}", git_commit);
-    println!("cargo:rustc-env=BUILD_GIT_DATE={}", commit_date);
-    println!("cargo:rustc-env=BUILD_TIME={}", build_time);
-    println!("cargo:rustc-env=BUILD_RUST_VERSION={}", rust_version);
+    println!("cargo:rustc-env=BUILD_GIT_BRANCH={git_branch}");
+    println!("cargo:rustc-env=BUILD_GIT_COMMIT={git_commit}");
+    println!("cargo:rustc-env=BUILD_GIT_DATE={commit_date}");
+    println!("cargo:rustc-env=BUILD_TIME={build_time}");
+    println!("cargo:rustc-env=BUILD_RUST_VERSION={rust_version}");
 }

--- a/tvm_block_json/src/block_parser/parser.rs
+++ b/tvm_block_json/src/block_parser/parser.rs
@@ -72,7 +72,7 @@ impl<T: ParserTracer, R: JsonReducer> BlockParser<T, R> {
         } else {
             None
         };
-        log::trace!("block order for {}: {:#?}", block_id_str, block_order);
+        log::trace!("block order for {block_id_str}: {block_order:#?}");
 
         let block_info = block.block.read_info()?;
         let ut = block_info.gen_utime();

--- a/tvm_block_json/src/block_parser/reducers.rs
+++ b/tvm_block_json/src/block_parser/reducers.rs
@@ -22,7 +22,7 @@ impl ReduceConfig {
         let config = if config.starts_with('{') {
             config.trim_start_matches('{').to_string()
         } else {
-            format!("{}}}", config)
+            format!("{config}}}")
         };
         let spaced = config.replace('{', " { ").replace('}', " } ");
 
@@ -62,8 +62,7 @@ impl ReduceConfig {
                     .is_some()
                 {
                     return Err(BlockParsingError::InvalidData(format!(
-                        "invalid field name {}",
-                        field
+                        "invalid field name {field}"
                     ))
                     .into());
                 }
@@ -129,8 +128,7 @@ impl JsonFieldsReducer {
             Value::Null => value,
             Value::Object(map) => Value::Object(Self::reduce_fields(fields, map)?),
             _ => Err(BlockParsingError::InvalidData(format!(
-                "JSON object expected, received value: {}",
-                value
+                "JSON object expected, received value: {value}"
             )))?,
         })
     }

--- a/tvm_block_json/src/deserialize.rs
+++ b/tvm_block_json/src/deserialize.rs
@@ -358,7 +358,7 @@ impl StateParser {
         num: i32,
         f: impl FnOnce(&PathMap) -> Result<ConfigParamEnum>,
     ) -> Result<()> {
-        let p = format!("p{}", num);
+        let p = format!("p{num}");
         match config.get_obj(&p) {
             Ok(p) => self
                 .extra
@@ -378,7 +378,7 @@ impl StateParser {
         num: i32,
         f: impl FnOnce(&Vec<Value>) -> Result<ConfigParamEnum>,
     ) -> Result<()> {
-        let p = format!("p{}", num);
+        let p = format!("p{num}");
         match config.get_vec(&p) {
             Ok(v) => {
                 self.extra.config.set_config(f(v)?).map_err(|err| {
@@ -398,7 +398,7 @@ impl StateParser {
         num: i32,
         f: impl FnOnce(UInt256) -> Result<ConfigParamEnum>,
     ) -> Result<()> {
-        let p = format!("p{}", num);
+        let p = format!("p{num}");
         match config.get_uint256(&p) {
             Ok(p) => {
                 self.extra.config.set_config(f(p)?).map_err(|err| {
@@ -417,7 +417,7 @@ impl StateParser {
         config: &PathMap,
         num: i32,
     ) -> Result<Option<MandatoryParams>> {
-        let p = format!("p{}", num);
+        let p = format!("p{num}");
         match config.get_vec(&p) {
             Ok(vec) => {
                 let mut params = MandatoryParams::default();

--- a/tvm_block_json/src/serialize.rs
+++ b/tvm_block_json/src/serialize.rs
@@ -123,7 +123,7 @@ fn get_msg_fees(msg: &Message) -> Option<(&Grams, &Grams)> {
 }
 
 pub fn u64_to_string(value: u64) -> String {
-    let mut string = format!("{:x}", value);
+    let mut string = format!("{value:x}");
     string.insert_str(0, &format!("{:x}", string.len() - 1));
     string
 }
@@ -134,7 +134,7 @@ pub fn bigint_to_string(value: &BigInt) -> String {
         let string = hex::encode(bytes).trim_start_matches('f').to_owned();
         format!("-{:02x}{}", (string.len() - 1) ^ 0xFF, string)
     } else {
-        let mut string = format!("{:x}", value);
+        let mut string = format!("{value:x}");
         string.insert_str(0, &format!("{:02x}", string.len() - 1));
         string
     }
@@ -146,7 +146,7 @@ pub fn block_order(block: &Block, mc_seq_no: u32) -> Result<String> {
     if !info.shard().is_masterchain() {
         let mut workchain_order = u64_to_string(info.shard().workchain_id().unsigned_abs() as u64);
         if info.shard().workchain_id() < 0 {
-            workchain_order = format!("-{}", workchain_order);
+            workchain_order = format!("-{workchain_order}");
         }
         let seq_no_order = u64_to_string(info.seq_no() as u64);
         let shard_order = u64_to_string(info.shard().shard_prefix_with_tag().reverse_bits());
@@ -196,9 +196,9 @@ fn serialize_u64(
             u64_to_string(*value)
         }
         SerializationMode::QServer => {
-            format!("0x{:x}", value)
+            format!("0x{value:x}")
         }
-        SerializationMode::Debug => format!("{}", value),
+        SerializationMode::Debug => format!("{value}"),
     };
     serialize_field(map, id_str, string);
 }
@@ -215,7 +215,7 @@ fn serialize_lt(
             u64_to_string(*value)
         }
         SerializationMode::QServer => {
-            format!("0x{:x}", value)
+            format!("0x{value:x}")
         }
         SerializationMode::Debug => format!("{}_{}", value / 1_000_000, value % 1_000_000),
     };
@@ -235,10 +235,10 @@ fn serialize_bigint(
             if num::bigint::Sign::Minus == value.sign() {
                 format!("-0x{:x}", value.abs())
             } else {
-                format!("0x{:x}", value)
+                format!("0x{value:x}")
             }
         }
-        SerializationMode::Debug => format!("{}", value),
+        SerializationMode::Debug => format!("{value}"),
     };
 
     if let SerializationMode::Standart = mode {
@@ -248,7 +248,7 @@ fn serialize_bigint(
 }
 
 pub fn shard_to_string(value: u64) -> String {
-    format!("{:016x}", value)
+    format!("{value:016x}")
 }
 
 fn construct_address(workchain_id: i32, account_id: AccountId) -> Result<MsgAddressInt> {
@@ -504,7 +504,7 @@ fn serialize_cc(
     serialize_grams(map, prefix, &cc.grams, mode);
     let other = serialize_ecc(&cc.other, mode)?;
     if !other.is_empty() {
-        map.insert(format!("{}_other", prefix), other.into());
+        map.insert(format!("{prefix}_other"), other.into());
     }
     Ok(())
 }
@@ -539,7 +539,7 @@ fn serialize_scc(
         other.push(other_map);
     }
     if !other.is_empty() {
-        map.insert(format!("{}_other", prefix), other.into());
+        map.insert(format!("{prefix}_other"), other.into());
     }
 }
 
@@ -576,8 +576,8 @@ fn serialize_envelope_msg(env: &MsgEnvelope, mode: SerializationMode) -> Map<Str
                 map.insert("dst_prefix".to_string(), dst_prefix.to_string().into());
             }
         }
-        map.insert("cur_prefix".to_string(), format!("{}", cur_prefix).into());
-        map.insert("next_prefix".to_string(), format!("{}", next_prefix).into());
+        map.insert("cur_prefix".to_string(), format!("{cur_prefix}").into());
+        map.insert("next_prefix".to_string(), format!("{next_prefix}").into());
         serialize_lt(&mut map, "create_lt", &msg.lt().unwrap_or_default(), mode);
     }
     serialize_intermidiate_address(&mut map, "cur_addr", env.cur_addr());
@@ -1269,7 +1269,7 @@ pub fn serialize_config(
         let num = num.get_next_u32()?;
         let mut cp = SliceData::load_cell(cp_ref.checked_drain_reference()?)?;
         if let Some(cp) = serialize_known_config_param(num, &mut cp.clone(), mode)? {
-            known_cp_map.insert(format!("p{}", num), cp);
+            known_cp_map.insert(format!("p{num}"), cp);
         } else {
             unknown_cp_vec.push(serialize_unknown_config_param(num, &mut cp)?);
         }
@@ -1408,7 +1408,7 @@ fn serialize_out_msg_queue_info(
         let value = IhrPendingSince::construct_from(value)?;
         let mut ihr_map = Map::new();
         ihr_map.insert("dest_addr_prefix".to_string(), shard_to_string(key.get_next_u64()?).into());
-        ihr_map.insert("msg_id".to_string(), format!("{:x}", key).into());
+        ihr_map.insert("msg_id".to_string(), format!("{key:x}").into());
         serialize_lt(&mut ihr_map, "import_lt", &value.import_lt(), mode);
         ihr_pending.push(ihr_map);
         Ok(true)
@@ -2028,7 +2028,7 @@ fn serialize_account_status(
     );
 
     if mode.is_q_server() {
-        let name = format!("{}_name", name);
+        let name = format!("{name}_name");
         serialize_field(
             map,
             &name,

--- a/tvm_block_json/src/tests/test_common.rs
+++ b/tvm_block_json/src/tests/test_common.rs
@@ -22,7 +22,7 @@ fn assert_json_eq(json: &str, expected: &str, name: &str) {
         expected
     };
     if json != expected {
-        std::fs::write(format!("target/{}.json", name), json).unwrap();
+        std::fs::write(format!("target/{name}.json"), json).unwrap();
         panic!("json != expected")
     }
 }

--- a/tvm_block_json/src/tests/test_deserialize.rs
+++ b/tvm_block_json/src/tests/test_deserialize.rs
@@ -495,7 +495,7 @@ fn test_config_params() {
 
     let check_params = |old: &ConfigParams, new: &ConfigParams| {
         for i in 0..45 {
-            println!("Iteration {}", i);
+            println!("Iteration {i}");
             if old.config_present(i).unwrap() {
                 let old_conf = old.config(i).unwrap().unwrap();
                 let new_conf = new.config(i).unwrap().unwrap();
@@ -523,7 +523,7 @@ fn test_parse_config_params() {
 
     for index in 0..45 {
         if let Ok(param) = serialize_config_param(&cp, index) {
-            println!("{}: {}", index, param);
+            println!("{index}: {param}");
             let config = serde_json::from_str(&param).unwrap();
             let cp_new = parse_config_with_mandatory_params(&config, &[index]).unwrap();
             assert_eq!(cp.config(index).unwrap(), cp_new.config(index).unwrap());

--- a/tvm_block_json/src/tests/test_parser.rs
+++ b/tvm_block_json/src/tests/test_parser.rs
@@ -71,7 +71,7 @@ fn parse_block(
     options: Option<ParseOptions>,
 ) -> (Vec<u8>, UInt256, ParsedBlock) {
     let in_path = Path::new("src/tests/data").join(file_rel_path);
-    let boc = read(in_path.clone()).unwrap_or_else(|_| panic!("Error reading file {:?}", in_path));
+    let boc = read(in_path.clone()).unwrap_or_else(|_| panic!("Error reading file {in_path:?}"));
     let cell = read_single_root_boc(&boc).expect("Error deserializing single root BOC");
 
     let block = Block::construct_from_cell(cell.clone()).unwrap();
@@ -270,7 +270,7 @@ fn check_msg_chain_order(
     src_chain_order: Option<&str>,
     dst_chain_order: Option<&str>,
 ) {
-    println!("{:?}", body);
+    println!("{body:?}");
     assert_eq!(body["id"], Value::from(id));
     if let Some(order) = src_chain_order {
         assert_eq!(body["src_chain_order"], Value::from(order));

--- a/tvm_block_json/src/tests/test_serialize.rs
+++ b/tvm_block_json/src/tests/test_serialize.rs
@@ -26,8 +26,7 @@ use super::*;
 include!("./test_common.rs");
 
 fn assert_json_eq_file(json: &str, name: &str) {
-    let expected =
-        std::fs::read_to_string(format!("src/tests/data/{name}-ethalon.json")).unwrap();
+    let expected = std::fs::read_to_string(format!("src/tests/data/{name}-ethalon.json")).unwrap();
     assert_json_eq(json, &expected, name);
 }
 

--- a/tvm_block_json/src/tests/test_serialize.rs
+++ b/tvm_block_json/src/tests/test_serialize.rs
@@ -27,7 +27,7 @@ include!("./test_common.rs");
 
 fn assert_json_eq_file(json: &str, name: &str) {
     let expected =
-        std::fs::read_to_string(format!("src/tests/data/{}-ethalon.json", name)).unwrap();
+        std::fs::read_to_string(format!("src/tests/data/{name}-ethalon.json")).unwrap();
     assert_json_eq(json, &expected, name);
 }
 
@@ -1030,9 +1030,9 @@ fn test_transaction_into_json_q() {
 }
 
 fn test_json_block(blockhash: &str, mode: SerializationMode) {
-    let filename = format!("{}.boc", blockhash);
+    let filename = format!("{blockhash}.boc");
     let in_path = Path::new("src/tests/data").join(filename);
-    let boc = read(in_path.clone()).unwrap_or_else(|_| panic!("Error reading file {:?}", in_path));
+    let boc = read(in_path.clone()).unwrap_or_else(|_| panic!("Error reading file {in_path:?}"));
     let cell = read_single_root_boc(&boc).expect("Error deserializing single root BOC");
 
     let block = Block::construct_from_cell(cell).unwrap();
@@ -1051,7 +1051,7 @@ fn test_get_config() {
     let filename =
         "src/tests/data/9C9906A80D020952E0192DC60C0B2BF1F55FE9A9E065606E8FE25C08BD1AA6B2.boc";
     let in_path = Path::new(filename);
-    let boc = read(in_path).unwrap_or_else(|_| panic!("Error reading file {:?}", filename));
+    let boc = read(in_path).unwrap_or_else(|_| panic!("Error reading file {filename:?}"));
     let cell = read_single_root_boc(boc).expect("Error deserializing single root BOC");
 
     let block = Block::construct_from_cell(cell).unwrap();
@@ -1185,7 +1185,7 @@ fn test_crafted_key_block_into_json() {
     let filename =
         "src/tests/data/48377CD82FF8091D6A45908727C8D4E5FC521603E5633AF3AC8C9E45F9579D5B.boc";
     let in_path = Path::new(filename);
-    let boc = read(in_path).unwrap_or_else(|_| panic!("Error reading file {:?}", filename));
+    let boc = read(in_path).unwrap_or_else(|_| panic!("Error reading file {filename:?}"));
     let cell = read_single_root_boc(&boc).expect("Error deserializing single root BOC");
     // println!("slice = {}", root_cell);
     let key = base64_decode("7w3fX5jiuo8PyQoFaEL+K9pE/XvbKjH63i0JcraLlBM=").unwrap();
@@ -1326,7 +1326,7 @@ fn test_db_serialize_block_signatures() {
     ))
     .unwrap();
 
-    println!("{}", doc);
+    println!("{doc}");
 
     assert_eq!(
         doc,
@@ -1405,8 +1405,8 @@ fn test_db_serialize_block_proof() {
 }
 
 fn prepare_shard_state_json(name: &str, workchain_id: i32, mode: SerializationMode) -> String {
-    let boc = read(format!("src/tests/data/states/{}", name))
-        .unwrap_or_else(|_| panic!("Error reading file {:?}", name));
+    let boc = read(format!("src/tests/data/states/{name}"))
+        .unwrap_or_else(|_| panic!("Error reading file {name:?}"));
     let cell = read_single_root_boc(&boc).expect("Error deserializing single root BOC");
     let id = format!("state:{:x}", cell.repr_hash());
 
@@ -1427,7 +1427,7 @@ fn check_shard_state(name: &str, workchain_id: i32, mode: SerializationMode) {
     };
     // std::fs::write(file_name.clone() + postfix + "-ethalon.json",
     // &json).unwrap();
-    let name = format!("states/{}{}", name, postfix);
+    let name = format!("states/{name}{postfix}");
     assert_json_eq_file(&json, &name);
 }
 
@@ -1613,7 +1613,7 @@ fn se_deserialise_remp_status(status: RempMessageStatus) {
     let signature = vec![1, 2, 3, 4];
 
     let json = serde_json::json!(db_serialize_remp_status(&rr, &signature).unwrap()).to_string();
-    println!("{}", json);
+    println!("{json}");
 
     let map = serde_json::from_str::<Map<String, Value>>(&json).unwrap();
     let (rr1, signature1) = crate::deserialize::parse_remp_status(&map).unwrap();

--- a/tvm_cli/build.rs
+++ b/tvm_cli/build.rs
@@ -28,8 +28,8 @@ fn main() {
         build_time = String::from_utf8(b_time.stdout).unwrap_or_else(|_| "Unknown".to_string());
     }
 
-    println!("cargo:rustc-env=BUILD_GIT_BRANCH={}", git_branch);
-    println!("cargo:rustc-env=BUILD_GIT_COMMIT={}", git_commit);
-    println!("cargo:rustc-env=BUILD_GIT_DATE={}", commit_date);
-    println!("cargo:rustc-env=BUILD_TIME={}", build_time);
+    println!("cargo:rustc-env=BUILD_GIT_BRANCH={git_branch}");
+    println!("cargo:rustc-env=BUILD_GIT_COMMIT={git_commit}");
+    println!("cargo:rustc-env=BUILD_GIT_DATE={commit_date}");
+    println!("cargo:rustc-env=BUILD_TIME={build_time}");
 }

--- a/tvm_cli/src/account.rs
+++ b/tvm_cli/src/account.rs
@@ -93,9 +93,8 @@ pub async fn get_account(
     if is_boc {
         let mut accounts = vec![];
         for path in addresses {
-            let account = Account::construct_from_file(&path).map_err(|e| {
-                format!(" failed to load account from the boc file {path}: {e}")
-            })?;
+            let account = Account::construct_from_file(&path)
+                .map_err(|e| format!(" failed to load account from the boc file {path}: {e}"))?;
             accounts.push(account);
         }
         if !config.is_json {

--- a/tvm_cli/src/account.rs
+++ b/tvm_cli/src/account.rs
@@ -77,7 +77,7 @@ async fn query_accounts(
             },
         )
         .await
-        .map_err(|e| format!("failed to query account info: {}", e))?;
+        .map_err(|e| format!("failed to query account info: {e}"))?;
         res.append(query_result.result.as_mut());
     }
     Ok(res)
@@ -94,7 +94,7 @@ pub async fn get_account(
         let mut accounts = vec![];
         for path in addresses {
             let account = Account::construct_from_file(&path).map_err(|e| {
-                format!(" failed to load account from the boc file {}: {}", path, e)
+                format!(" failed to load account from the boc file {path}: {e}")
             })?;
             accounts.push(account);
         }
@@ -145,7 +145,7 @@ pub async fn get_account(
                     let bal = bal.unwrap().grams.clone().to_string();
                     if config.balance_in_vmshells {
                         let bal = u64::from_str_radix(&bal, 10)
-                            .map_err(|e| format!("failed to decode balance: {}", e))?;
+                            .map_err(|e| format!("failed to decode balance: {e}"))?;
                         let int_bal = bal as f64 / 1e9;
                         let frac_balance = (bal as f64 / 1e6 + 0.5) as u64 % 1000;
                         let balance_str = format!("{}", int_bal as u64);
@@ -172,14 +172,14 @@ pub async fn get_account(
                 let last_paid = format!("{}", acc.last_paid());
 
                 let trans_lt =
-                    acc.last_tr_time().map_or("Undefined".to_owned(), |v| format!("{:#x}", v));
+                    acc.last_tr_time().map_or("Undefined".to_owned(), |v| format!("{v:#x}"));
 
                 let data = tree_of_cells_into_base64(acc.get_data().as_ref());
 
                 let data_boc = if data.is_ok() {
                     hex::encode(
                         base64_decode(&data.unwrap())
-                            .map_err(|e| format!("Failed to decode base64: {}", e))?,
+                            .map_err(|e| format!("Failed to decode base64: {e}"))?,
                     )
                 } else {
                     "null".to_owned()
@@ -235,7 +235,7 @@ pub async fn get_account(
                     json_res["dapp_id"] = json!(dapp_id);
                     json_res["ecc_balance"] = ecc_balance;
                 } else {
-                    println!("dapp_id:       {}", dapp_id);
+                    println!("dapp_id:       {dapp_id}");
                     println!("ecc:           {}", serde_json::to_string(&ecc_balance).unwrap());
                 }
             } else if config.is_json {
@@ -274,13 +274,13 @@ pub async fn get_account(
                        "acc_type": "NonExist"
                     });
                 } else {
-                    println!("{} not found", address);
+                    println!("{address} not found");
                     println!();
                 }
             }
         }
         if config.is_json {
-            println!("{:#}", json_res);
+            println!("{json_res:#}");
         }
     } else if config.is_json {
         println!("{{\n}}");
@@ -328,14 +328,14 @@ pub async fn calc_storage(config: &Config, addr: &str, period: u32) -> Result<()
         ParamsOfCalcStorageFee { account: boc, period, ..Default::default() },
     )
     .await
-    .map_err(|e| format!("failed to calculate storage fee: {}", e))?;
+    .map_err(|e| format!("failed to calculate storage fee: {e}"))?;
 
     if !config.is_json {
         println!("Storage fee per {} seconds: {} nanovmshells", period, res.fee);
     } else {
         println!("{{");
         println!("  \"storage_fee\": \"{}\",", res.fee);
-        println!("  \"period\": \"{}\"", period);
+        println!("  \"period\": \"{period}\"");
         println!("}}");
     }
     Ok(())
@@ -366,18 +366,18 @@ pub async fn dump_accounts(
         let boc =
             account["boc"].as_str().ok_or("Failed to parse boc in the query result".to_owned())?;
         Account::construct_from_base64(boc)
-            .map_err(|e| format!("Failed to load account from the boc: {}", e))?
+            .map_err(|e| format!("Failed to load account from the boc: {e}"))?
             .write_to_file(path.clone())
             .map_err(|e| format!("Failed to write data to the file {}: {}", path.clone(), e))?;
         if !config.is_json {
-            println!("{} successfully dumped.", path);
+            println!("{path} successfully dumped.");
         }
     }
 
     if !config.is_json {
         if !addresses.is_empty() {
             for address in addresses.iter() {
-                println!("{} was not found.", address);
+                println!("{address} was not found.");
             }
         }
         println!("Succeeded.");
@@ -414,7 +414,7 @@ pub async fn wait_for_change(
         },
     )
     .await
-    .map_err(|e| format!("Failed to query the account: {}", e))?;
+    .map_err(|e| format!("Failed to query the account: {e}"))?;
 
     let last_trans_lt = extract_last_trans_lt(&query.result[0])
         .ok_or_else(|| format!("Failed to parse query result: {}", query.result[0]))?;
@@ -434,7 +434,7 @@ pub async fn wait_for_change(
                         Err(format!("Can't parse the result: {}", res.result))
                     }
                 }
-                Err(e) => Err(format!("Client error: {}", e)),
+                Err(e) => Err(format!("Client error: {e}")),
             };
             s.send(res).await.unwrap()
         }
@@ -458,7 +458,7 @@ pub async fn wait_for_change(
         callback,
     )
     .await
-    .map_err(|e| format!("Failed to subscribe: {}", e))?;
+    .map_err(|e| format!("Failed to subscribe: {e}"))?;
 
     tokio::spawn(async move {
         tokio::time::sleep(std::time::Duration::from_secs(wait_secs)).await;
@@ -468,7 +468,7 @@ pub async fn wait_for_change(
     let res = r.recv().await.ok_or_else(|| "Sender has dropped".to_owned())?;
     tvm_client::net::unsubscribe(context.clone(), subscription)
         .await
-        .map_err(|e| format!("Failed to unsubscribe: {}", e))?;
+        .map_err(|e| format!("Failed to unsubscribe: {e}"))?;
 
     if !config.is_json {
         if res.is_ok() {

--- a/tvm_cli/src/call.rs
+++ b/tvm_cli/src/call.rs
@@ -53,7 +53,7 @@ async fn decode_call_parameters(
         ton,
         ParamsOfDecodeMessage { abi, message: msg.message.clone(), ..Default::default() },
     )
-    .map_err(|e| format!("couldn't decode message: {}", e))?;
+    .map_err(|e| format!("couldn't decode message: {e}"))?;
 
     Ok((result.name, format!("{:#}", result.value.unwrap_or(json!({})))))
 }
@@ -112,7 +112,7 @@ async fn build_json_from_params(
         params_json[input.name.clone()] = value;
     }
 
-    serde_json::to_string(&params_json).map_err(|e| format!("{}", e))
+    serde_json::to_string(&params_json).map_err(|e| format!("{e}"))
 }
 
 pub async fn emulate_locally(
@@ -126,12 +126,12 @@ pub async fn emulate_locally(
     if state_boc.is_err() {
         if is_fee {
             let addr = tvm_block::MsgAddressInt::from_str(addr)
-                .map_err(|e| format!("couldn't decode address: {}", e))?;
+                .map_err(|e| format!("couldn't decode address: {e}"))?;
             state = base64_encode(
                 &tvm_types::write_boc(&Account::with_address(addr).serialize().map_err(|e| {
-                    format!("couldn't create dummy account for deploy emulation: {}", e)
+                    format!("couldn't create dummy account for deploy emulation: {e}")
                 })?)
-                .map_err(|e| format!("failed to serialize account cell: {}", e))?,
+                .map_err(|e| format!("failed to serialize account cell: {e}"))?,
             );
         } else {
             return Err(state_boc.err().unwrap());
@@ -189,7 +189,7 @@ pub async fn send_message_and_wait(
         callback,
     )
     .await
-    .map_err(|e| format!("{:#}", e))?;
+    .map_err(|e| format!("{e:#}"))?;
 
     let value = serde_json::to_value(result).map_err(|e| format!("{e:#}"))?;
     Ok(value)
@@ -218,7 +218,7 @@ pub async fn send_message(
         callback,
     )
     .await
-    .map_err(|e| format!("{:#}", e))?;
+    .map_err(|e| format!("{e:#}"))?;
 
     serde_json::to_value(result).map_err(|e| format!("{e:#}"))
 }
@@ -236,7 +236,7 @@ pub async fn process_message(
             message: _,
         } = event
         {
-            println!("MessageId: {}", message_id)
+            println!("MessageId: {message_id}")
         }
     };
     let res = if !config.is_json {
@@ -269,7 +269,7 @@ pub async fn call_contract_with_result(
     thread_id: Option<&str>,
 ) -> Result<Value, String> {
     let tvm_client = if config.debug_fail != *"None" {
-        init_debug_logger(&format!("call_{}_{}.log", addr, method))?;
+        init_debug_logger(&format!("call_{addr}_{method}.log"))?;
         create_client(config)?
     } else {
         create_client_verbose(config)?
@@ -297,7 +297,7 @@ pub async fn call_contract_with_client(
 
     let encoded_message = encode_message(tvm_client.clone(), msg_params.clone())
         .await
-        .map_err(|e| format!("failed to create inbound message: {}", e))?;
+        .map_err(|e| format!("failed to create inbound message: {e}"))?;
 
     if !config.is_json {
         println!("MessageId: {}", encoded_message.message_id);
@@ -317,9 +317,9 @@ pub async fn call_contract_with_client(
 pub fn print_json_result(result: Value, config: &Config) -> Result<(), String> {
     if !result.is_null() {
         if !config.is_json {
-            println!("Result: {:#}", result);
+            println!("Result: {result:#}");
         } else {
-            println!("{:#}", result);
+            println!("{result:#}");
         }
     }
     Ok(())
@@ -375,7 +375,7 @@ pub async fn call_contract_with_msg(
     if !config.is_json {
         println!("Succeeded.");
         if !result.is_null() {
-            println!("Result: {:#}", result);
+            println!("Result: {result:#}");
         }
     }
     Ok(())

--- a/tvm_cli/src/completion.rs
+++ b/tvm_cli/src/completion.rs
@@ -119,7 +119,7 @@ fn main() {
     if prev_word == "--addr" {
         if word_being_completed.is_empty() {
             for alias in aliases.keys() {
-                println!("{}", alias);
+                println!("{alias}");
             }
         } else {
             for alias in aliases {

--- a/tvm_cli/src/config.rs
+++ b/tvm_cli/src/config.rs
@@ -300,7 +300,7 @@ impl FullConfig {
         let conf_str = serde_json::to_string_pretty(self)
             .map_err(|_| "failed to serialize config object".to_string())?;
         std::fs::write(path, conf_str)
-            .map_err(|e| format!("failed to write config file {}: {}", path, e))?;
+            .map_err(|e| format!("failed to write config file {path}: {e}"))?;
         Ok(())
     }
 
@@ -498,31 +498,31 @@ pub fn set_config(
     }
     if let Some(retries) = matches.value_of("RETRIES") {
         config.retries = u8::from_str_radix(retries, 10)
-            .map_err(|e| format!(r#"failed to parse "retries": {}"#, e))?;
+            .map_err(|e| format!(r#"failed to parse "retries": {e}"#))?;
     }
     if let Some(lifetime) = matches.value_of("LIFETIME") {
         config.lifetime = u32::from_str_radix(lifetime, 10)
-            .map_err(|e| format!(r#"failed to parse "lifetime": {}"#, e))?;
+            .map_err(|e| format!(r#"failed to parse "lifetime": {e}"#))?;
         if config.lifetime < 2 * config.out_of_sync_threshold {
             config.out_of_sync_threshold = config.lifetime >> 1;
         }
     }
     if let Some(timeout) = matches.value_of("TIMEOUT") {
         config.timeout = u32::from_str_radix(timeout, 10)
-            .map_err(|e| format!(r#"failed to parse "timeout": {}"#, e))?;
+            .map_err(|e| format!(r#"failed to parse "timeout": {e}"#))?;
     }
     if let Some(message_processing_timeout) = matches.value_of("MSG_TIMEOUT") {
         config.message_processing_timeout = u32::from_str_radix(message_processing_timeout, 10)
-            .map_err(|e| format!(r#"failed to parse "message_processing_timeout": {}"#, e))?;
+            .map_err(|e| format!(r#"failed to parse "message_processing_timeout": {e}"#))?;
     }
     if let Some(wc) = matches.value_of("WC") {
         config.wc = i32::from_str_radix(wc, 10)
-            .map_err(|e| format!(r#"failed to parse "workchain id": {}"#, e))?;
+            .map_err(|e| format!(r#"failed to parse "workchain id": {e}"#))?;
     }
     if let Some(depool_fee) = matches.value_of("DEPOOL_FEE") {
         config.depool_fee = depool_fee
             .parse::<f32>()
-            .map_err(|e| format!(r#"failed to parse "depool_fee": {}"#, e))?;
+            .map_err(|e| format!(r#"failed to parse "depool_fee": {e}"#))?;
         if config.depool_fee < 0.5 {
             return Err("Minimal value for depool fee is 0.5".to_string());
         }
@@ -530,26 +530,26 @@ pub fn set_config(
     if let Some(no_answer) = matches.value_of("NO_ANSWER") {
         config.no_answer = no_answer
             .parse::<bool>()
-            .map_err(|e| format!(r#"failed to parse "no_answer": {}"#, e))?;
+            .map_err(|e| format!(r#"failed to parse "no_answer": {e}"#))?;
     }
     if let Some(balance_in_vmshells) = matches.value_of("BALANCE_IN_VMSHELLS") {
         config.balance_in_vmshells = balance_in_vmshells
             .parse::<bool>()
-            .map_err(|e| format!(r#"failed to parse "balance_in_vmshells": {}"#, e))?;
+            .map_err(|e| format!(r#"failed to parse "balance_in_vmshells": {e}"#))?;
     }
     if let Some(local_run) = matches.value_of("LOCAL_RUN") {
         config.local_run = local_run
             .parse::<bool>()
-            .map_err(|e| format!(r#"failed to parse "local_run": {}"#, e))?;
+            .map_err(|e| format!(r#"failed to parse "local_run": {e}"#))?;
     }
     if let Some(async_call) = matches.value_of("ASYNC_CALL") {
         config.async_call = async_call
             .parse::<bool>()
-            .map_err(|e| format!(r#"failed to parse "async_call": {}"#, e))?;
+            .map_err(|e| format!(r#"failed to parse "async_call": {e}"#))?;
     }
     if let Some(out_of_sync_threshold) = matches.value_of("OUT_OF_SYNC") {
         let time = u32::from_str_radix(out_of_sync_threshold, 10)
-            .map_err(|e| format!(r#"failed to parse "out_of_sync_threshold": {}"#, e))?;
+            .map_err(|e| format!(r#"failed to parse "out_of_sync_threshold": {e}"#))?;
         if time * 2 > config.lifetime {
             return Err("\"out_of_sync\" should not exceed 0.5 * \"lifetime\".".to_string());
         }
@@ -569,7 +569,7 @@ pub fn set_config(
     }
     if let Some(is_json) = matches.value_of("IS_JSON") {
         config.is_json =
-            is_json.parse::<bool>().map_err(|e| format!(r#"failed to parse "is_json": {}"#, e))?;
+            is_json.parse::<bool>().map_err(|e| format!(r#"failed to parse "is_json": {e}"#))?;
     }
     if let Some(s) = matches.value_of("PROJECT_ID") {
         config.project_id = Some(s.to_string());

--- a/tvm_cli/src/convert.rs
+++ b/tvm_cli/src/convert.rs
@@ -30,7 +30,7 @@ pub fn convert_amount(amount: &str, decimals: usize) -> Result<String, String> {
             result += &"0".repeat(decimals);
         }
         let result = result.trim_start_matches('0').to_string();
-        u64::from_str_radix(&result, 10).map_err(|e| format!("failed to parse amount: {}", e))?;
+        u64::from_str_radix(&result, 10).map_err(|e| format!("failed to parse amount: {e}"))?;
 
         return Ok(result);
     }
@@ -40,7 +40,7 @@ pub fn convert_amount(amount: &str, decimals: usize) -> Result<String, String> {
 pub fn convert_u64_to_tokens(value: u64) -> String {
     let integer = value / 1_000_000_000;
     let float = value - integer * 1_000_000_000;
-    format!("{}.{:>09}", integer, float)
+    format!("{integer}.{float:>09}")
 }
 
 pub fn nodeid_from_pubkey(key: &[u8]) -> Result<String, String> {

--- a/tvm_cli/src/crypto.rs
+++ b/tvm_cli/src/crypto.rs
@@ -47,7 +47,7 @@ pub fn gen_seed_phrase() -> Result<String, String> {
             ..Default::default()
         },
     )
-    .map_err(|e| format!("{}", e))
+    .map_err(|e| format!("{e}"))
     .map(|r| r.phrase)
 }
 
@@ -62,7 +62,7 @@ pub fn generate_keypair_from_mnemonic(mnemonic: &str) -> Result<KeyPair, String>
             ..Default::default()
         },
     )
-    .map_err(|e| format!("{}", e))?;
+    .map_err(|e| format!("{e}"))?;
 
     let hdk_root = hdkey_derive_from_xprv_path(
         client.clone(),
@@ -72,23 +72,23 @@ pub fn generate_keypair_from_mnemonic(mnemonic: &str) -> Result<KeyPair, String>
             ..Default::default()
         },
     )
-    .map_err(|e| format!("{}", e))?;
+    .map_err(|e| format!("{e}"))?;
 
     let secret = hdkey_secret_from_xprv(
         client.clone(),
         ParamsOfHDKeySecretFromXPrv { xprv: hdk_root.xprv.clone(), ..Default::default() },
     )
-    .map_err(|e| format!("{}", e))?;
+    .map_err(|e| format!("{e}"))?;
 
     let mut keypair: KeyPair = nacl_sign_keypair_from_secret_key(
         client,
         ParamsOfNaclSignKeyPairFromSecret { secret: secret.secret.clone(), ..Default::default() },
     )
-    .map_err(|e| format!("failed to get KeyPair from secret key: {}", e))?;
+    .map_err(|e| format!("failed to get KeyPair from secret key: {e}"))?;
 
     // special case if secret contains public key too.
     let secret =
-        hex::decode(&keypair.secret).map_err(|e| format!("failed to decode the keypair: {}", e))?;
+        hex::decode(&keypair.secret).map_err(|e| format!("failed to decode the keypair: {e}"))?;
     if secret.len() > 32 {
         keypair.secret = hex::encode(&secret[..32]);
     }
@@ -101,10 +101,10 @@ pub fn generate_keypair_from_secret(secret: String) -> Result<KeyPair, String> {
         client,
         ParamsOfNaclSignKeyPairFromSecret { secret, ..Default::default() },
     )
-    .map_err(|e| format!("failed to get KeyPair from secret key: {}", e))?;
+    .map_err(|e| format!("failed to get KeyPair from secret key: {e}"))?;
     // special case if secret contains public key too.
     let secret =
-        hex::decode(&keypair.secret).map_err(|e| format!("failed to decode the keypair: {}", e))?;
+        hex::decode(&keypair.secret).map_err(|e| format!("failed to decode the keypair: {e}"))?;
     if secret.len() > 32 {
         keypair.secret = hex::encode(&secret[..32]);
     }
@@ -115,16 +115,16 @@ pub fn generate_mnemonic(keypath: Option<&str>, config: &Config) -> Result<(), S
     let mnemonic = gen_seed_phrase()?;
     if !config.is_json {
         println!("Succeeded.");
-        println!(r#"Seed phrase: "{}""#, mnemonic);
+        println!(r#"Seed phrase: "{mnemonic}""#);
     } else {
         println!("{{");
-        println!("  \"phrase\": \"{}\"", mnemonic);
+        println!("  \"phrase\": \"{mnemonic}\"");
         println!("}}");
     }
     if let Some(path) = keypath {
         generate_keypair(Some(path), Some(&mnemonic), config)?;
         if !config.is_json {
-            println!("Keypair saved to {}", path);
+            println!("Keypair saved to {path}");
         }
     }
     Ok(())
@@ -137,7 +137,7 @@ pub fn extract_pubkey(mnemonic: &str, is_json: bool) -> Result<(), String> {
         println!("Public key: {}", keypair.public);
         println!();
         qr2term::print_qr(&keypair.public)
-            .map_err(|e| format!("failed to print the QR code: {}", e))?;
+            .map_err(|e| format!("failed to print the QR code: {e}"))?;
         println!();
     } else {
         println!("{{");
@@ -160,7 +160,7 @@ pub fn generate_keypair(
             }
             let phrase = gen_seed_phrase()?;
             if !config.is_json {
-                println!(r#"Seed phrase: "{}""#, phrase);
+                println!(r#"Seed phrase: "{phrase}""#);
             }
             phrase
         }
@@ -172,20 +172,20 @@ pub fn generate_keypair(
         generate_keypair_from_secret(mnemonic)?
     };
     let keys_json = serde_json::to_string_pretty(&keys)
-        .map_err(|e| format!("failed to serialize the keypair: {}", e))?;
+        .map_err(|e| format!("failed to serialize the keypair: {e}"))?;
     if let Some(keys_path) = keys_path {
         let folder_path = keys_path.trim_end_matches(|c| c != '/').trim_end_matches('/');
         check_dir(folder_path)?;
         std::fs::write(keys_path, &keys_json)
-            .map_err(|e| format!("failed to create file with keys: {}", e))?;
+            .map_err(|e| format!("failed to create file with keys: {e}"))?;
         if !config.is_json {
-            println!("Keypair successfully saved to {}.", keys_path);
+            println!("Keypair successfully saved to {keys_path}.");
         }
     } else {
         if !config.is_json {
             print!("Keypair: ");
         }
-        println!("{}", keys_json);
+        println!("{keys_json}");
     }
     if !config.is_json {
         println!("Succeeded.");

--- a/tvm_cli/src/debot/callbacks.rs
+++ b/tvm_cli/src/debot/callbacks.rs
@@ -99,7 +99,7 @@ impl BrowserCallbacks for Callbacks {
 
     /// Debot is switched to another context.
     async fn switch(&self, ctx_id: u8) {
-        log::debug!("switched to ctx {}", ctx_id);
+        log::debug!("switched to ctx {ctx_id}");
         let mut state = self.state.write().unwrap();
         state.state_id = ctx_id;
         if ctx_id == STATE_EXIT {
@@ -133,7 +133,7 @@ impl BrowserCallbacks for Callbacks {
             Err(ProcessorError::InterfaceCallNeeded) => {
                 TerminalSigningBox::new::<&[u8]>(self.client.clone(), vec![], None).await?.leak().0
             }
-            Err(e) => return Err(format!("{:?}", e)),
+            Err(e) => return Err(format!("{e:?}")),
             Ok(handle) => handle,
         };
         Ok(SigningBoxHandle(handle))
@@ -168,7 +168,7 @@ impl BrowserCallbacks for Callbacks {
             } => {
                 info += "DeBot is going to create an onchain transaction.\n";
                 info += "Details:\n";
-                info += &format!("  account: {}\n", dst);
+                info += &format!("  account: {dst}\n");
                 info += &format!("  Transaction fees: {} tokens\n", convert_u64_to_tokens(fee));
                 if !out.is_empty() {
                     info += "  Outgoing transfers from the account:\n";
@@ -182,7 +182,7 @@ impl BrowserCallbacks for Callbacks {
                 } else {
                     info += "  No outgoing transfers from the account.\n";
                 }
-                info += &format!("  Message signer public key: {}\n", signkey);
+                info += &format!("  Message signer public key: {signkey}\n");
                 if setcode {
                     info += "  Warning: the transaction will change the account's code\n";
                 }

--- a/tvm_cli/src/debot/interfaces/address_input.rs
+++ b/tvm_cli/src/debot/interfaces/address_input.rs
@@ -63,7 +63,7 @@ impl AddressInput {
         let prompt = decode_prompt(args)?;
         let value = terminal_input(&prompt, |val| {
             let _ = load_ton_address(val, &self.config)
-                .map_err(|e| format!("Invalid address: {}", e))?;
+                .map_err(|e| format!("Invalid address: {e}"))?;
             Ok(())
         });
         Ok((answer_id, json!({ "value": value })))
@@ -73,7 +73,7 @@ impl AddressInput {
         let answer_id = decode_answer_id(args)?;
         let value = terminal_input("", |val| {
             let _ = load_ton_address(val, &self.config)
-                .map_err(|e| format!("Invalid address: {}", e))?;
+                .map_err(|e| format!("Invalid address: {e}"))?;
             Ok(())
         });
         Ok((answer_id, json!({ "value": value })))
@@ -94,7 +94,7 @@ impl DebotInterface for AddressInput {
         match func {
             "get" => self.get(args),
             "select" => self.select(args),
-            _ => Err(format!("function \"{}\" is not implemented", func)),
+            _ => Err(format!("function \"{func}\" is not implemented")),
         }
     }
 }

--- a/tvm_cli/src/debot/interfaces/address_input.rs
+++ b/tvm_cli/src/debot/interfaces/address_input.rs
@@ -62,8 +62,8 @@ impl AddressInput {
         let answer_id = decode_answer_id(args)?;
         let prompt = decode_prompt(args)?;
         let value = terminal_input(&prompt, |val| {
-            let _ = load_ton_address(val, &self.config)
-                .map_err(|e| format!("Invalid address: {e}"))?;
+            let _ =
+                load_ton_address(val, &self.config).map_err(|e| format!("Invalid address: {e}"))?;
             Ok(())
         });
         Ok((answer_id, json!({ "value": value })))
@@ -72,8 +72,8 @@ impl AddressInput {
     fn select(&self, args: &Value) -> InterfaceResult {
         let answer_id = decode_answer_id(args)?;
         let value = terminal_input("", |val| {
-            let _ = load_ton_address(val, &self.config)
-                .map_err(|e| format!("Invalid address: {e}"))?;
+            let _ =
+                load_ton_address(val, &self.config).map_err(|e| format!("Invalid address: {e}"))?;
             Ok(())
         });
         Ok((answer_id, json!({ "value": value })))

--- a/tvm_cli/src/debot/interfaces/amount_input.rs
+++ b/tvm_cli/src/debot/interfaces/amount_input.rs
@@ -66,7 +66,7 @@ impl AmountInput {
         let prompt = decode_prompt(args)?;
         let decimals = decode_num_arg::<usize>(args, "decimals")?;
         if decimals > 255 {
-            return Err(format!("too many decimals ({})", decimals));
+            return Err(format!("too many decimals ({decimals})"));
         }
         let min = decode_num_arg::<u128>(args, "min")?;
         let max = decode_num_arg::<u128>(args, "max")?;
@@ -81,7 +81,7 @@ impl AmountInput {
         let _ = terminal_input(&prompt, |val| {
             value = convert::convert_amount(val.as_str(), decimals)?;
             let number = decode_abi_number::<u128>(&value)
-                .map_err(|e| format!("input is not a valid amount: {}", e))?;
+                .map_err(|e| format!("input is not a valid amount: {e}"))?;
             if number < min || number > max {
                 return Err("amount is out of range".to_string());
             }
@@ -104,17 +104,17 @@ impl DebotInterface for AmountInput {
     async fn call(&self, func: &str, args: &Value) -> InterfaceResult {
         match func {
             "get" => self.get(args),
-            _ => Err(format!("function \"{}\" is not implemented", func)),
+            _ => Err(format!("function \"{func}\" is not implemented")),
         }
     }
 }
 
 fn format_amount(amount: u128, decimals: usize) -> String {
     if decimals == 0 {
-        format!("{}", amount)
+        format!("{amount}")
     } else {
         let integer = amount / 10u128.pow(decimals as u32);
         let float = amount - integer * 10u128.pow(decimals as u32);
-        format!("{}.{:0>width$}", integer, float, width = decimals)
+        format!("{integer}.{float:0>decimals$}")
     }
 }

--- a/tvm_cli/src/debot/interfaces/confirm_input.rs
+++ b/tvm_cli/src/debot/interfaces/confirm_input.rs
@@ -59,7 +59,7 @@ impl ConfirmInput {
         let answer_id = decode_answer_id(args)?;
         let prompt = decode_prompt(args)?;
         let mut yes_no = false;
-        let _ = terminal_input(&format!("{} (y/n)", prompt), |val| {
+        let _ = terminal_input(&format!("{prompt} (y/n)"), |val| {
             yes_no = match val.as_str() {
                 "y" => true,
                 "n" => false,
@@ -84,7 +84,7 @@ impl DebotInterface for ConfirmInput {
     async fn call(&self, func: &str, args: &Value) -> InterfaceResult {
         match func {
             "get" => self.get(args),
-            _ => Err(format!("function \"{}\" is not implemented", func)),
+            _ => Err(format!("function \"{func}\" is not implemented")),
         }
     }
 }

--- a/tvm_cli/src/debot/interfaces/dinterface.rs
+++ b/tvm_cli/src/debot/interfaces/dinterface.rs
@@ -152,8 +152,7 @@ where
 
 pub fn decode_int256(args: &Value, name: &str) -> Result<BigInt, String> {
     let num_str = decode_arg(args, name)?;
-    decode_abi_bigint(&num_str)
-        .map_err(|e| format!("failed to decode integer \"{num_str}\": {e}"))
+    decode_abi_bigint(&num_str).map_err(|e| format!("failed to decode integer \"{num_str}\": {e}"))
 }
 
 pub fn decode_array<F, T>(args: &Value, name: &str, validator: F) -> Result<Vec<T>, String>

--- a/tvm_cli/src/debot/interfaces/dinterface.rs
+++ b/tvm_cli/src/debot/interfaces/dinterface.rs
@@ -118,15 +118,15 @@ pub fn decode_answer_id(args: &Value) -> Result<u32, String> {
         args["answerId"].as_str().ok_or("answer id not found in argument list".to_string())?,
         10,
     )
-    .map_err(|e| format!("{}", e))
+    .map_err(|e| format!("{e}"))
 }
 
 pub fn decode_arg(args: &Value, name: &str) -> Result<String, String> {
-    args[name].as_str().ok_or(format!("\"{}\" not found", name)).map(|x| x.to_string())
+    args[name].as_str().ok_or(format!("\"{name}\" not found")).map(|x| x.to_string())
 }
 
 pub fn decode_bool_arg(args: &Value, name: &str) -> Result<bool, String> {
-    args[name].as_bool().ok_or(format!("\"{}\" not found", name))
+    args[name].as_bool().ok_or(format!("\"{name}\" not found"))
 }
 
 pub fn decode_string_arg(args: &Value, name: &str) -> Result<String, String> {
@@ -147,20 +147,20 @@ where
 {
     let num_str = decode_arg(args, name)?;
     decode_abi_number::<T>(&num_str)
-        .map_err(|e| format!("failed to parse integer \"{}\": {}", num_str, e))
+        .map_err(|e| format!("failed to parse integer \"{num_str}\": {e}"))
 }
 
 pub fn decode_int256(args: &Value, name: &str) -> Result<BigInt, String> {
     let num_str = decode_arg(args, name)?;
     decode_abi_bigint(&num_str)
-        .map_err(|e| format!("failed to decode integer \"{}\": {}", num_str, e))
+        .map_err(|e| format!("failed to decode integer \"{num_str}\": {e}"))
 }
 
 pub fn decode_array<F, T>(args: &Value, name: &str, validator: F) -> Result<Vec<T>, String>
 where
     F: Fn(&Value) -> Option<T>,
 {
-    let array = args[name].as_array().ok_or(format!("\"{}\" is invalid: must be array", name))?;
+    let array = args[name].as_array().ok_or(format!("\"{name}\" is invalid: must be array"))?;
     let mut strings = vec![];
     for elem in array {
         strings.push(validator(elem).ok_or("invalid array element type".to_string())?);

--- a/tvm_cli/src/debot/interfaces/echo.rs
+++ b/tvm_cli/src/debot/interfaces/echo.rs
@@ -63,7 +63,7 @@ impl DebotInterface for Echo {
     async fn call(&self, func: &str, args: &Value) -> InterfaceResult {
         match func {
             "echo" => self.echo(args),
-            _ => Err(format!("function \"{}\" is not implemented", func)),
+            _ => Err(format!("function \"{func}\" is not implemented")),
         }
     }
 }

--- a/tvm_cli/src/debot/interfaces/encryption_box_input.rs
+++ b/tvm_cli/src/debot/interfaces/encryption_box_input.rs
@@ -118,7 +118,7 @@ impl EncryptionBoxInput {
         let prompt = decode_prompt(args)?;
         let nonce = decode_nonce(args)?;
         let their_pubkey = decode_arg(args, "theirPubkey")?;
-        println!("{}", prompt);
+        println!("{prompt}");
         let result = TerminalEncryptionBox::new(ParamsOfTerminalEncryptionBox {
             context: self.client.clone(),
             box_type: EncryptionBoxType::NaCl,
@@ -133,7 +133,7 @@ impl EncryptionBoxInput {
         let answer_id = decode_answer_id(args)?;
         let prompt = decode_prompt(args)?;
         let nonce = decode_nonce(args)?;
-        println!("{}", prompt);
+        println!("{prompt}");
         let result = TerminalEncryptionBox::new(ParamsOfTerminalEncryptionBox {
             context: self.client.clone(),
             box_type: EncryptionBoxType::SecretNaCl,
@@ -148,7 +148,7 @@ impl EncryptionBoxInput {
         let answer_id = decode_answer_id(args)?;
         let nonce = decode_nonce(args)?;
         let prompt = decode_prompt(args)?;
-        println!("{}", prompt);
+        println!("{prompt}");
         let result = TerminalEncryptionBox::new(ParamsOfTerminalEncryptionBox {
             context: self.client.clone(),
             box_type: EncryptionBoxType::ChaCha20,
@@ -216,7 +216,7 @@ impl DebotInterface for EncryptionBoxInput {
             "getChaCha20Box" => self.get_chacha20_box(args).await,
             "remove" => self.remove_handle(args).await,
             "getSupportedAlgorithms" => self.get_supported_algorithms(args).await,
-            _ => Err(format!("function \"{}\" is not implemented", func)),
+            _ => Err(format!("function \"{func}\" is not implemented")),
         }
     }
 }

--- a/tvm_cli/src/debot/interfaces/input_interface.rs
+++ b/tvm_cli/src/debot/interfaces/input_interface.rs
@@ -50,7 +50,7 @@ impl DebotInterface for InputInterface {
                 let res = self.inner_interface.call(func, args).await?;
                 Ok(res)
             }
-            Err(e) => return Err(format!("{:?}", e)),
+            Err(e) => return Err(format!("{e:?}")),
             Ok(params) => {
                 let prompt = decode_prompt(args);
                 let title = decode_string_arg(args, "title");

--- a/tvm_cli/src/debot/interfaces/menu.rs
+++ b/tvm_cli/src/debot/interfaces/menu.rs
@@ -80,10 +80,10 @@ impl Menu {
         let title = decode_string_arg(args, "title")?;
         let description = decode_string_arg(args, "description")?;
         if !title.is_empty() {
-            println!("{}", title);
+            println!("{title}");
         }
         if !description.is_empty() {
-            println!("{}", description);
+            println!("{description}");
         }
         for (i, menu) in menu_items.iter().enumerate() {
             println!("{}) {}", i + 1, menu.title);
@@ -122,7 +122,7 @@ impl DebotInterface for Menu {
     async fn call(&self, func: &str, args: &Value) -> InterfaceResult {
         match func {
             "select" => self.select(args),
-            _ => Err(format!("function \"{}\" is not implemented", func)),
+            _ => Err(format!("function \"{func}\" is not implemented")),
         }
     }
 }

--- a/tvm_cli/src/debot/interfaces/number_input.rs
+++ b/tvm_cli/src/debot/interfaces/number_input.rs
@@ -64,10 +64,10 @@ impl NumberInput {
         let prompt = decode_prompt(args)?;
         let min = decode_int256(args, "min")?;
         let max = decode_int256(args, "max")?;
-        let prompt = format!("{}\n(>= {} and <= {})", prompt, min, max);
+        let prompt = format!("{prompt}\n(>= {min} and <= {max})");
         let value = terminal_input(&prompt, |val| {
             let number = decode_abi_bigint(val.as_str())
-                .map_err(|e| format!("input is not a valid number: {}", e))?;
+                .map_err(|e| format!("input is not a valid number: {e}"))?;
             if number < min || number > max {
                 return Err("number is out of range".to_string());
             }
@@ -90,7 +90,7 @@ impl DebotInterface for NumberInput {
     async fn call(&self, func: &str, args: &Value) -> InterfaceResult {
         match func {
             "get" => self.get(args),
-            _ => Err(format!("function \"{}\" is not implemented", func)),
+            _ => Err(format!("function \"{func}\" is not implemented")),
         }
     }
 }

--- a/tvm_cli/src/debot/interfaces/signing_box_input.rs
+++ b/tvm_cli/src/debot/interfaces/signing_box_input.rs
@@ -74,7 +74,7 @@ impl SigningBoxInput {
             decode_abi_bigint(elem.as_str()?).ok()?;
             Some(elem.as_str().unwrap().to_string())
         })?;
-        println!("{}", prompt);
+        println!("{prompt}");
         let result = self.processor.write().await.next_signing_box();
         match result {
             Err(ProcessorError::InterfaceCallNeeded) => {
@@ -85,7 +85,7 @@ impl SigningBoxInput {
                 self.handles.write().await.push(signing_box);
                 Ok((answer_id, json!({ "handle": handle.0})))
             }
-            Err(e) => Err(format!("{:?}", e)),
+            Err(e) => Err(format!("{e:?}")),
             Ok(handle) => Ok((answer_id, json!({ "handle": handle}))),
         }
     }
@@ -104,7 +104,7 @@ impl DebotInterface for SigningBoxInput {
     async fn call(&self, func: &str, args: &Value) -> InterfaceResult {
         match func {
             "get" => self.get(args).await,
-            _ => Err(format!("function \"{}\" is not implemented", func)),
+            _ => Err(format!("function \"{func}\" is not implemented")),
         }
     }
 }

--- a/tvm_cli/src/debot/interfaces/stdout.rs
+++ b/tvm_cli/src/debot/interfaces/stdout.rs
@@ -41,7 +41,7 @@ impl Stdout {
     pub fn print(&self, args: &Value) -> InterfaceResult {
         let text_vec = hex::decode(args["message"].as_str().unwrap()).unwrap();
         let text = std::str::from_utf8(&text_vec).unwrap();
-        println!("{}", text);
+        println!("{text}");
         Ok((0, json!({})))
     }
 }
@@ -59,7 +59,7 @@ impl DebotInterface for Stdout {
     async fn call(&self, func: &str, args: &Value) -> InterfaceResult {
         match func {
             "print" => self.print(args),
-            _ => Err(format!("function \"{}\" is not implemented", func)),
+            _ => Err(format!("function \"{func}\" is not implemented")),
         }
     }
 }

--- a/tvm_cli/src/debot/interfaces/terminal.rs
+++ b/tvm_cli/src/debot/interfaces/terminal.rs
@@ -98,9 +98,7 @@ impl Terminal {
             } else {
                 println!("(Ctrl+D to exit)");
             }
-            std::io::stdin()
-                .read_to_string(&mut value)
-                .map_err(|e| format!("input error: {e}"))?;
+            std::io::stdin().read_to_string(&mut value).map_err(|e| format!("input error: {e}"))?;
             println!();
         } else {
             value = terminal_input(&prompt, |_val| Ok(()));

--- a/tvm_cli/src/debot/interfaces/terminal.rs
+++ b/tvm_cli/src/debot/interfaces/terminal.rs
@@ -100,7 +100,7 @@ impl Terminal {
             }
             std::io::stdin()
                 .read_to_string(&mut value)
-                .map_err(|e| format!("input error: {}", e))?;
+                .map_err(|e| format!("input error: {e}"))?;
             println!();
         } else {
             value = terminal_input(&prompt, |_val| Ok(()));
@@ -111,7 +111,7 @@ impl Terminal {
     fn input_int(&self, args: &Value) -> InterfaceResult {
         let answer_id = decode_answer_id(args)?;
         let value = terminal_input(&decode_prompt(args)?, |val| {
-            let _ = decode_abi_bigint(val).map_err(|e| format!("{}", e))?;
+            let _ = decode_abi_bigint(val).map_err(|e| format!("{e}"))?;
             Ok(())
         });
         Ok((answer_id, json!({ "value": value })))
@@ -120,7 +120,7 @@ impl Terminal {
     fn input_uint(&self, args: &Value) -> InterfaceResult {
         let answer_id = decode_answer_id(args)?;
         let value = terminal_input(&decode_prompt(args)?, |val| {
-            let _ = decode_abi_bigint(val).map_err(|e| format!("{}", e))?;
+            let _ = decode_abi_bigint(val).map_err(|e| format!("{e}"))?;
             Ok(())
         });
         Ok((answer_id, json!({ "value": value })))
@@ -178,7 +178,7 @@ impl DebotInterface for Terminal {
             "inputTons" => self.input_tokens(args),
             "inputBoolean" => self.input_boolean(args),
             "print" => self.print(args).await,
-            _ => Err(format!("function \"{}\" is not implemented", func)),
+            _ => Err(format!("function \"{func}\" is not implemented")),
         }
     }
 }

--- a/tvm_cli/src/debot/interfaces/userinfo.rs
+++ b/tvm_cli/src/debot/interfaces/userinfo.rs
@@ -116,7 +116,7 @@ impl DebotInterface for UserInfo {
             "getAccount" => self.get_account(args),
             "getPublicKey" => self.get_public_key(args),
             "getSigningBox" => self.get_signing_box(args).await,
-            _ => Err(format!("function \"{}\" is not implemented", func)),
+            _ => Err(format!("function \"{func}\" is not implemented")),
         }
     }
 }

--- a/tvm_cli/src/debot/mod.rs
+++ b/tvm_cli/src/debot/mod.rs
@@ -123,9 +123,9 @@ async fn fetch_command(m: &ArgMatches, config: Config) -> Result<(), String> {
     let is_json = config.is_json;
     let pipechain = if let Some(filename) = pipechain {
         let manifest_raw = std::fs::read_to_string(filename)
-            .map_err(|e| format!("failed to read pipechain: {}", e))?;
+            .map_err(|e| format!("failed to read pipechain: {e}"))?;
         serde_json::from_str(&manifest_raw)
-            .map_err(|e| format!("failed to parse pipechain: {}", e))?
+            .map_err(|e| format!("failed to parse pipechain: {e}"))?
     } else {
         PipeChain::new()
     };
@@ -136,7 +136,7 @@ async fn fetch_command(m: &ArgMatches, config: Config) -> Result<(), String> {
             if !is_json {
                 println!("Returned value:");
             }
-            println!("{:#}", arg);
+            println!("{arg:#}");
             Ok(())
         }
         Err(err) if err.contains("NoMoreChainlinks") => Ok(()),

--- a/tvm_cli/src/debot/processor.rs
+++ b/tvm_cli/src/debot/processor.rs
@@ -46,7 +46,7 @@ impl ChainProcessor {
 
     pub fn print(&self, message: &str) {
         if self.interactive() {
-            println!("{}", message);
+            println!("{message}");
         }
     }
 

--- a/tvm_cli/src/debot/term_browser.rs
+++ b/tvm_cli/src/debot/term_browser.rs
@@ -96,7 +96,7 @@ impl TerminalBrowser {
         };
         let _ = browser.fetch_debot(addr, start, !interactive).await?;
         let abi =
-            browser.bots.get(addr).ok_or(format!("DeBot not found: address {}", addr))?.abi.clone();
+            browser.bots.get(addr).ok_or(format!("DeBot not found: address {addr}"))?.abi.clone();
 
         if !start && init_message.is_none() {
             init_message = Some(
@@ -105,13 +105,13 @@ impl TerminalBrowser {
                     ParamsOfEncodeInternalMessage {
                         abi: Some(abi),
                         address: Some(addr.to_owned()),
-                        src_address: Some(format!("{}:{}", DEBOT_WC, BROWSER_ID)),
+                        src_address: Some(format!("{DEBOT_WC}:{BROWSER_ID}")),
                         call_set,
                         value: "1000000000000000".to_owned(),
                         ..Default::default()
                     },
                 )
-                .map_err(|e| format!("{}", e))?
+                .map_err(|e| format!("{e}"))?
                 .message,
             );
         }
@@ -184,11 +184,11 @@ impl TerminalBrowser {
             self.interfaces.try_execute(&msg, &interface_id, &debot.info.dabi_version).await
         {
             let (func_id, return_args) = result?;
-            log::debug!("response: {} ({})", func_id, return_args);
+            log::debug!("response: {func_id} ({return_args})");
             let call_set = match func_id {
                 0 => None,
                 _ => {
-                    CallSet::some_with_function_and_input(&format!("0x{:x}", func_id), return_args)
+                    CallSet::some_with_function_and_input(&format!("0x{func_id:x}"), return_args)
                 }
             };
             let response_msg = encode_internal_message(
@@ -201,12 +201,12 @@ impl TerminalBrowser {
                     ..Default::default()
                 },
             )
-            .map_err(|e| format!("{}", e))?
+            .map_err(|e| format!("{e}"))?
             .message;
             let result = debot.dengine.send(response_msg).await;
             debot.callbacks.take_messages(&mut self.msg_queue);
             if let Err(e) = result {
-                println!("Debot error: {}", e);
+                println!("Debot error: {e}");
             }
         }
 
@@ -218,7 +218,7 @@ impl TerminalBrowser {
             self.fetch_debot(addr, false, !self.interactive).await?;
         }
         let debot = self.bots.get_mut(addr).ok_or("Internal error: debot not found")?;
-        debot.dengine.send(msg).await.map_err(|e| format!("Debot failed: {}", e))?;
+        debot.dengine.send(msg).await.map_err(|e| format!("Debot failed: {e}"))?;
         debot.callbacks.take_messages(&mut self.msg_queue);
         Ok(())
     }
@@ -244,7 +244,7 @@ impl TerminalBrowser {
                 self.client.clone(),
                 ParamsOfDecodeMessage { abi, message, ..Default::default() },
             )
-            .map_err(|e| format!("{}", e))?;
+            .map_err(|e| format!("{e}"))?;
             decoded.value.unwrap_or(json!({}))
         } else {
             json!({"message": message})
@@ -262,13 +262,13 @@ where
     let mut input_str = "".to_owned();
     let mut argc = 0;
     while argc == 0 {
-        println!("{}", prefix);
+        println!("{prefix}");
         if let Err(e) = writer.flush() {
-            println!("failed to flush: {}", e);
+            println!("failed to flush: {e}");
             return input_str;
         }
         if let Err(e) = reader.read_line(&mut input_str) {
-            println!("failed to read line: {}", e);
+            println!("failed to read line: {e}");
             return input_str;
         }
         argc = input_str.split_whitespace().count();
@@ -285,7 +285,7 @@ where
     let mut writer = io::stdout();
     let mut value = input(prompt, &mut reader, &mut writer);
     while let Err(e) = validator(&value) {
-        println!("{}. Try again.", e);
+        println!("{e}. Try again.");
         value = input(prompt, &mut reader, &mut writer);
     }
     value
@@ -298,7 +298,7 @@ pub fn action_input(max: usize) -> Result<(usize, usize, Vec<String>), String> {
     while argc == 0 {
         print!("debash$ ");
         let _ = io::stdout().flush();
-        io::stdin().read_line(&mut a_str).map_err(|e| format!("failed to read line: {}", e))?;
+        io::stdin().read_line(&mut a_str).map_err(|e| format!("failed to read line: {e}"))?;
         argv = a_str
             .split_whitespace()
             .map(|x| x.parse::<String>().expect("parse error"))
@@ -346,7 +346,7 @@ pub async fn run_debot_browser(
                 ton.clone(),
                 ParamsOfParse { boc: msg.clone(), ..Default::default() },
             )
-            .map_err(|e| format!("{}", e))?
+            .map_err(|e| format!("{e}"))?
             .parsed;
 
             let msg_dest = parsed["dst"]
@@ -359,7 +359,7 @@ pub async fn run_debot_browser(
 
             let wc_and_addr: Vec<_> = msg_dest.split(':').collect();
             let id = wc_and_addr[1].to_string();
-            let wc = i8::from_str_radix(wc_and_addr[0], 10).map_err(|e| format!("{}", e))?;
+            let wc = i8::from_str_radix(wc_and_addr[0], 10).map_err(|e| format!("{e}"))?;
 
             if wc == DEBOT_WC {
                 if id == BROWSER_ID {

--- a/tvm_cli/src/debot/term_browser.rs
+++ b/tvm_cli/src/debot/term_browser.rs
@@ -187,9 +187,7 @@ impl TerminalBrowser {
             log::debug!("response: {func_id} ({return_args})");
             let call_set = match func_id {
                 0 => None,
-                _ => {
-                    CallSet::some_with_function_and_input(&format!("0x{func_id:x}"), return_args)
-                }
+                _ => CallSet::some_with_function_and_input(&format!("0x{func_id:x}"), return_args),
             };
             let response_msg = encode_internal_message(
                 self.client.clone(),

--- a/tvm_cli/src/debot/term_signing_box.rs
+++ b/tvm_cli/src/debot/term_signing_box.rs
@@ -91,11 +91,11 @@ where
     let enter_str = prompt.unwrap_or_default();
     let mut pair = Err("no keypair".to_string());
     let mut format_pubkeys = String::new();
-    possible_keys.iter().for_each(|x| format_pubkeys += &format!(" {},", x));
+    possible_keys.iter().for_each(|x| format_pubkeys += &format!(" {x},"));
     for _ in 0..tries {
         let value = input(enter_str, reader, writer);
         pair = load_keypair(&value).map_err(|e| {
-            println!("Invalid keys: {}. Try again.", e);
+            println!("Invalid keys: {e}. Try again.");
             e
         });
         if let Ok(ref keys) = pair {
@@ -103,8 +103,7 @@ where
                 if !possible_keys.iter().any(|x| x.get(2..).unwrap() == keys.public.as_str()) {
                     println!("Unexpected keys.");
                     println!(
-                        "Hint: enter keypair which contains one of the following public keys: {}",
-                        format_pubkeys
+                        "Hint: enter keypair which contains one of the following public keys: {format_pubkeys}"
                     );
                 } else {
                     break;
@@ -134,10 +133,9 @@ mod tests {
         file.write_all(
             format!(
                 r#"{{
-            "public": "{}",
-            "secret": "{}"
-        }}"#,
-                PUBLIC, PRIVATE
+            "public": "{PUBLIC}",
+            "secret": "{PRIVATE}"
+        }}"#
             )
             .as_bytes(),
         )

--- a/tvm_cli/src/debug.rs
+++ b/tvm_cli/src/debug.rs
@@ -599,8 +599,7 @@ async fn replay_transaction_command(matches: &ArgMatches, config: &Config) -> Re
     let msg = trans
         .in_msg_cell()
         .map(|c| {
-            Message::construct_from_cell(c)
-                .map_err(|e| format!("failed to construct message: {e}"))
+            Message::construct_from_cell(c).map_err(|e| format!("failed to construct message: {e}"))
         })
         .transpose()?;
 
@@ -1166,10 +1165,8 @@ fn choose_transaction(transactions: Vec<TrDetails>) -> Result<String, String> {
     println!("\n\nEnter number of the chosen transaction (from 1 to {}):", transactions.len());
     let mut input = String::new();
     std::io::stdin().read_line(&mut input).unwrap();
-    let chosen: usize = input
-        .trim()
-        .parse()
-        .map_err(|e| format!("Failed to parse user input as integer: {e}"))?;
+    let chosen: usize =
+        input.trim().parse().map_err(|e| format!("Failed to parse user input as integer: {e}"))?;
     if !(1..=transactions.len()).contains(&chosen) {
         return Err("Wrong transaction number".to_string());
     }
@@ -1538,11 +1535,8 @@ async fn make_sequence_diagram(
     writeln!(output, "@startuml").unwrap();
     for address in addresses {
         let (index, name) = &name_map[&address];
-        writeln!(
-            output,
-            "participant \"[[{url_account_prefix}{address} {name}]]\" as {index}"
-        )
-        .unwrap();
+        writeln!(output, "participant \"[[{url_account_prefix}{address} {name}]]\" as {index}")
+            .unwrap();
     }
 
     let mut last_own_index = None;

--- a/tvm_cli/src/debug.rs
+++ b/tvm_cli/src/debug.rs
@@ -542,7 +542,7 @@ async fn debug_transaction_command(
 
     decode_messages(&tr, load_decode_abi(matches, config), config).await?;
     if !config.is_json {
-        println!("Log saved to {}.", trace_path);
+        println!("Log saved to {trace_path}.");
     }
     Ok(())
 }
@@ -575,7 +575,7 @@ async fn replay_transaction_command(matches: &ArgMatches, config: &Config) -> Re
         },
     )
     .await
-    .map_err(|e| format!("Failed to query transaction: {}", e))?;
+    .map_err(|e| format!("Failed to query transaction: {e}"))?;
 
     if trans.result.is_empty() {
         return Err("Transaction with specified id was not found".to_string());
@@ -585,22 +585,22 @@ async fn replay_transaction_command(matches: &ArgMatches, config: &Config) -> Re
     let block_lt =
         trans["block"]["start_lt"].as_str().ok_or("Failed to parse block_lt.".to_string())?;
     let block_lt = u64::from_str_radix(&block_lt[2..], 16)
-        .map_err(|e| format!("Failed to convert block_lt: {}", e))?;
+        .map_err(|e| format!("Failed to convert block_lt: {e}"))?;
     let boc = trans["boc"].as_str().ok_or("Failed to parse boc.".to_string())?;
 
     let trans = Transaction::construct_from_base64(boc)
-        .map_err(|e| format!("Failed to parse transaction: {}", e))?;
+        .map_err(|e| format!("Failed to parse transaction: {e}"))?;
 
     let mut account = Account::construct_from_file(input.unwrap())
-        .map_err(|e| format!("Failed to construct account from the file: {}", e))?
+        .map_err(|e| format!("Failed to construct account from the file: {e}"))?
         .serialize()
-        .map_err(|e| format!("Failed to serialize account: {}", e))?;
+        .map_err(|e| format!("Failed to serialize account: {e}"))?;
 
     let msg = trans
         .in_msg_cell()
         .map(|c| {
             Message::construct_from_cell(c)
-                .map_err(|e| format!("failed to construct message: {}", e))
+                .map_err(|e| format!("failed to construct message: {e}"))
         })
         .transpose()?;
 
@@ -622,9 +622,9 @@ async fn replay_transaction_command(matches: &ArgMatches, config: &Config) -> Re
 
     if do_update && result_trans.is_ok() {
         Account::construct_from_cell(account.clone())
-            .map_err(|e| format!("Failed to construct account: {}", e))?
+            .map_err(|e| format!("Failed to construct account: {e}"))?
             .write_to_file(input.unwrap())
-            .map_err(|e| format!("Failed to save account state: {}", e))?;
+            .map_err(|e| format!("Failed to save account state: {e}"))?;
         if !config.is_json {
             println!("Contract state was updated.");
         }
@@ -639,7 +639,7 @@ async fn replay_transaction_command(matches: &ArgMatches, config: &Config) -> Re
         }
         Err(e) => {
             if !config.is_json {
-                println!("Execution failed: {}", e);
+                println!("Execution failed: {e}");
             }
         }
     }
@@ -651,7 +651,7 @@ async fn replay_transaction_command(matches: &ArgMatches, config: &Config) -> Re
 
 fn parse_now(matches: &ArgMatches) -> Result<u64, String> {
     Ok(match matches.value_of("NOW") {
-        Some(now) => now.parse().map_err(|e| format!("Failed to convert now to u64: {}", e))?,
+        Some(now) => now.parse().map_err(|e| format!("Failed to convert now to u64: {e}"))?,
         _ => now_ms(),
     })
 }
@@ -666,7 +666,7 @@ fn load_decode_abi(matches: &ArgMatches, config: &Config) -> Option<String> {
             Ok(res) => Some(res),
             Err(e) => {
                 if !config.is_json {
-                    println!("Failed to read abi: {}", e);
+                    println!("Failed to read abi: {e}");
                 }
                 None
             }
@@ -714,13 +714,13 @@ async fn debug_call_command(
     } else if is_boc {
         ton_client = create_client_local()?;
         Account::construct_from_file(input)
-            .map_err(|e| format!(" failed to load account from the file {}: {}", input, e))?
+            .map_err(|e| format!(" failed to load account from the file {input}: {e}"))?
     } else {
         ton_client = create_client(&full_config.config)?;
         let address = load_ton_address(input, &full_config.config)?;
         let account = query_account_field(ton_client.clone(), &address, "boc").await?;
         Account::construct_from_base64(&account)
-            .map_err(|e| format!("Failed to construct account: {}", e))?
+            .map_err(|e| format!("Failed to construct account: {e}"))?
     };
     let now = parse_now(matches)?;
 
@@ -767,18 +767,18 @@ async fn debug_call_command(
         };
         encode_message(ton_client, msg_params)
             .await
-            .map_err(|e| format!("Failed to encode message: {}", e))?
+            .map_err(|e| format!("Failed to encode message: {e}"))?
             .message
     };
 
     let message = Message::construct_from_base64(&message)
-        .map_err(|e| format!("Failed to construct message: {}", e))?;
+        .map_err(|e| format!("Failed to construct message: {e}"))?;
 
     if is_getter {
         account.set_balance(CurrencyCollection::with_grams(u64::MAX));
     }
     let mut acc_root =
-        account.serialize().map_err(|e| format!("Failed to serialize account: {}", e))?;
+        account.serialize().map_err(|e| format!("Failed to serialize account: {e}"))?;
 
     let trace_path = output.unwrap();
     init_debug_logger(trace_path)?;
@@ -814,7 +814,7 @@ async fn debug_call_command(
             if is_getter && e.contains("Contract did not accept message") {
                 "Execution finished.".to_string()
             } else if !full_config.config.is_json {
-                format!("Execution failed: {}", e)
+                format!("Execution failed: {e}")
             } else {
                 return Err(e);
             }
@@ -823,24 +823,24 @@ async fn debug_call_command(
 
     if matches.is_present("UPDATE_BOC") {
         Account::construct_from_cell(acc_root)
-            .map_err(|e| format!("Failed to construct account: {}", e))?
+            .map_err(|e| format!("Failed to construct account: {e}"))?
             .write_to_file(input)
-            .map_err(|e| format!("Failed to dump account: {}", e))?;
+            .map_err(|e| format!("Failed to dump account: {e}"))?;
         if !full_config.config.is_json {
-            println!("{} successfully updated", input);
+            println!("{input} successfully updated");
         }
     }
 
     if is_getter && !out_res.is_empty() && !full_config.config.is_json {
         print!("Output: ");
         for msg in out_res {
-            println!("{:#}", msg)
+            println!("{msg:#}")
         }
     }
 
     if !full_config.config.is_json {
-        println!("{}", msg_string);
-        println!("Log saved to {}", trace_path);
+        println!("{msg_string}");
+        println!("Log saved to {trace_path}");
     }
     Ok(())
 }
@@ -859,12 +859,12 @@ async fn debug_message_command(matches: &ArgMatches, config: &Config) -> Result<
     let input = input.unwrap();
     let account = if is_boc {
         Account::construct_from_file(input)
-            .map_err(|e| format!(" failed to load account from the file {}: {}", input, e))?
+            .map_err(|e| format!(" failed to load account from the file {input}: {e}"))?
     } else {
         let address = load_ton_address(input, config)?;
         let account = query_account_field(ton_client.clone(), &address, "boc").await?;
         Account::construct_from_base64(&account)
-            .map_err(|e| format!("Failed to construct account: {}", e))?
+            .map_err(|e| format!("Failed to construct account: {e}"))?
     };
 
     let message = message.unwrap();
@@ -873,9 +873,9 @@ async fn debug_message_command(matches: &ArgMatches, config: &Config) -> Result<
     } else {
         Message::construct_from_base64(message)
     }
-    .map_err(|e| format!("Failed to decode message: {}", e))?;
+    .map_err(|e| format!("Failed to decode message: {e}"))?;
     let mut acc_root =
-        account.serialize().map_err(|e| format!("Failed to serialize account: {}", e))?;
+        account.serialize().map_err(|e| format!("Failed to serialize account: {e}"))?;
 
     let trace_path = output.unwrap();
     init_debug_logger(trace_path)?;
@@ -900,22 +900,22 @@ async fn debug_message_command(matches: &ArgMatches, config: &Config) -> Result<
             decode_messages(&trans, load_decode_abi(matches, config), config).await?;
             ("Execution finished.".to_string(), None)
         }
-        Err(e) => (format!("Execution failed: {}", e), Some(e)),
+        Err(e) => (format!("Execution failed: {e}"), Some(e)),
     };
 
     if matches.is_present("UPDATE_BOC") {
         Account::construct_from_cell(acc_root)
-            .map_err(|e| format!("Failed to construct account: {}", e))?
+            .map_err(|e| format!("Failed to construct account: {e}"))?
             .write_to_file(input)
-            .map_err(|e| format!("Failed to dump account: {}", e))?;
+            .map_err(|e| format!("Failed to dump account: {e}"))?;
         if !config.is_json {
-            println!("{} successfully updated", input);
+            println!("{input} successfully updated");
         }
     }
 
     if !config.is_json {
-        println!("{}", msg_string);
-        println!("Log saved to {}", trace_path);
+        println!("{msg_string}");
+        println!("Log saved to {trace_path}");
     }
     match error {
         Some(e) => Err(e),
@@ -960,26 +960,26 @@ async fn debug_deploy_command(matches: &ArgMatches, config: &Config) -> Result<(
     let ton_client = create_client(config)?;
     let enc_msg = encode_message(ton_client.clone(), msg.clone())
         .await
-        .map_err(|e| format!("failed to create inbound message: {}", e))?;
+        .map_err(|e| format!("failed to create inbound message: {e}"))?;
 
     let account = if let Some(initial_balance) = initial_balance_opt {
         let address = AccountId::from_string(address.split(':').collect::<Vec<&str>>()[1])
-            .map_err(|e| format!("{}", e))?;
+            .map_err(|e| format!("{e}"))?;
         let addr =
-            MsgAddressInt::with_standart(None, wc as i8, address).map_err(|e| format!("{}", e))?;
+            MsgAddressInt::with_standart(None, wc as i8, address).map_err(|e| format!("{e}"))?;
         let balance = CurrencyCollection::with_grams(initial_balance);
         Account::with_address_and_ballance(&addr, &balance)
     } else {
         let account = query_account_field(ton_client.clone(), &address, "boc").await?;
         Account::construct_from_base64(&account)
-            .map_err(|e| format!("Failed to construct account: {}", e))?
+            .map_err(|e| format!("Failed to construct account: {e}"))?
     };
 
     let message = Message::construct_from_base64(&enc_msg.message)
-        .map_err(|e| format!("Failed to construct message: {}", e))?;
+        .map_err(|e| format!("Failed to construct message: {e}"))?;
 
     let mut acc_root =
-        account.serialize().map_err(|e| format!("Failed to serialize account: {}", e))?;
+        account.serialize().map_err(|e| format!("Failed to serialize account: {e}"))?;
 
     let trace_path = output.unwrap();
     init_debug_logger(trace_path)?;
@@ -1007,19 +1007,19 @@ async fn debug_deploy_command(matches: &ArgMatches, config: &Config) -> Result<(
                     .map_err(|e| format!("Failed to construct account after debug deploy: {e}"))?;
                 let output = std::path::PathBuf::from(tvc.unwrap()).with_extension("boc");
                 account.write_to_file(&output).map_err(|e| {
-                    format!("Failed to serialize account after debug deploy {:?}: {e}", output)
+                    format!("Failed to serialize account after debug deploy {output:?}: {e}")
                 })?;
             }
             decode_messages(&trans, load_decode_abi(matches, config), config).await?;
             "Execution finished.".to_string()
         }
         Err(e) => {
-            format!("Execution failed: {}", e)
+            format!("Execution failed: {e}")
         }
     };
     if !config.is_json {
-        println!("{}", msg_string);
-        println!("Log saved to {}", trace_path);
+        println!("{msg_string}");
+        println!("Log saved to {trace_path}");
     }
     Ok(())
 }
@@ -1033,16 +1033,16 @@ pub async fn decode_messages(
     if !msgs.is_empty() {
         log::debug!(target: "executor", "Output messages:\n----------------");
     }
-    let msgs = msgs.export_vector().map_err(|e| format!("Failed to parse out messages: {}", e))?;
+    let msgs = msgs.export_vector().map_err(|e| format!("Failed to parse out messages: {e}"))?;
 
     let mut res = vec![];
     let mut output = vec![];
     for InRefValue(msg) in msgs {
         let mut ser_msg = serialize_msg(&msg, abi.clone(), config)
             .await
-            .map_err(|e| format!("Failed to serialize message: {}", e))?;
+            .map_err(|e| format!("Failed to serialize message: {e}"))?;
         let msg_cell =
-            msg.serialize().map_err(|e| format!("Failed to serialize out message: {}", e))?;
+            msg.serialize().map_err(|e| format!("Failed to serialize out message: {e}"))?;
         ser_msg["id"] = msg_cell.repr_hash().as_hex_string().into();
         let msg_bytes = tvm_types::write_boc(&msg_cell)
             .map_err(|e| format!("failed to encode out message: {e}"))?;
@@ -1051,7 +1051,7 @@ pub async fn decode_messages(
         if body.is_object() {
             res.push(body.clone());
         }
-        log::debug!(target: "executor", "\n{:#}\n", ser_msg);
+        log::debug!(target: "executor", "\n{ser_msg:#}\n");
         output.push(ser_msg);
     }
     if config.is_json {
@@ -1080,7 +1080,7 @@ pub async fn decode_messages(
             "messages": output,
             // "transaction": _tr
         });
-        println!("{:#}", result);
+        println!("{result:#}");
     }
     Ok(res)
 }
@@ -1100,7 +1100,7 @@ async fn query_address(tr_id: &str, config: &Config) -> Result<String, String> {
         Some(1),
     )
     .await
-    .map_err(|e| format!("Failed to query address: {}", e))?;
+    .map_err(|e| format!("Failed to query address: {e}"))?;
     match query_result.len() {
         0 => Err("Transaction was not found".to_string()),
         _ => Ok(query_result[0]["account_addr"]
@@ -1143,7 +1143,7 @@ async fn query_transactions(address: &str, config: &Config) -> Result<Vec<TrDeta
         Some(TRANSACTION_QUANTITY),
     )
     .await
-    .map_err(|e| format!("Failed to query address: {}", e))?;
+    .map_err(|e| format!("Failed to query address: {e}"))?;
     match query_result.len() {
         0 => Err("Transaction list is empty.".to_string()),
         _ => Ok(query_result
@@ -1169,7 +1169,7 @@ fn choose_transaction(transactions: Vec<TrDetails>) -> Result<String, String> {
     let chosen: usize = input
         .trim()
         .parse()
-        .map_err(|e| format!("Failed to parse user input as integer: {}", e))?;
+        .map_err(|e| format!("Failed to parse user input as integer: {e}"))?;
     if !(1..=transactions.len()).contains(&chosen) {
         return Err("Wrong transaction number".to_string());
     }
@@ -1237,7 +1237,7 @@ pub async fn execute_debug(
         config.set_config(c20).unwrap();
         config.set_config(c21).unwrap();
         BlockchainConfig::with_config(config)
-            .map_err(|e| format!("Failed to construct config for getter: {}", e))?
+            .map_err(|e| format!("Failed to construct config for getter: {e}"))?
     } else {
         bc_config
     };
@@ -1262,13 +1262,13 @@ pub async fn execute_debug(
             Some(tvm_executor::ExecutorError::NoAcceptError(exit_code, _)) => *exit_code,
             Some(tvm_executor::ExecutorError::TvmExceptionCode(exit_code)) => *exit_code as i32,
             None => tvm_vm::error::tvm_exception_or_custom_code(&e),
-            _ => return format!("Debug failed: {}", e),
+            _ => return format!("Debug failed: {e}"),
         };
         let result = json!({
             "exit_code": exit_code,
             "message": e.to_string(),
         });
-        format!("{:#}", result)
+        format!("{result:#}")
     });
     match tr {
         Ok(data) => Ok(data.0),
@@ -1297,14 +1297,14 @@ fn trace_callback(info: &EngineTraceInfo, debug_info: Option<&DbgInfo>) {
     );
 
     if let Ok(position) = get_position(info, debug_info) {
-        log::info!(target: "tvm", "Position: {}", position);
+        log::info!(target: "tvm", "Position: {position}");
     } else {
         log::info!(target: "tvm", "Position: Undefined");
     }
 
     log::info!(target: "tvm", "\n--- Stack trace ------------------------");
     for item in info.stack.iter() {
-        log::info!(target: "tvm", "{}", item);
+        log::info!(target: "tvm", "{item}");
     }
     log::info!(target: "tvm", "----------------------------------------\n");
 }
@@ -1371,7 +1371,7 @@ const RENDER_GAS: u8 = 0x01;
 
 pub async fn sequence_diagram_command(matches: &ArgMatches, config: &Config) -> Result<(), String> {
     let filename = matches.value_of("ADDRESSES").unwrap();
-    let file = std::fs::File::open(filename).map_err(|e| format!("Failed to open file: {}", e))?;
+    let file = std::fs::File::open(filename).map_err(|e| format!("Failed to open file: {e}"))?;
 
     let mut addresses = vec![];
     let lines = std::io::BufReader::new(file).lines();
@@ -1385,17 +1385,17 @@ pub async fn sequence_diagram_command(matches: &ArgMatches, config: &Config) -> 
     if addresses.iter().collect::<HashSet<_>>().len() < addresses.len() {
         return Err("Addresses are not unique".to_owned());
     }
-    let mut output = std::fs::File::create(format!("{}.plantuml", filename))
-        .map_err(|e| format!("Failed to create file: {}", e))?;
+    let mut output = std::fs::File::create(format!("{filename}.plantuml"))
+        .map_err(|e| format!("Failed to create file: {e}"))?;
     make_sequence_diagram(config, addresses, RENDER_NONE, &mut output).await.map(|res| {
-        println!("{}", res);
+        println!("{res}");
     })
 }
 
 fn infer_address_width(input: &Vec<String>, min_width: usize) -> Result<usize, String> {
     let max_width = input.iter().fold(0, |acc, item| std::cmp::max(acc, item.len()));
     let addresses =
-        input.iter().map(|address| format!("{:>max_width$}", address)).collect::<Vec<_>>();
+        input.iter().map(|address| format!("{address:>max_width$}")).collect::<Vec<_>>();
 
     let mut width = min_width;
     loop {
@@ -1454,7 +1454,7 @@ async fn fetch_transactions(
 
             let transactions = tokio_retry::Retry::spawn(retry_strategy.clone(), action)
                 .await
-                .map_err(|e| format!("Failed to fetch transactions: {}", e))?;
+                .map_err(|e| format!("Failed to fetch transactions: {e}"))?;
 
             if transactions.result.is_empty() {
                 break;
@@ -1465,7 +1465,7 @@ async fn fetch_transactions(
                 let id = txn["id"].as_str().unwrap();
                 let workchain_id = txn["workchain_id"].as_i64().unwrap();
                 let txn = Transaction::construct_from_base64(boc)
-                    .map_err(|e| format!("Failed to deserialize txn: {}", e))?;
+                    .map_err(|e| format!("Failed to deserialize txn: {e}"))?;
                 txns.push(TransactionExt {
                     id: id.to_owned(),
                     address: format!("{}:{}", workchain_id, txn.account_id().to_hex_string()),
@@ -1528,20 +1528,19 @@ async fn make_sequence_diagram(
 
     let mut url = config.url.replace(".dev", ".live");
     if !url.starts_with("https://") {
-        url = format!("https://{}", url);
+        url = format!("https://{url}");
     }
 
-    let url_account_prefix = format!("{}/accounts/accountDetails?id=", url);
-    let url_message_prefix = format!("{}/messages/messageDetails?id=", url);
-    let url_txn_prefix = format!("{}/transactions/transactionDetails?id=", url);
+    let url_account_prefix = format!("{url}/accounts/accountDetails?id=");
+    let url_message_prefix = format!("{url}/messages/messageDetails?id=");
+    let url_txn_prefix = format!("{url}/transactions/transactionDetails?id=");
 
     writeln!(output, "@startuml").unwrap();
     for address in addresses {
         let (index, name) = &name_map[&address];
         writeln!(
             output,
-            "participant \"[[{url_account_prefix}{} {}]]\" as {}",
-            address, name, index
+            "participant \"[[{url_account_prefix}{address} {name}]]\" as {index}"
         )
         .unwrap();
     }
@@ -1550,7 +1549,7 @@ async fn make_sequence_diagram(
     let mut last_tr_id: Option<String> = None;
     let mut rendered = HashSet::<UInt256>::default();
     for TransactionExt { id, address, tr } in txns {
-        writeln!(output, "' {}", id).unwrap();
+        writeln!(output, "' {id}").unwrap();
 
         let is_separate = last_tr_id.as_ref() != Some(&id);
         let tr_name = id.split_at(MESSAGE_WIDTH).0;
@@ -1568,16 +1567,14 @@ async fn make_sequence_diagram(
                     // message from an inner account
                     writeln!(
                         output,
-                        "{} ->> {} : m:[[{url_message_prefix}{} {}]]\\nt:[[{url_txn_prefix}{} {}]]",
-                        src_index, own_index, msg_id, msg_name, id, tr_name
+                        "{src_index} ->> {own_index} : m:[[{url_message_prefix}{msg_id} {msg_name}]]\\nt:[[{url_txn_prefix}{id} {tr_name}]]"
                     )
                     .unwrap();
                 } else {
                     // message from an out of the scope account
                     writeln!(
                         output,
-                        "[->> {} : m:[[{url_message_prefix}{} {}]]\\nt:[[{url_txn_prefix}{} {}]]",
-                        own_index, msg_id, msg_name, id, tr_name
+                        "[->> {own_index} : m:[[{url_message_prefix}{msg_id} {msg_name}]]\\nt:[[{url_txn_prefix}{id} {tr_name}]]"
                     )
                     .unwrap();
                 }
@@ -1586,17 +1583,16 @@ async fn make_sequence_diagram(
                 assert!(in_msg.is_inbound_external());
                 writeln!(
                     output,
-                    "[o->> {} : m:[[{url_message_prefix}{} {}]]\\nt:[[{url_txn_prefix}{} {}]]",
-                    own_index, msg_id, msg_name, id, tr_name
+                    "[o->> {own_index} : m:[[{url_message_prefix}{msg_id} {msg_name}]]\\nt:[[{url_txn_prefix}{id} {tr_name}]]"
                 )
                 .unwrap();
             }
         } else if last_own_index == Some(own_index) {
             // rendered, adjacent, and active participant stays unchanged
-            writeln!(output, "{} [hidden]-> {}", own_index, own_index).unwrap();
+            writeln!(output, "{own_index} [hidden]-> {own_index}").unwrap();
         }
 
-        let desc = tr.read_description().map_err(|e| format!("Failed to read tr desc: {}", e))?;
+        let desc = tr.read_description().map_err(|e| format!("Failed to read tr desc: {e}"))?;
         let (tr_color, tr_gas) = match desc.compute_phase_ref() {
             None | Some(tvm_block::TrComputePhase::Skipped(_)) => ("", None),
             Some(tvm_block::TrComputePhase::Vm(tr_compute_phase_vm)) => {
@@ -1609,7 +1605,7 @@ async fn make_sequence_diagram(
             }
         };
 
-        writeln!(output, "activate {} {}", own_index, tr_color).unwrap();
+        writeln!(output, "activate {own_index} {tr_color}").unwrap();
         last_tr_id = None;
         let out_msgs = sort_outbound_messages(&tr, &inbound_map)?;
         for out_msg in out_msgs {
@@ -1625,15 +1621,13 @@ async fn make_sequence_diagram(
                         // message spawns a known transaction
                         let tr_id = tr.serialize().unwrap().repr_hash().to_hex_string();
                         let tr_name = tr_id.split_at(MESSAGE_WIDTH).0;
-                        writeln!(output, "{} ->> {} : m:[[{url_message_prefix}{} {}]]\\nt:[[{url_txn_prefix}{} {}]]",
-                            own_index, out_index, out_id, out_name, tr_id, tr_name).unwrap();
+                        writeln!(output, "{own_index} ->> {out_index} : m:[[{url_message_prefix}{out_id} {out_name}]]\\nt:[[{url_txn_prefix}{tr_id} {tr_name}]]").unwrap();
                         last_tr_id = Some(tr_id);
                     } else {
                         // transaction spawned by the message is out of the scope
                         writeln!(
                             output,
-                            "{} ->> {} : m:[[{url_message_prefix}{} {}]]",
-                            own_index, out_index, out_id, out_name
+                            "{own_index} ->> {out_index} : m:[[{url_message_prefix}{out_id} {out_name}]]"
                         )
                         .unwrap();
                     }
@@ -1648,22 +1642,21 @@ async fn make_sequence_diagram(
                 assert!(out_msg.is_outbound_external());
                 writeln!(
                     output,
-                    "{} ->>o] : m:[[{url_message_prefix}{} {}]]",
-                    own_index, out_id, out_name
+                    "{own_index} ->>o] : m:[[{url_message_prefix}{out_id} {out_name}]]"
                 )
                 .unwrap();
             }
             rendered.insert(out_hash);
         }
         if tr.msg_count() == 0 {
-            writeln!(output, "{} [hidden]-> {}", own_index, own_index).unwrap();
+            writeln!(output, "{own_index} [hidden]-> {own_index}").unwrap();
         }
         if render_flags & RENDER_GAS != 0 {
             if let Some(tr_gas) = tr_gas {
-                writeln!(output, "note over {}: {}", own_index, tr_gas).unwrap();
+                writeln!(output, "note over {own_index}: {tr_gas}").unwrap();
             }
         }
-        writeln!(output, "deactivate {}", own_index).unwrap();
+        writeln!(output, "deactivate {own_index}").unwrap();
         last_own_index = Some(own_index);
     }
 
@@ -1706,14 +1699,14 @@ impl<'a> DebugParams<'a> {
 }
 
 pub async fn debug_error(e: &ClientError, debug_params: DebugParams<'_>) -> Result<(), String> {
-    let result = format!("{:#}", e);
+    let result = format!("{e:#}");
     if e.code != SDK_EXECUTION_ERROR_CODE || !debug_params.check_debug() {
         return Err(result);
     }
     if debug_params.config.is_json {
         println!("{:#}", json!({"Error": e}));
     } else {
-        println!("Error: {}", result);
+        println!("Error: {result}");
         println!("Execution failed. Starting debug...");
     }
     let _ = execute_debug_params(&debug_params).await;

--- a/tvm_cli/src/decode.rs
+++ b/tvm_cli/src/decode.rs
@@ -384,10 +384,8 @@ async fn decode_body(
     };
     let mut signature = None;
 
-    let cell =
-        read_single_root_boc(body_vec).map_err(|e| format!("Failed to create cell: {e}"))?;
-    let orig_slice =
-        SliceData::load_cell(cell).map_err(|e| format!("Failed to load cell: {e}"))?;
+    let cell = read_single_root_boc(body_vec).map_err(|e| format!("Failed to create cell: {e}"))?;
+    let orig_slice = SliceData::load_cell(cell).map_err(|e| format!("Failed to load cell: {e}"))?;
     if is_external {
         let mut slice = orig_slice.clone();
         let flag = slice.get_next_bit();

--- a/tvm_cli/src/deploy.rs
+++ b/tvm_cli/src/deploy.rs
@@ -54,7 +54,7 @@ pub async fn deploy_contract(
 
     let encoded_msg = encode_message(tvm_client.clone(), msg_params.clone())
         .await
-        .map_err(|e| format!("failed to create inbound message: {}", e))?;
+        .map_err(|e| format!("failed to create inbound message: {e}"))?;
 
     let msg = encoded_msg.message;
 
@@ -82,7 +82,7 @@ pub async fn deploy_contract(
                 println!("{k}: {v}");
             }
         });
-        println!("Contract deployed at address: {}", addr);
+        println!("Contract deployed at address: {addr}");
     } else {
         map.insert("deployed_at".to_string(), serde_json::Value::String(addr.clone()));
         print_json_result(serde_json::Value::Object(map), config)?;
@@ -108,7 +108,7 @@ pub async fn generate_deploy_message(
     let (msg, addr) = prepare_deploy_message(tvc, abi, params, keys_file, wc, config).await?;
     let msg = encode_message(ton, msg)
         .await
-        .map_err(|e| format!("failed to create inbound message: {}", e))?;
+        .map_err(|e| format!("failed to create inbound message: {e}"))?;
 
     let msg = EncodedMessage {
         message: msg.message,
@@ -118,7 +118,7 @@ pub async fn generate_deploy_message(
     };
     display_generated_message(&msg, "constructor", is_raw, output, config.is_json)?;
     if !config.is_json {
-        println!("Contract's address: {}", addr);
+        println!("Contract's address: {addr}");
         println!("Succeeded.");
     }
     Ok(())
@@ -182,7 +182,7 @@ pub async fn prepare_deploy_message_params(
     let deploy_set =
         Some(DeploySet { tvc: Some(tvc), workchain_id: Some(wc), ..Default::default() });
     let params = serde_json::from_str(params)
-        .map_err(|e| format!("function arguments is not a json: {}", e))?;
+        .map_err(|e| format!("function arguments is not a json: {e}"))?;
     let call_set = Some(CallSet { function_name, input: Some(params), header });
     let signer = if let Some(keys) = keys { Signer::Keys { keys } } else { Signer::None };
     Ok((

--- a/tvm_cli/src/depool.rs
+++ b/tvm_cli/src/depool.rs
@@ -277,10 +277,10 @@ impl<'a> DepoolCmd<'a> {
             }
         };
         let wperiod = u32::from_str_radix(withdrawal_period, 10)
-            .map_err(|e| format!("invalid withdrawal period: {}", e))
+            .map_err(|e| format!("invalid withdrawal period: {e}"))
             .and_then(period_checker)?;
         let tperiod = u32::from_str_radix(total_period, 10)
-            .map_err(|e| format!("invalid total period: {}", e))
+            .map_err(|e| format!("invalid total period: {e}"))
             .and_then(period_checker)?;
         let wp = wperiod * 86400;
         let tp = tperiod * 86400;
@@ -406,7 +406,7 @@ impl<'a> DepoolCmd<'a> {
             },
         )
         .await
-        .map_err(|e| println!("failed to query message: {}", e));
+        .map_err(|e| println!("failed to query message: {e}"));
 
         if message.is_err() {
             println!(
@@ -452,7 +452,7 @@ impl<'a> DepoolCmd<'a> {
                 },
             )
             .await
-            .map_err(|e| println!("failed to query answer: {}", e));
+            .map_err(|e| println!("failed to query answer: {e}"));
             if message.is_ok() {
                 let message = message.unwrap().result;
                 println!("\nAnswer: ");
@@ -460,18 +460,18 @@ impl<'a> DepoolCmd<'a> {
                     print_message(client.clone(), &message, PARTICIPANT_ABI, true).await?;
                 if name == "receiveAnswer" {
                     let args: serde_json::Value = serde_json::from_str(&args)
-                        .map_err(|e| format!("failed to deserialize args: {}", e))?;
+                        .map_err(|e| format!("failed to deserialize args: {e}"))?;
                     let status = args["errcode"]
                         .as_str()
                         .ok_or("failed to serialize the error code")?
                         .parse::<u32>()
-                        .map_err(|e| format!("failed to parse the error code: {}", e))?;
+                        .map_err(|e| format!("failed to parse the error code: {e}"))?;
                     let comment =
                         args["comment"].as_str().ok_or("failed to serialize the comment")?;
                     if statuses.contains_key(&status) {
                         println!("Answer status: {}\nComment: {}", statuses[&status], comment);
                     } else {
-                        println!("Answer status: Unknown({})\nComment: {}", status, comment);
+                        println!("Answer status: Unknown({status})\nComment: {comment}");
                     }
                 }
                 println!();
@@ -486,14 +486,14 @@ impl<'a> DepoolCmd<'a> {
     fn depool_fee(config: &Config) -> Result<u64, String> {
         let depool_fee = config.depool_fee.clone().to_string();
         u64::from_str_radix(&convert::convert_token(&depool_fee)?, 10)
-            .map_err(|e| format!(r#"failed to parse depool fee value: {}"#, e))
+            .map_err(|e| format!(r#"failed to parse depool fee value: {e}"#))
     }
 }
 
 fn parse_value(m: &ArgMatches) -> Result<u64, String> {
     let amount = m.value_of("VALUE").ok_or("value is not defined.".to_string())?;
     let amount = u64::from_str_radix(&convert::convert_token(amount)?, 10)
-        .map_err(|e| format!(r#"failed to parse stake value: {}"#, e))?;
+        .map_err(|e| format!(r#"failed to parse stake value: {e}"#))?;
     Ok(amount)
 }
 
@@ -503,7 +503,7 @@ pub async fn depool_command(m: &ArgMatches, config: &mut Config) -> Result<(), S
             .to_string(),
     )?;
     let depool =
-        load_ton_address(&depool, config).map_err(|e| format!("invalid depool address: {}", e))?;
+        load_ton_address(&depool, config).map_err(|e| format!("invalid depool address: {e}"))?;
 
     let mut set_wait_answer = |m: &ArgMatches| {
         if m.is_present("WAIT_ANSWER") {
@@ -578,14 +578,14 @@ async fn answer_command(m: &ArgMatches, config: &Config, depool: &str) -> Result
     let since = m
         .value_of("SINCE")
         .map(|s| {
-            u32::from_str_radix(s, 10).map_err(|e| format!(r#"cannot parse "since" option: {}"#, e))
+            u32::from_str_radix(s, 10).map_err(|e| format!(r#"cannot parse "since" option: {e}"#))
         })
         .transpose()?
         .unwrap_or(0);
 
     let ton = create_client_verbose(config)?;
     let wallet =
-        load_ton_address(&wallet, config).map_err(|e| format!("invalid depool address: {}", e))?;
+        load_ton_address(&wallet, config).map_err(|e| format!("invalid depool address: {e}"))?;
 
     let messages = tvm_client::net::query_collection(
         ton.clone(),
@@ -601,7 +601,7 @@ async fn answer_command(m: &ArgMatches, config: &Config, depool: &str) -> Result
         },
     )
     .await
-    .map_err(|e| format!("failed to query depool messages: {}", e))?;
+    .map_err(|e| format!("failed to query depool messages: {e}"))?;
     println!("{} answers found", messages.result.len());
     for messages in &messages.result {
         print_answer(ton.clone(), messages).await?;
@@ -627,7 +627,7 @@ async fn events_command(m: &ArgMatches, config: &Config, depool: &str) -> Result
         let since = since
             .map(|s| {
                 u32::from_str_radix(s, 10)
-                    .map_err(|e| format!(r#"cannot parse "since" option: {}"#, e))
+                    .map_err(|e| format!(r#"cannot parse "since" option: {e}"#))
             })
             .transpose()?
             .unwrap_or(0);
@@ -647,7 +647,7 @@ async fn print_event(ton: TonClient, event: &serde_json::Value) -> Result<(), St
         ParamsOfDecodeMessageBody {
             abi: load_abi(DEPOOL_ABI, &def_config)
                 .await
-                .map_err(|e| format!("failed to load depool abi: {}", e))?,
+                .map_err(|e| format!("failed to load depool abi: {e}"))?,
             body: body.to_owned(),
             is_internal: false,
             ..Default::default()
@@ -660,7 +660,7 @@ async fn print_event(ton: TonClient, event: &serde_json::Value) -> Result<(), St
         (
             result.name,
             serde_json::to_string(&result.value)
-                .map_err(|e| format!("failed to serialize the result: {}", e))?,
+                .map_err(|e| format!("failed to serialize the result: {e}"))?,
         )
     };
 
@@ -692,7 +692,7 @@ async fn get_events(config: &Config, depool: &str, since: u32) -> Result<(), Str
         },
     )
     .await
-    .map_err(|e| format!("failed to query depool events: {}", e))?;
+    .map_err(|e| format!("failed to query depool events: {e}"))?;
     println!("{} events found", events.result.len());
     for event in &events.result {
         print_event(ton.clone(), event).await?;
@@ -716,7 +716,7 @@ async fn wait_for_event(config: &Config, depool: &str) -> Result<(), String> {
         },
     )
     .await
-    .map_err(|e| println!("failed to query event: {}", e));
+    .map_err(|e| println!("failed to query event: {e}"));
     if event.is_ok() {
         print_event(ton.clone(), &event.unwrap().result).await?;
     }
@@ -737,7 +737,7 @@ async fn encode_body(func: &str, params: serde_json::Value) -> Result<String, St
         },
     )
     .await
-    .map_err(|e| format!("failed to encode body: {}", e))
+    .map_err(|e| format!("failed to encode body: {e}"))
     .map(|r| r.body)
 }
 

--- a/tvm_cli/src/genaddr.rs
+++ b/tvm_cli/src/genaddr.rs
@@ -31,7 +31,7 @@ pub async fn generate_address(
     update_tvc: bool,
 ) -> Result<(), String> {
     let contract =
-        std::fs::read(tvc).map_err(|e| format!("failed to read smart contract file: {}", e))?;
+        std::fs::read(tvc).map_err(|e| format!("failed to read smart contract file: {e}"))?;
 
     let abi = load_abi(abi_path, config).await?;
 
@@ -54,7 +54,7 @@ pub async fn generate_address(
     let wc = wc_str
         .map(|wc| i32::from_str_radix(wc, 10))
         .transpose()
-        .map_err(|e| format!("failed to parse workchain id: {}", e))?
+        .map_err(|e| format!("failed to parse workchain id: {e}"))?
         .unwrap_or(config.wc);
 
     let addr = calc_acc_address(
@@ -70,7 +70,7 @@ pub async fn generate_address(
         let initial_data = initial_data.map(|s| s.to_string());
         let key_bytes = match keys.as_ref() {
             Some(keys) => hex::decode(&keys.public)
-                .map_err(|e| format!("failed to decode public key: {}", e))?,
+                .map_err(|e| format!("failed to decode public key: {e}"))?,
             _ => {
                 vec![0; 32]
             }
@@ -84,17 +84,17 @@ pub async fn generate_address(
 
     if new_keys && keys_file.is_some() {
         let keys_json = serde_json::to_string_pretty(&keys.clone().unwrap())
-            .map_err(|e| format!("failed to serialize the keypair: {}", e))?;
+            .map_err(|e| format!("failed to serialize the keypair: {e}"))?;
         std::fs::write(keys_file.unwrap(), &keys_json)
-            .map_err(|e| format!("failed to save the keypair: {}", e))?;
+            .map_err(|e| format!("failed to save the keypair: {e}"))?;
     }
 
     if !config.is_json {
         println!();
         if !phrase.is_empty() {
-            println!(r#"Seed phrase: "{}""#, phrase);
+            println!(r#"Seed phrase: "{phrase}""#);
         }
-        println!("Raw address: {}", addr);
+        println!("Raw address: {addr}");
         println!("Succeeded");
     } else {
         let mut res = json!({});
@@ -102,7 +102,7 @@ pub async fn generate_address(
             res["seed_phrase"] = json!(phrase);
         }
         res["raw_address"] = json!(addr);
-        println!("{:#}", res);
+        println!("{res:#}");
     }
     Ok(())
 }
@@ -120,50 +120,50 @@ fn update_contract_state(
     use tvm_sdk::ContractImage;
 
     let data_map_supported: bool = (Contract::load(abi.as_bytes())
-        .map_err(|e| format!("unable to load abi: {}", e))?)
+        .map_err(|e| format!("unable to load abi: {e}"))?)
     .data_map_supported();
 
     let mut state_init = OpenOptions::new()
         .read(true)
         .write(true)
         .open(tvc_file)
-        .map_err(|e| format!("unable to open contract file: {}", e))?;
+        .map_err(|e| format!("unable to open contract file: {e}"))?;
 
     let pubkey_object =
-        pubkey.try_into().map_err(|e| format!("unable to load public key: {}", e))?;
+        pubkey.try_into().map_err(|e| format!("unable to load public key: {e}"))?;
 
     let mut contract_image = if data_map_supported {
         ContractImage::from_state_init_and_key(&mut state_init, &pubkey_object)
-            .map_err(|e| format!("unable to load contract image with key: {}", e))?
+            .map_err(|e| format!("unable to load contract image with key: {e}"))?
     } else {
         ContractImage::from_state_init(&mut state_init)
-            .map_err(|e| format!("unable to load contract image: {}", e))?
+            .map_err(|e| format!("unable to load contract image: {e}"))?
     };
 
     if data_map_supported {
         if data.is_some() {
             contract_image
                 .update_data(true, &data.unwrap(), abi)
-                .map_err(|e| format!("unable to update contract image data: {}", e))?;
+                .map_err(|e| format!("unable to update contract image data: {e}"))?;
         }
     } else {
         let js_init_data =
             crate::helpers::insert_pubkey_to_init_data(Some(hex::encode(pubkey)), data.as_deref())?;
         contract_image
             .update_data(false, js_init_data.as_str(), abi)
-            .map_err(|e| format!("unable to update contract image data: {}", e))?;
+            .map_err(|e| format!("unable to update contract image data: {e}"))?;
     }
 
     let vec_bytes = contract_image
         .serialize()
-        .map_err(|e| format!("unable to serialize contract image: {}", e))?;
+        .map_err(|e| format!("unable to serialize contract image: {e}"))?;
 
     state_init
         .seek(std::io::SeekFrom::Start(0))
-        .map_err(|e| format!("failed to access the tvc file: {}", e))?;
+        .map_err(|e| format!("failed to access the tvc file: {e}"))?;
     state_init
         .write_all(&vec_bytes)
-        .map_err(|e| format!("failed to update the tvc file: {}", e))?;
+        .map_err(|e| format!("failed to update the tvc file: {e}"))?;
 
     Ok(())
 }

--- a/tvm_cli/src/genaddr.rs
+++ b/tvm_cli/src/genaddr.rs
@@ -129,8 +129,7 @@ fn update_contract_state(
         .open(tvc_file)
         .map_err(|e| format!("unable to open contract file: {e}"))?;
 
-    let pubkey_object =
-        pubkey.try_into().map_err(|e| format!("unable to load public key: {e}"))?;
+    let pubkey_object = pubkey.try_into().map_err(|e| format!("unable to load public key: {e}"))?;
 
     let mut contract_image = if data_map_supported {
         ContractImage::from_state_init_and_key(&mut state_init, &pubkey_object)
@@ -161,9 +160,7 @@ fn update_contract_state(
     state_init
         .seek(std::io::SeekFrom::Start(0))
         .map_err(|e| format!("failed to access the tvc file: {e}"))?;
-    state_init
-        .write_all(&vec_bytes)
-        .map_err(|e| format!("failed to update the tvc file: {e}"))?;
+    state_init.write_all(&vec_bytes).map_err(|e| format!("failed to update the tvc file: {e}"))?;
 
     Ok(())
 }

--- a/tvm_cli/src/helpers.rs
+++ b/tvm_cli/src/helpers.rs
@@ -105,9 +105,9 @@ impl log::Log for SimpleLogger {
 
 pub fn read_keys(filename: &str) -> Result<KeyPair, String> {
     let keys_str = std::fs::read_to_string(filename)
-        .map_err(|e| format!("failed to read the keypair file: {}", e))?;
+        .map_err(|e| format!("failed to read the keypair file: {e}"))?;
     let keys: KeyPair =
-        serde_json::from_str(&keys_str).map_err(|e| format!("failed to load keypair: {}", e))?;
+        serde_json::from_str(&keys_str).map_err(|e| format!("failed to load keypair: {e}"))?;
     Ok(keys)
 }
 
@@ -115,7 +115,7 @@ pub fn load_ton_address(addr: &str, config: &Config) -> Result<String, String> {
     let addr =
         if addr.find(':').is_none() { format!("{}:{}", config.wc, addr) } else { addr.to_owned() };
     let _ = MsgAddressInt::from_str(&addr).map_err(|e| {
-        format!("Address is specified in the wrong format. Error description: {}", e)
+        format!("Address is specified in the wrong format. Error description: {e}")
     })?;
     Ok(addr)
 }
@@ -127,7 +127,7 @@ pub fn now() -> u32 {
 pub fn now_ms() -> u64 {
     SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap_or_else(|e| panic!("failed to obtain system time: {}", e))
+        .unwrap_or_else(|e| panic!("failed to obtain system time: {e}"))
         .as_millis() as u64
 }
 
@@ -136,7 +136,7 @@ pub type TvmClient = Arc<ClientContext>;
 
 pub fn create_client_local() -> Result<TonClient, String> {
     let cli = ClientContext::new(ClientConfig::default())
-        .map_err(|e| format!("failed to create tonclient: {}", e))?;
+        .map_err(|e| format!("failed to create tonclient: {e}"))?;
     Ok(Arc::new(cli))
 }
 
@@ -162,7 +162,7 @@ pub fn create_client(config: &Config) -> Result<TonClient, String> {
     let modified_endpoints = get_server_endpoints(config);
     if !config.is_json {
         println!("Connecting to:\n\tUrl: {}", config.url);
-        println!("\tEndpoints: {:?}\n", modified_endpoints);
+        println!("\tEndpoints: {modified_endpoints:?}\n");
     }
     let endpoints_cnt = if resolve_net_name(&config.url).unwrap_or(config.url.clone()).eq(LOCALNET)
     {
@@ -195,7 +195,7 @@ pub fn create_client(config: &Config) -> Result<TonClient, String> {
         ..Default::default()
     };
     let cli =
-        ClientContext::new(cli_conf).map_err(|e| format!("failed to create tonclient: {}", e))?;
+        ClientContext::new(cli_conf).map_err(|e| format!("failed to create tonclient: {e}"))?;
     Ok(Arc::new(cli))
 }
 
@@ -203,7 +203,7 @@ pub fn create_client_verbose(config: &Config) -> Result<TonClient, String> {
     let level = debug_level_from_env();
     log::set_max_level(level);
     log::set_boxed_logger(Box::new(SimpleLogger))
-        .map_err(|e| format!("failed to init logger: {}", e))?;
+        .map_err(|e| format!("failed to init logger: {e}"))?;
     create_client(config)
 }
 
@@ -220,15 +220,15 @@ pub async fn query_raw(
     let filter = filter
         .map(serde_json::from_str)
         .transpose()
-        .map_err(|e| format!("Failed to parse filter field: {}", e))?;
+        .map_err(|e| format!("Failed to parse filter field: {e}"))?;
     let limit = limit
         .map(|s| s.parse::<u32>())
         .transpose()
-        .map_err(|e| format!("Failed to parse limit field: {}", e))?;
+        .map_err(|e| format!("Failed to parse limit field: {e}"))?;
     let order = order
         .map(serde_json::from_str)
         .transpose()
-        .map_err(|e| format!("Failed to parse order field: {}", e))?;
+        .map_err(|e| format!("Failed to parse order field: {e}"))?;
 
     let query = tvm_client::net::query_collection(
         context.clone(),
@@ -242,7 +242,7 @@ pub async fn query_raw(
         },
     )
     .await
-    .map_err(|e| format!("Failed to execute query: {}", e))?;
+    .map_err(|e| format!("Failed to execute query: {e}"))?;
 
     println!("{:#}", Value::Array(query.result));
     Ok(())
@@ -281,7 +281,7 @@ pub async fn query_message(ton: TonClient, message_id: &str) -> Result<String, S
         Some(1),
     )
     .await
-    .map_err(|e| format!("failed to query account data: {}", e))?;
+    .map_err(|e| format!("failed to query account data: {e}"))?;
     if messages.is_empty() {
         Err("message with specified id was not found.".to_string())
     } else {
@@ -337,7 +337,7 @@ pub async fn decode_msg_body(
         ton,
         ParamsOfDecodeMessageBody { abi, body: body.to_owned(), is_internal, ..Default::default() },
     )
-    .map_err(|e| format!("failed to decode body: {}", e))
+    .map_err(|e| format!("failed to decode body: {e}"))
 }
 
 pub async fn load_abi_str(abi_path: &str, config: &Config) -> Result<String, String> {
@@ -348,9 +348,9 @@ pub async fn load_abi_str(abi_path: &str, config: &Config) -> Result<String, Str
     if Url::parse(abi_path).is_ok() {
         let abi_bytes = load_file_with_url(abi_path, config.timeout as u64).await?;
         return String::from_utf8(abi_bytes)
-            .map_err(|e| format!("Downloaded string contains not valid UTF8 characters: {}", e));
+            .map_err(|e| format!("Downloaded string contains not valid UTF8 characters: {e}"));
     }
-    std::fs::read_to_string(abi_path).map_err(|e| format!("failed to read ABI file: {}", e))
+    std::fs::read_to_string(abi_path).map_err(|e| format!("failed to read ABI file: {e}"))
 }
 
 pub async fn load_abi(abi_path: &str, config: &Config) -> Result<Abi, String> {
@@ -360,7 +360,7 @@ pub async fn load_abi(abi_path: &str, config: &Config) -> Result<Abi, String> {
 
 pub async fn load_ton_abi(abi_path: &str, config: &Config) -> Result<tvm_abi::Contract, String> {
     let abi_str = load_abi_str(abi_path, config).await?;
-    tvm_abi::Contract::load(abi_str.as_bytes()).map_err(|e| format!("Failed to load ABI: {}", e))
+    tvm_abi::Contract::load(abi_str.as_bytes()).map_err(|e| format!("Failed to load ABI: {e}"))
 }
 
 pub async fn load_file_with_url(url: &str, timeout: u64) -> Result<Vec<u8>, String> {
@@ -393,7 +393,7 @@ pub async fn calc_acc_address(
         let init_data_json = init_data
             .map(serde_json::from_str)
             .transpose()
-            .map_err(|e| format!("initial data is not in json: {}", e))?;
+            .map_err(|e| format!("initial data is not in json: {e}"))?;
 
         DeploySet {
             tvc: Some(base64_encode(tvc)),
@@ -405,7 +405,7 @@ pub async fn calc_acc_address(
     } else {
         let init_data_json = insert_pubkey_to_init_data(pubkey.clone(), init_data)?;
         let js = serde_json::from_str(init_data_json.as_str())
-            .map_err(|e| format!("initial data is not in json: {}", e))?;
+            .map_err(|e| format!("initial data is not in json: {e}"))?;
         DeploySet {
             tvc: Some(base64_encode(tvc)),
             workchain_id: Some(wc),
@@ -428,7 +428,7 @@ pub async fn calc_acc_address(
         },
     )
     .await
-    .map_err(|e| format!("cannot generate address: {}", e))?;
+    .map_err(|e| format!("cannot generate address: {e}"))?;
     Ok(result.address)
 }
 
@@ -457,9 +457,9 @@ pub async fn print_message(
     println!("Id: {}", message["id"].as_str().unwrap_or("Undefined"));
     let value = message["value"].as_str().unwrap_or("0x0");
     let value = u64::from_str_radix(value.trim_start_matches("0x"), 16)
-        .map_err(|e| format!("failed to decode msg value: {}", e))?;
+        .map_err(|e| format!("failed to decode msg value: {e}"))?;
     let value: f64 = value as f64 / 1e9;
-    println!("Value: {:.9}", value);
+    println!("Value: {value:.9}");
     println!(
         "Created at: {} ({})",
         message["created_at"].as_u64().unwrap_or(0),
@@ -486,10 +486,10 @@ pub async fn print_message(
             (
                 result.name,
                 serde_json::to_string(&result.value)
-                    .map_err(|e| format!("failed to serialize the result: {}", e))?,
+                    .map_err(|e| format!("failed to serialize the result: {e}"))?,
             )
         };
-        println!("Decoded body:\n{} {}\n", name, args);
+        println!("Decoded body:\n{name} {args}\n");
         return Ok((name, args));
     }
     println!();
@@ -556,7 +556,7 @@ pub fn print_account(
             code_hash,
             state_init,
         );
-        println!("{:#}", acc);
+        println!("{acc:#}");
     } else {
         if acc_type.is_some() && acc_type.clone().unwrap() == "NonExist" {
             println!("Account does not exist.");
@@ -597,7 +597,7 @@ pub fn construct_account_from_tvc(
     Account::active_by_init_code_hash(
         match address {
             Some(address) => MsgAddressInt::from_str(address)
-                .map_err(|e| format!("Failed to set address: {}", e))?,
+                .map_err(|e| format!("Failed to set address: {e}"))?,
             _ => MsgAddressInt::default(),
         },
         match balance {
@@ -606,16 +606,16 @@ pub fn construct_account_from_tvc(
         },
         0,
         StateInit::construct_from_file(tvc_path)
-            .map_err(|e| format!(" failed to load TVC from the file {}: {}", tvc_path, e))?,
+            .map_err(|e| format!(" failed to load TVC from the file {tvc_path}: {e}"))?,
         true,
     )
-    .map_err(|e| format!(" failed to create account with the stateInit: {}", e))
+    .map_err(|e| format!(" failed to create account with the stateInit: {e}"))
 }
 
 pub fn check_dir(path: &str) -> Result<(), String> {
     if !path.is_empty() && !std::path::Path::new(path).exists() {
         std::fs::create_dir(path)
-            .map_err(|e| format!("Failed to create folder {}: {}", path, e))?;
+            .map_err(|e| format!("Failed to create folder {path}: {e}"))?;
     }
     Ok(())
 }
@@ -642,21 +642,21 @@ pub async fn load_account(
             let boc = query_account_field(ton_client.clone(), source, "boc").await?;
             Ok((
                 Account::construct_from_base64(&boc)
-                    .map_err(|e| format!("Failed to construct account: {}", e))?,
+                    .map_err(|e| format!("Failed to construct account: {e}"))?,
                 boc,
             ))
         }
         _ => {
             let account = if source_type == &AccountSource::BOC {
                 Account::construct_from_file(source).map_err(|e| {
-                    format!(" failed to load account from the file {}: {}", source, e)
+                    format!(" failed to load account from the file {source}: {e}")
                 })?
             } else {
                 construct_account_from_tvc(source, None, None)?
             };
             let account_bytes = account
                 .write_to_bytes()
-                .map_err(|e| format!(" failed to load data from the account: {}", e))?;
+                .map_err(|e| format!(" failed to load data from the account: {e}"))?;
             Ok((account, base64_encode(&account_bytes)))
         }
     }
@@ -697,7 +697,7 @@ pub fn abi_from_matches_or_config(matches: &ArgMatches, config: &Config) -> Resu
 pub fn parse_lifetime(lifetime: Option<&str>, config: &Config) -> Result<u32, String> {
     Ok(lifetime
         .map(|val| {
-            u32::from_str_radix(val, 10).map_err(|e| format!("failed to parse lifetime: {}", e))
+            u32::from_str_radix(val, 10).map_err(|e| format!("failed to parse lifetime: {e}"))
         })
         .transpose()?
         .unwrap_or(config.lifetime))
@@ -721,7 +721,7 @@ macro_rules! print_args {
 pub fn load_params(params: &str) -> Result<String, String> {
     if params.find('{').is_none() {
         std::fs::read_to_string(params)
-            .map_err(|e| format!("failed to load params from file: {}", e))
+            .map_err(|e| format!("failed to load params from file: {e}"))
     } else {
         Ok(params.to_string())
     }
@@ -746,7 +746,7 @@ pub fn wc_from_matches_or_config(matches: &ArgMatches, config: &Config) -> Resul
         .value_of("WC")
         .map(|v| i32::from_str_radix(v, 10))
         .transpose()
-        .map_err(|e| format!("failed to parse workchain id: {}", e))?
+        .map_err(|e| format!("failed to parse workchain id: {e}"))?
         .unwrap_or(config.wc))
 }
 
@@ -1071,7 +1071,7 @@ pub fn decode_data(data: &str, param_name: &str) -> Result<Vec<u8>, String> {
     } else if let Ok(data) = hex::decode(data) {
         Ok(data)
     } else {
-        Err(format!("the {} parameter should be base64 or hex encoded", param_name))
+        Err(format!("the {param_name} parameter should be base64 or hex encoded"))
     }
 }
 
@@ -1082,14 +1082,14 @@ pub fn insert_pubkey_to_init_data(
     let init_data = opt_init_data.unwrap_or("{}");
 
     let mut js_init_data = serde_json::from_str(init_data)
-        .map_err(|e| format!("Failed to decode initial data as json: {}", e))?;
+        .map_err(|e| format!("Failed to decode initial data as json: {e}"))?;
     match &mut js_init_data {
         Value::Object(obj) => {
             if obj.contains_key(&"_pubkey".to_string()) {
                 return Err("Public key was set via init data. Please, use command line options --genkey/--setkey to set public key.".to_owned());
             }
             if let Some(pk) = pubkey {
-                let pubkey_str = format!("0x{}", pk);
+                let pubkey_str = format!("0x{pk}");
                 obj.insert("_pubkey".to_string(), Value::String(pubkey_str));
             }
         }

--- a/tvm_cli/src/helpers.rs
+++ b/tvm_cli/src/helpers.rs
@@ -114,9 +114,8 @@ pub fn read_keys(filename: &str) -> Result<KeyPair, String> {
 pub fn load_ton_address(addr: &str, config: &Config) -> Result<String, String> {
     let addr =
         if addr.find(':').is_none() { format!("{}:{}", config.wc, addr) } else { addr.to_owned() };
-    let _ = MsgAddressInt::from_str(&addr).map_err(|e| {
-        format!("Address is specified in the wrong format. Error description: {e}")
-    })?;
+    let _ = MsgAddressInt::from_str(&addr)
+        .map_err(|e| format!("Address is specified in the wrong format. Error description: {e}"))?;
     Ok(addr)
 }
 
@@ -614,8 +613,7 @@ pub fn construct_account_from_tvc(
 
 pub fn check_dir(path: &str) -> Result<(), String> {
     if !path.is_empty() && !std::path::Path::new(path).exists() {
-        std::fs::create_dir(path)
-            .map_err(|e| format!("Failed to create folder {path}: {e}"))?;
+        std::fs::create_dir(path).map_err(|e| format!("Failed to create folder {path}: {e}"))?;
     }
     Ok(())
 }
@@ -648,9 +646,8 @@ pub async fn load_account(
         }
         _ => {
             let account = if source_type == &AccountSource::BOC {
-                Account::construct_from_file(source).map_err(|e| {
-                    format!(" failed to load account from the file {source}: {e}")
-                })?
+                Account::construct_from_file(source)
+                    .map_err(|e| format!(" failed to load account from the file {source}: {e}"))?
             } else {
                 construct_account_from_tvc(source, None, None)?
             };
@@ -720,8 +717,7 @@ macro_rules! print_args {
 
 pub fn load_params(params: &str) -> Result<String, String> {
     if params.find('{').is_none() {
-        std::fs::read_to_string(params)
-            .map_err(|e| format!("failed to load params from file: {e}"))
+        std::fs::read_to_string(params).map_err(|e| format!("failed to load params from file: {e}"))
     } else {
         Ok(params.to_string())
     }

--- a/tvm_cli/src/main.rs
+++ b/tvm_cli/src/main.rs
@@ -142,7 +142,7 @@ fn main() {
     let result = runtime.block_on(async move { main_internal().await });
     if let Err(err_str) = result {
         if !err_str.is_empty() {
-            println!("{}", err_str);
+            println!("{err_str}");
         }
         exit(1)
     }
@@ -1012,11 +1012,11 @@ async fn main_internal() -> Result<(), String> {
             exit(0);
         }
         clap::ErrorKind::DisplayHelp => {
-            println!("{}", e);
+            println!("{e}");
             exit(0);
         }
         _ => {
-            eprintln!("{}", e);
+            eprintln!("{e}");
             format!("{:#}", json!({"Error": e.to_string()}))
         }
     })?;
@@ -1249,7 +1249,7 @@ async fn body_command(matches: &ArgMatches, config: &Config) -> Result<(), Strin
     }
 
     let params = serde_json::from_str(&params.unwrap())
-        .map_err(|e| format!("arguments are not in json format: {}", e))?;
+        .map_err(|e| format!("arguments are not in json format: {e}"))?;
 
     let client = create_client_local()?;
     let body = tvm_client::abi::encode_message_body(
@@ -1263,14 +1263,14 @@ async fn body_command(matches: &ArgMatches, config: &Config) -> Result<(), Strin
         },
     )
     .await
-    .map_err(|e| format!("failed to encode body: {}", e))
+    .map_err(|e| format!("failed to encode body: {e}"))
     .map(|r| r.body)?;
 
     if !config.is_json {
-        println!("Message body: {}", body);
+        println!("Message body: {body}");
     } else {
         println!("{{");
-        println!("  \"Message\": \"{}\"", body);
+        println!("  \"Message\": \"{body}\"");
         println!("}}");
     }
 
@@ -1426,7 +1426,7 @@ async fn deploy_command(
         unpack_alternative_params(matches, abi.as_ref().unwrap(), "constructor", config).await?,
     );
     if !config.is_json {
-        let opt_wc = Some(format!("{}", wc));
+        let opt_wc = Some(format!("{wc}"));
         print_args!(tvc, params, abi, keys, opt_wc, alias);
     }
     match deploy_type {
@@ -1484,7 +1484,7 @@ async fn deployx_command(matches: &ArgMatches, full_config: &mut FullConfig) -> 
 
     let alias = matches.value_of("ALIAS");
     if !config.is_json {
-        let opt_wc = Some(format!("{}", wc));
+        let opt_wc = Some(format!("{wc}"));
         print_args!(tvc, params, abi, keys, opt_wc, alias);
     }
     deploy_contract(
@@ -1552,7 +1552,7 @@ fn config_command(
     println!(
         "{}",
         serde_json::to_string_pretty(&full_config.config)
-            .map_err(|e| format!("failed to print config parameters: {}", e))?
+            .map_err(|e| format!("failed to print config parameters: {e}"))?
     );
     result
 }
@@ -1601,7 +1601,7 @@ async fn account_command(matches: &ArgMatches, config: &Config) -> Result<(), St
             formatted_list.push(formatted);
         } else {
             if !std::path::Path::new(address).exists() {
-                return Err(format!("File {} doesn't exist.", address));
+                return Err(format!("File {address} doesn't exist."));
             }
             formatted_list.push(address.to_string());
         }
@@ -1637,7 +1637,7 @@ async fn account_wait_command(matches: &ArgMatches, config: &Config) -> Result<(
         .value_of("TIMEOUT")
         .unwrap_or("30")
         .parse::<u64>()
-        .map_err(|e| format!("failed to parse timeout: {}", e))?;
+        .map_err(|e| format!("failed to parse timeout: {e}"))?;
     wait_for_change(config, &address, timeout).await
 }
 
@@ -1659,7 +1659,7 @@ async fn storage_command(matches: &ArgMatches, config: &Config) -> Result<(), St
     let address = load_ton_address(address.unwrap(), config)?;
     let period = period
         .map(|val| {
-            u32::from_str_radix(val, 10).map_err(|e| format!("failed to parse period: {}", e))
+            u32::from_str_radix(val, 10).map_err(|e| format!("failed to parse period: {e}"))
         })
         .transpose()?
         .unwrap_or(DEF_STORAGE_PERIOD);
@@ -1759,22 +1759,22 @@ fn nodeid_command(matches: &ArgMatches, config: &Config) -> Result<(), String> {
         print_args!(key, keypair);
     }
     let nodeid = if let Some(key) = key {
-        let vec = hex::decode(key).map_err(|e| format!("failed to decode public key: {}", e))?;
+        let vec = hex::decode(key).map_err(|e| format!("failed to decode public key: {e}"))?;
         convert::nodeid_from_pubkey(&vec)?
     } else if let Some(pair) = keypair {
         let pair = crypto::load_keypair(pair)?;
         convert::nodeid_from_pubkey(
             &hex::decode(&pair.public)
-                .map_err(|e| format!("failed to decode public key: {}", e))?,
+                .map_err(|e| format!("failed to decode public key: {e}"))?,
         )?
     } else {
         return Err("Either public key or key pair parameter should be provided".to_owned());
     };
     if !config.is_json {
-        println!("{}", nodeid);
+        println!("{nodeid}");
     } else {
         println!("{{");
-        println!("  \"nodeid\": \"{}\"", nodeid);
+        println!("  \"nodeid\": \"{nodeid}\"");
         println!("}}");
     }
     Ok(())

--- a/tvm_cli/src/main.rs
+++ b/tvm_cli/src/main.rs
@@ -1658,9 +1658,7 @@ async fn storage_command(matches: &ArgMatches, config: &Config) -> Result<(), St
     }
     let address = load_ton_address(address.unwrap(), config)?;
     let period = period
-        .map(|val| {
-            u32::from_str_radix(val, 10).map_err(|e| format!("failed to parse period: {e}"))
-        })
+        .map(|val| u32::from_str_radix(val, 10).map_err(|e| format!("failed to parse period: {e}")))
         .transpose()?
         .unwrap_or(DEF_STORAGE_PERIOD);
     calc_storage(config, address.as_str(), period).await
@@ -1764,8 +1762,7 @@ fn nodeid_command(matches: &ArgMatches, config: &Config) -> Result<(), String> {
     } else if let Some(pair) = keypair {
         let pair = crypto::load_keypair(pair)?;
         convert::nodeid_from_pubkey(
-            &hex::decode(&pair.public)
-                .map_err(|e| format!("failed to decode public key: {e}"))?,
+            &hex::decode(&pair.public).map_err(|e| format!("failed to decode public key: {e}"))?,
         )?
     } else {
         return Err("Either public key or key pair parameter should be provided".to_owned());

--- a/tvm_cli/src/message.rs
+++ b/tvm_cli/src/message.rs
@@ -127,8 +127,7 @@ pub fn pack_message(msg: &EncodedMessage, method: &str, is_raw: bool) -> Result<
 pub fn unpack_message(str_msg: &str) -> Result<(EncodedMessage, String), String> {
     let bytes = hex::decode(str_msg).map_err(|e| format!("couldn't unpack message: {e}"))?;
 
-    let str_msg =
-        std::str::from_utf8(&bytes).map_err(|e| format!("message is corrupted: {e}"))?;
+    let str_msg = std::str::from_utf8(&bytes).map_err(|e| format!("message is corrupted: {e}"))?;
 
     let json_msg: serde_json::Value =
         serde_json::from_str(str_msg).map_err(|e| format!("couldn't decode message: {e}"))?;

--- a/tvm_cli/src/message.rs
+++ b/tvm_cli/src/message.rs
@@ -53,7 +53,7 @@ pub async fn prepare_message(
 
     let msg = encode_message(ton, msg_params)
         .await
-        .map_err(|e| format!("failed to create inbound message: {}", e))?;
+        .map_err(|e| format!("failed to create inbound message: {e}"))?;
 
     Ok(EncodedMessage {
         message: msg.message,
@@ -73,7 +73,7 @@ pub fn prepare_message_params(
 ) -> Result<ParamsOfEncodeMessage, String> {
     let keys = keys.map(|k| load_keypair(&k)).transpose()?;
     let params = serde_json::from_str(params)
-        .map_err(|e| format!("arguments are not in json format: {}", e))?;
+        .map_err(|e| format!("arguments are not in json format: {e}"))?;
 
     let call_set =
         Some(CallSet { function_name: method.into(), input: Some(params), header: header.clone() });
@@ -97,16 +97,16 @@ pub fn print_encoded_message(msg: &EncodedMessage, is_json: bool) {
     if !is_json {
         println!();
         println!("MessageId: {}", msg.message_id);
-        println!("Expire at: {}", expire);
+        println!("Expire at: {expire}");
     } else {
         println!("  \"MessageId\": \"{}\",", msg.message_id);
-        println!("  \"Expire at\": \"{}\",", expire);
+        println!("  \"Expire at\": \"{expire}\",");
     }
 }
 
 pub fn pack_message(msg: &EncodedMessage, method: &str, is_raw: bool) -> Result<Vec<u8>, String> {
     let res = if is_raw {
-        base64_decode(&msg.message).map_err(|e| format!("failed to decode message: {}", e))?
+        base64_decode(&msg.message).map_err(|e| format!("failed to decode message: {e}"))?
     } else {
         let json_msg = json!({
             "msg": {
@@ -118,20 +118,20 @@ pub fn pack_message(msg: &EncodedMessage, method: &str, is_raw: bool) -> Result<
             "method": method,
         });
         serde_json::to_string(&json_msg)
-            .map_err(|e| format!("failed to serialize message: {}", e))?
+            .map_err(|e| format!("failed to serialize message: {e}"))?
             .into_bytes()
     };
     Ok(res)
 }
 
 pub fn unpack_message(str_msg: &str) -> Result<(EncodedMessage, String), String> {
-    let bytes = hex::decode(str_msg).map_err(|e| format!("couldn't unpack message: {}", e))?;
+    let bytes = hex::decode(str_msg).map_err(|e| format!("couldn't unpack message: {e}"))?;
 
     let str_msg =
-        std::str::from_utf8(&bytes).map_err(|e| format!("message is corrupted: {}", e))?;
+        std::str::from_utf8(&bytes).map_err(|e| format!("message is corrupted: {e}"))?;
 
     let json_msg: serde_json::Value =
-        serde_json::from_str(str_msg).map_err(|e| format!("couldn't decode message: {}", e))?;
+        serde_json::from_str(str_msg).map_err(|e| format!("couldn't decode message: {e}"))?;
 
     let method =
         json_msg["method"].as_str().ok_or(r#"couldn't find "method" key in message"#)?.to_owned();
@@ -168,7 +168,7 @@ pub async fn generate_message(
     let ton = create_client_local()?;
 
     let ton_addr =
-        load_ton_address(addr, config).map_err(|e| format!("failed to parse address: {}", e))?;
+        load_ton_address(addr, config).map_err(|e| format!("failed to parse address: {e}"))?;
 
     let abi = load_abi(abi, config).await?;
 
@@ -208,21 +208,21 @@ pub fn display_generated_message(
     if output.is_some() {
         let out_file = output.unwrap();
         std::fs::write(out_file, msg_bytes)
-            .map_err(|e| format!("cannot write message to file: {}", e))?;
+            .map_err(|e| format!("cannot write message to file: {e}"))?;
         if !is_json {
-            println!("Message saved to file {}", out_file);
+            println!("Message saved to file {out_file}");
         } else {
-            println!("  \"Message\": \"saved to file {}\"", out_file);
+            println!("  \"Message\": \"saved to file {out_file}\"");
         }
     } else {
         let msg_hex = hex::encode(&msg_bytes);
         if !is_json {
-            println!("Message: {}", msg_hex);
+            println!("Message: {msg_hex}");
             println!();
-            qr2term::print_qr(msg_hex).map_err(|e| format!("failed to print QR code: {}", e))?;
+            qr2term::print_qr(msg_hex).map_err(|e| format!("failed to print QR code: {e}"))?;
             println!();
         } else {
-            println!("  \"Message\": \"{}\"", msg_hex);
+            println!("  \"Message\": \"{msg_hex}\"");
         }
     }
     if is_json {

--- a/tvm_cli/src/multisig.rs
+++ b/tvm_cli/src/multisig.rs
@@ -262,7 +262,7 @@ impl CallArgs {
                 .replace(['[', ']', '\"', '\''], "")
                 .replace("0x", "")
                 .split(',')
-                .map(|o| format!("0x{}", o))
+                .map(|o| format!("0x{o}"))
                 .collect::<Vec<String>>()
         });
 
@@ -480,7 +480,7 @@ pub async fn encode_transfer_body(text: &str) -> Result<String, String> {
         },
     )
     .await
-    .map_err(|e| format!("failed to encode transfer body: {}", e))
+    .map_err(|e| format!("failed to encode transfer body: {e}"))
     .map(|r| r.body)
 }
 
@@ -513,13 +513,13 @@ async fn multisig_deploy_command(matches: &ArgMatches, config: &Config) -> Resul
     .await?;
 
     if !config.is_json {
-        println!("Wallet address: {}", address);
+        println!("Wallet address: {address}");
     }
 
     let ton = create_client_verbose(config)?;
 
     if let Some(value) = matches.value_of("VALUE") {
-        let params = format!(r#"{{"dest":"{}","amount":"{}"}}"#, address, value);
+        let params = format!(r#"{{"dest":"{address}","amount":"{value}"}}"#);
         call::call_contract_with_client(
             ton.clone(),
             config,
@@ -534,7 +534,7 @@ async fn multisig_deploy_command(matches: &ArgMatches, config: &Config) -> Resul
         .await?;
     }
 
-    let res = call::process_message(ton.clone(), msg, config).await.map_err(|e| format!("{:#}", e));
+    let res = call::process_message(ton.clone(), msg, config).await.map_err(|e| format!("{e:#}"));
 
     if res.is_err() {
         if res.clone().err().unwrap().contains("Account does not exist.") {
@@ -547,7 +547,7 @@ async fn multisig_deploy_command(matches: &ArgMatches, config: &Config) -> Resul
                 println!(
                     "  \"Error\": \"Your account should have initial balance for deployment. Please transfer some value to your wallet address before deploy.\","
                 );
-                println!("  \"Address\": \"{}\"", address);
+                println!("  \"Address\": \"{address}\"");
                 println!("}}");
             }
             return Ok(());
@@ -557,10 +557,10 @@ async fn multisig_deploy_command(matches: &ArgMatches, config: &Config) -> Resul
 
     if !config.is_json {
         println!("Wallet successfully deployed");
-        println!("Wallet address: {}", address);
+        println!("Wallet address: {address}");
     } else {
         println!("{{");
-        println!("  \"Address\": \"{}\"", address);
+        println!("  \"Address\": \"{address}\"");
         println!("}}");
     }
 

--- a/tvm_cli/src/replay.rs
+++ b/tvm_cli/src/replay.rs
@@ -517,10 +517,8 @@ pub async fn replay(
             let local_desc = tr_local
                 .read_description()
                 .map_err(|e| format!("failed to read description: {e}"))?;
-            let remote_desc = tr
-                .tr
-                .read_description()
-                .map_err(|e| format!("failed to read description: {e}"))?;
+            let remote_desc =
+                tr.tr.read_description().map_err(|e| format!("failed to read description: {e}"))?;
             assert_eq!(remote_desc, local_desc);
             exit(2);
         }

--- a/tvm_cli/src/run.rs
+++ b/tvm_cli/src/run.rs
@@ -79,7 +79,7 @@ pub async fn run_command(
     };
     let trace_path;
     let ton_client = if account_source == AccountSource::NETWORK {
-        trace_path = format!("run_{}_{}.log", address, method);
+        trace_path = format!("run_{address}_{method}.log");
         create_client(config)?
     } else {
         trace_path = "trace.log".to_string();
@@ -188,7 +188,7 @@ async fn run(
             };
             init_debug_logger(&trace_path)?;
             debug_error(&e, debug_params).await?;
-            return Err(format!("{:#}", e));
+            return Err(format!("{e:#}"));
         }
     };
     if !config.is_json {
@@ -248,7 +248,7 @@ pub async fn run_get_method(
     let params = params
         .map(|p| serde_json::from_str(&p))
         .transpose()
-        .map_err(|e| format!("arguments are not in json format: {}", e))?;
+        .map_err(|e| format!("arguments are not in json format: {e}"))?;
 
     if !config.is_json {
         println!("Running get-method...");
@@ -265,19 +265,19 @@ pub async fn run_get_method(
         },
     )
     .await
-    .map_err(|e| format!("run failed: {}", e))?
+    .map_err(|e| format!("run failed: {e}"))?
     .output;
 
     if !config.is_json {
         println!("Succeeded.");
-        println!("Result: {}", result);
+        println!("Result: {result}");
     } else {
         let mut res = Map::new();
         match result {
             Value::Array(array) => {
                 let mut i = 0;
                 for val in array.iter() {
-                    res.insert(format!("value{}", i), val.to_owned());
+                    res.insert(format!("value{i}"), val.to_owned());
                     i += 1;
                 }
             }
@@ -286,7 +286,7 @@ pub async fn run_get_method(
             }
         }
         let res = Value::Object(res);
-        println!("{:#}", res);
+        println!("{res:#}");
     }
     Ok(())
 }

--- a/tvm_cli/src/sendfile.rs
+++ b/tvm_cli/src/sendfile.rs
@@ -16,13 +16,13 @@ use crate::helpers::create_client_verbose;
 
 pub async fn sendfile(config: &Config, msg_boc: &str) -> Result<(), String> {
     let ton = create_client_verbose(config)?;
-    let boc_vec = std::fs::read(msg_boc).map_err(|e| format!("failed to read boc file: {}", e))?;
+    let boc_vec = std::fs::read(msg_boc).map_err(|e| format!("failed to read boc file: {e}"))?;
     let tvm_msg = tvm_sdk::Contract::deserialize_message(&boc_vec[..])
-        .map_err(|e| format!("failed to parse message from boc: {}", e))?;
+        .map_err(|e| format!("failed to parse message from boc: {e}"))?;
     let dst = tvm_msg.dst().ok_or("failed to parse dst address".to_string())?;
 
     if !config.is_json {
-        println!("Sending message to account {}", dst);
+        println!("Sending message to account {dst}");
     }
     send_message_and_wait(ton, None, base64_encode(&boc_vec), config).await?;
     if !config.is_json {

--- a/tvm_cli/src/test.rs
+++ b/tvm_cli/src/test.rs
@@ -257,7 +257,7 @@ async fn test_deploy(matches: &ArgMatches, config: &Config) -> Result<(), String
         ..Default::default()
     });
     let params = serde_json::from_str(&load_params(&params)?)
-        .map_err(|e| format!("function arguments is not a json: {}", e))?;
+        .map_err(|e| format!("function arguments is not a json: {e}"))?;
     let header = Some(FunctionHeader { time: Some(now), ..Default::default() });
     let call_set =
         Some(CallSet { function_name, input: Some(params), header, ..Default::default() });
@@ -328,9 +328,9 @@ async fn test_deploy(matches: &ArgMatches, config: &Config) -> Result<(), String
     let output = PathBuf::from(input).with_extension("boc");
     account
         .write_to_file(&output)
-        .map_err(|e| format!("Failed write to file {:?}: {e}", output))?;
+        .map_err(|e| format!("Failed write to file {output:?}: {e}"))?;
     if !config.is_json {
-        println!("Account written to {:?}", output);
+        println!("Account written to {output:?}");
     }
     Ok(())
 }
@@ -375,9 +375,9 @@ async fn test_ticktock(matches: &ArgMatches, config: &Config) -> Result<(), Stri
     }
     let account = Account::construct_from_cell(account_root)
         .map_err(|e| format!("Failed to construct Account after transaction: {e}"))?;
-    account.write_to_file(input).map_err(|e| format!("Failed write to file {:?}: {e}", input))?;
+    account.write_to_file(input).map_err(|e| format!("Failed write to file {input:?}: {e}"))?;
     if !config.is_json {
-        println!("Account written to {:?}", input);
+        println!("Account written to {input:?}");
     }
     Ok(())
 }
@@ -388,7 +388,7 @@ pub fn test_sign_command(matches: &ArgMatches, config: &Config) -> Result<(), St
     } else if let Some(data) = matches.value_of("CELL") {
         let data = decode_data(data, "cell")?;
         let cell = read_single_root_boc(data)
-            .map_err(|err| format!("Cannot deserialize tree of cells {}", err))?;
+            .map_err(|err| format!("Cannot deserialize tree of cells {err}"))?;
         if cell.references_count() == 0 && (cell.bit_length() % 8) == 0 {
             // sign data
             cell.data().to_vec()
@@ -405,7 +405,7 @@ pub fn test_sign_command(matches: &ArgMatches, config: &Config) -> Result<(), St
             None => return Err("nor signing keys in the params neither in the config".to_string()),
         },
     };
-    let key = pair.decode().map_err(|err| format!("cannot decode keypair {}", err))?;
+    let key = pair.decode().map_err(|err| format!("cannot decode keypair {err}"))?;
     let signature = ed25519_sign_with_secret(&key.to_bytes(), &data)
         .map_err(|e| format!("Failed to sign: {e}"))?;
     let signature = base64_encode(signature.as_ref());
@@ -415,9 +415,9 @@ pub fn test_sign_command(matches: &ArgMatches, config: &Config) -> Result<(), St
             "public": hex::encode(pair.public.as_bytes()),
             "Signature": signature
         });
-        println!("{:#}", result);
+        println!("{result:#}");
     } else {
-        println!("Signature: {}", signature);
+        println!("Signature: {signature}");
     }
 
     Ok(())
@@ -434,7 +434,7 @@ pub fn test_config_command(matches: &ArgMatches, config: &Config) -> Result<(), 
         if config.is_json {
             println!("{:#}", json!({ "Cell": cell, "index": index }));
         } else {
-            println!("Cell: \"{}\"", cell);
+            println!("Cell: \"{cell}\"");
         }
     } else if let Some(decode) = matches.value_of("DECODE") {
         let bytes = std::fs::read(decode).unwrap();
@@ -458,7 +458,7 @@ pub fn test_config_command(matches: &ArgMatches, config: &Config) -> Result<(), 
             tvm_block_json::serialize_config_param(&params, 0)
                 .map_err(|e| format!("Failed to serialize config params: {e}"))?
         };
-        println!("{}", result);
+        println!("{result}");
     }
     Ok(())
 }

--- a/tvm_cli/src/test.rs
+++ b/tvm_cli/src/test.rs
@@ -326,9 +326,7 @@ async fn test_deploy(matches: &ArgMatches, config: &Config) -> Result<(), String
         account.set_addr(addr);
     }
     let output = PathBuf::from(input).with_extension("boc");
-    account
-        .write_to_file(&output)
-        .map_err(|e| format!("Failed write to file {output:?}: {e}"))?;
+    account.write_to_file(&output).map_err(|e| format!("Failed write to file {output:?}: {e}"))?;
     if !config.is_json {
         println!("Account written to {output:?}");
     }

--- a/tvm_cli/src/voting.rs
+++ b/tvm_cli/src/voting.rs
@@ -135,7 +135,7 @@ pub async fn decode_proposal(config: &Config, addr: &str, proposal_id: &str) -> 
             let ton = create_client_local()?;
             let result = decode_msg_body(ton.clone(), TRANSFER_WITH_COMMENT, body, true, config)
                 .await
-                .map_err(|e| format!("failed to decode proposal payload: {}", e))?;
+                .map_err(|e| format!("failed to decode proposal payload: {e}"))?;
 
             let comment = String::from_utf8(
                 hex::decode(
@@ -143,25 +143,25 @@ pub async fn decode_proposal(config: &Config, addr: &str, proposal_id: &str) -> 
                         .as_str()
                         .ok_or("failed to obtain result comment")?,
                 )
-                .map_err(|e| format!("failed to parse comment from transaction payload: {}", e))?,
+                .map_err(|e| format!("failed to parse comment from transaction payload: {e}"))?,
             )
-            .map_err(|e| format!("failed to convert comment to string: {}", e))?;
+            .map_err(|e| format!("failed to convert comment to string: {e}"))?;
 
             if !config.is_json {
-                println!("Comment: {}", comment);
+                println!("Comment: {comment}");
             } else {
                 println!("{{");
-                println!("  \"Comment\": \"{}\"", comment);
+                println!("  \"Comment\": \"{comment}\"");
                 println!("}}");
             }
             return Ok(());
         }
     }
     if !config.is_json {
-        println!("Proposal with id {} not found", proposal_id);
+        println!("Proposal with id {proposal_id} not found");
     } else {
         println!("{{");
-        println!("  \"Error\": \"Proposal with id {} not found\"", proposal_id);
+        println!("  \"Error\": \"Proposal with id {proposal_id} not found\"");
         println!("}}");
     }
     Ok(())

--- a/tvm_cli/tests/_network_test.rs
+++ b/tvm_cli/tests/_network_test.rs
@@ -37,7 +37,7 @@ fn test_network() -> Result<(), Box<dyn std::error::Error>> {
         .arg("--sign")
         .arg(GIVER_V2_KEY)
         .arg("sendTransaction")
-        .arg(format!(r#"{{"dest":"{}","value":10000000,"bounce":false}}"#, GIVER_V2_ADDR))
+        .arg(format!(r#"{{"dest":"{GIVER_V2_ADDR}","value":10000000,"bounce":false}}"#))
         .assert();
     let res = res.get_output().stdout.clone();
     let res = String::from_utf8(res);

--- a/tvm_cli/tests/browser.rs
+++ b/tvm_cli/tests/browser.rs
@@ -14,9 +14,9 @@ use common::grep_address;
 
 fn get_debot_paths(name: &str) -> (String, String, String) {
     (
-        format!("tests/samples/{}.tvc", name),
-        format!("tests/samples/{}.abi.json", name),
-        format!("tests/{}.keys.json", name),
+        format!("tests/samples/{name}.tvc"),
+        format!("tests/samples/{name}.abi.json"),
+        format!("tests/{name}.keys.json"),
     )
 }
 
@@ -70,7 +70,7 @@ fn test_signing_box_interface() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut cmd = Command::cargo_bin(BIN_NAME)?;
     cmd.timeout(std::time::Duration::from_secs(2))
-        .write_stdin(format!("y\n{}", keys))
+        .write_stdin(format!("y\n{keys}"))
         .arg("debot")
         .arg("fetch")
         .arg(&addr);
@@ -104,7 +104,7 @@ fn test_userinfo() -> Result<(), Box<dyn std::error::Error>> {
         .arg(keys)
         .arg(&addr)
         .arg("setParams")
-        .arg(format!(r#"{{"wallet":"{}","key":"{}"}}"#, wallet, key));
+        .arg(format!(r#"{{"wallet":"{wallet}","key":"{key}"}}"#));
     cmd.assert().success();
 
     let mut cmd = Command::cargo_bin(BIN_NAME)?;
@@ -162,7 +162,7 @@ fn test_encryptionboxes() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut cmd = Command::cargo_bin(BIN_NAME)?;
     cmd.timeout(std::time::Duration::from_secs(2))
-        .write_stdin(format!("y\n{}\n{}\n{}", keys, keys, keys))
+        .write_stdin(format!("y\n{keys}\n{keys}\n{keys}"))
         .arg("debot")
         .arg("fetch")
         .arg(&addr);

--- a/tvm_cli/tests/common/mod.rs
+++ b/tvm_cli/tests/common/mod.rs
@@ -61,7 +61,7 @@ pub fn giver(addr: &str) {
         .arg(GIVER_ABI)
         .arg(GIVER_ADDR)
         .arg("sendGrams")
-        .arg(format!(r#"{{"dest":"{}","amount":1000000000}}"#, addr));
+        .arg(format!(r#"{{"dest":"{addr}","amount":1000000000}}"#));
     cmd.assert().success();
 }
 
@@ -75,7 +75,7 @@ pub fn giver_v2(addr: &str) {
         .arg("--sign")
         .arg(GIVER_V2_KEY)
         .arg("sendTransaction")
-        .arg(format!(r#"{{"dest":"{}","value":100000000000,"bounce":false}}"#, addr));
+        .arg(format!(r#"{{"dest":"{addr}","value":100000000000,"bounce":false}}"#));
     cmd.assert().success();
 }
 
@@ -89,7 +89,7 @@ pub fn giver_v3(addr: &str) {
         .arg("--sign")
         .arg(GIVER_V3_KEY)
         .arg("sendTransaction")
-        .arg(format!(r#"{{"dest":"{}","value":100000000000,"bounce":false}}"#, addr));
+        .arg(format!(r#"{{"dest":"{addr}","value":100000000000,"bounce":false}}"#));
     cmd.assert().success();
 }
 

--- a/tvm_cli/tests/json_output_test.rs
+++ b/tvm_cli/tests/json_output_test.rs
@@ -181,9 +181,7 @@ fn test_json_output_4() -> Result<(), Box<dyn std::error::Error>> {
     run_command_and_decode_json(&format!(
         "decode msg tests/samples/wallet.boc --abi {DEPOOL_ABI}"
     ))?;
-    run_command_and_decode_json(&format!(
-        "decode msg tests/account_fift.tvc --abi {DEPOOL_ABI}"
-    ))?;
+    run_command_and_decode_json(&format!("decode msg tests/account_fift.tvc --abi {DEPOOL_ABI}"))?;
     run_command_and_decode_json(&format!(
         "decode body te6ccgEBAQEARAAAgwAAALqUCTqWL8OX7JivfJrAAzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMQAAAAAAAAAAAAAAAEeGjADA== --abi {DEPOOL_ABI}"
     ))?;

--- a/tvm_cli/tests/json_output_test.rs
+++ b/tvm_cli/tests/json_output_test.rs
@@ -26,7 +26,7 @@ fn _run_command_and_decode_json(
     local_node: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin(BIN_NAME)?;
-    println!("Command: {}", command);
+    println!("Command: {command}");
     cmd.arg("-j");
     if local_node {
         cmd.arg("--url").arg(&*NETWORK);
@@ -36,31 +36,28 @@ fn _run_command_and_decode_json(
         .output()
         .expect("Failed to execute command.");
 
-    println!("OUT: {:?}", out);
+    println!("OUT: {out:?}");
 
     let out = core::str::from_utf8(&out.stdout)
-        .map_err(|e| format!("Failed to decode command output: {}", e))?;
+        .map_err(|e| format!("Failed to decode command output: {e}"))?;
 
-    println!("OUT: {}", out);
+    println!("OUT: {out}");
     let _: Value =
-        serde_json::from_str(out).map_err(|e| format!("Failed to decode output as json: {}", e))?;
+        serde_json::from_str(out).map_err(|e| format!("Failed to decode output as json: {e}"))?;
     Ok(())
 }
 
 #[test]
 fn test_json_output_1() -> Result<(), Box<dyn std::error::Error>> {
-    run_command_and_decode_json(&format!("account {}", GIVER_V2_ADDR))?;
+    run_command_and_decode_json(&format!("account {GIVER_V2_ADDR}"))?;
     run_command_and_decode_json(&format!(
-        "body --abi {} addOrdinaryStake {{\"stake\":65535}}",
-        DEPOOL_ABI
+        "body --abi {DEPOOL_ABI} addOrdinaryStake {{\"stake\":65535}}"
     ))?;
     run_command_and_decode_json(&format!(
-        "call {} sendGrams {{\"dest\":\"{}\",\"amount\":1111111}} --abi {}",
-        GIVER_ADDR, GIVER_ADDR, GIVER_ABI
+        "call {GIVER_ADDR} sendGrams {{\"dest\":\"{GIVER_ADDR}\",\"amount\":1111111}} --abi {GIVER_ABI}"
     ))?;
     run_command_and_decode_json(&format!(
-        "callx --addr {} sendGrams --dest {} --amount 1111111 --abi {}",
-        GIVER_ADDR, GIVER_ADDR, GIVER_ABI
+        "callx --addr {GIVER_ADDR} sendGrams --dest {GIVER_ADDR} --amount 1111111 --abi {GIVER_ABI}"
     ))?;
     run_command_and_decode_json(r#"config endpoint add randomurl randomendpoint"#)?;
     run_command_and_decode_json(r#"config endpoint print"#)?;
@@ -81,36 +78,32 @@ fn test_json_output_2() -> Result<(), Box<dyn std::error::Error>> {
     run_command_and_decode_json(
         r#"decode body te6ccgEBAQEARAAAgwAAALqUCTqWL8OX7JivfJrAAzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMQAAAAAAAAAAAAAAAEeGjADA== --abi tests/samples/wallet.abi.json"#,
     )?;
-    run_command_and_decode_json(&format!("decode stateinit {}", GIVER_ADDR))?;
+    run_command_and_decode_json(&format!("decode stateinit {GIVER_ADDR}"))?;
     run_command_and_decode_json(
         r#"decode account data --abi tests/test_abi_v2.1.abi.json --tvc tests/decode_fields.tvc"#,
     )?;
     run_command_and_decode_json(r#"decode account boc tests/account.boc"#)?;
     run_command_and_decode_json(&format!(
-        "fee deploy --abi {} --sign {} {} {{}}",
-        DEPOOL_ABI, key_path, DEPOOL_TVC
+        "fee deploy --abi {DEPOOL_ABI} --sign {key_path} {DEPOOL_TVC} {{}}"
     ))?;
     run_command_and_decode_json(&format!(
-        "deploy --abi {} --sign {} {} {{}}",
-        DEPOOL_ABI, key_path, DEPOOL_TVC
+        "deploy --abi {DEPOOL_ABI} --sign {key_path} {DEPOOL_TVC} {{}}"
     ))?;
 
     let depool_addr = generate_key_and_address(key_path, DEPOOL_TVC, DEPOOL_ABI)?;
     giver_v3(&depool_addr);
     run_command_and_decode_json(&format!(
-        "deployx --abi {} --keys {} {}",
-        DEPOOL_ABI, key_path, DEPOOL_TVC
+        "deployx --abi {DEPOOL_ABI} --keys {key_path} {DEPOOL_TVC}"
     ))?;
     run_command_and_decode_json(&format!(
-        "deploy_message --raw --abi {} -o fakeDepool.msg --sign {} {} {{}}",
-        DEPOOL_ABI, key_path, DEPOOL_TVC
+        "deploy_message --raw --abi {DEPOOL_ABI} -o fakeDepool.msg --sign {key_path} {DEPOOL_TVC} {{}}"
     ))?;
     run_command_and_decode_json(
         r#"dump account 841288ed3b55d9cdafa806807f02a0ae0c169aa5edfe88a789a6482429756a94"#,
     )?;
-    let command = format!("run --abi {} {} getData {{}}", DEPOOL_ABI, depool_addr);
+    let command = format!("run --abi {DEPOOL_ABI} {depool_addr} getData {{}}");
     run_command_and_decode_json(&command)?;
-    let command = format!("runx --abi {} --addr {} getData ", DEPOOL_ABI, depool_addr);
+    let command = format!("runx --abi {DEPOOL_ABI} --addr {depool_addr} getData ");
     run_command_and_decode_json(&command)?;
 
     fs::remove_file(key_path)?;
@@ -130,10 +123,9 @@ fn test_json_output_3() -> Result<(), Box<dyn std::error::Error>> {
     _run_command_and_decode_json(r#"-c 123.conf --url net.ton.dev getconfig 1"#, false)?;
     _run_command_and_decode_json(r#"-c 123.conf --url net.ton.dev getconfig"#, false)?;
     fs::remove_file("123.conf")?;
-    run_command_and_decode_json(&format!("fee storage {}", GIVER_ADDR))?;
+    run_command_and_decode_json(&format!("fee storage {GIVER_ADDR}"))?;
     run_command_and_decode_json(&format!(
-        "fee call {} sendGrams {{\"dest\":\"{}\",\"amount\":1111111}} --abi {}",
-        GIVER_ADDR, GIVER_ADDR, GIVER_ABI
+        "fee call {GIVER_ADDR} sendGrams {{\"dest\":\"{GIVER_ADDR}\",\"amount\":1111111}} --abi {GIVER_ABI}"
     ))?;
     run_command_and_decode_json(
         r#"genaddr tests/samples/wallet.tvc --genkey tests/json_test1.key"#,
@@ -150,20 +142,18 @@ fn test_json_output_3() -> Result<(), Box<dyn std::error::Error>> {
     run_command_and_decode_json(
         r#"message 0:841288ed3b55d9cdafa806807f02a0ae0c169aa5edfe88a789a6482429756a94 sendTransaction {"dest":"0:841288ed3b55d9cdafa806807f02a0ae0c169aa5edfe88a789a6482429756a94","value":1000000000,"bounce":true} --abi tests/samples/wallet.abi.json --raw"#,
     )?;
-    run_command_and_decode_json(&format!("multisig deploy -k {} -l 1000000000", key_path))?;
+    run_command_and_decode_json(&format!("multisig deploy -k {key_path} -l 1000000000"))?;
     run_command_and_decode_json(
         r#"nodeid --pubkey cde8fbf86c44e4ed2095f83b6f3c97b7aec55a77e06e843f8b9ffeab66ad4b32"#,
     )?;
     run_command_and_decode_json(r#"nodeid --keypair tests/samples/exp.json"#)?;
     run_command_and_decode_json(&format!(
-        "proposal vote 0:28a3738f08f5b3410e92aab20f702d64160e2891aaaed881f27d59ff518078d1 12313 {}",
-        key_path
+        "proposal vote 0:28a3738f08f5b3410e92aab20f702d64160e2891aaaed881f27d59ff518078d1 12313 {key_path}"
     ))?;
     run_command_and_decode_json(r#"runget --boc tests/account_fift.boc past_election_ids"#)?;
     run_command_and_decode_json(r#"sendfile fakeDepool1.msg"#)?;
     run_command_and_decode_json(&format!(
-        "debug call {} sendGrams {{\"dest\":\"{}\",\"amount\":1111111}} --abi {} -c tests/config.boc",
-        GIVER_ADDR, GIVER_ADDR, GIVER_ABI
+        "debug call {GIVER_ADDR} sendGrams {{\"dest\":\"{GIVER_ADDR}\",\"amount\":1111111}} --abi {GIVER_ABI} -c tests/config.boc"
     ))?;
     run_command_and_decode_json("convert tokens 0.123456789")?;
     run_command_and_decode_json("version")?;
@@ -178,30 +168,24 @@ fn test_json_output_4() -> Result<(), Box<dyn std::error::Error>> {
         "account 841288ed3b55d9cdafa806807f02a0ae0c169aa5edfe88a789a6482429756a23",
     )?;
     run_command_and_decode_json(&format!(
-        "body --abi {} addOrdinaryStake {{\"stake1\":65535}}",
-        DEPOOL_ABI
+        "body --abi {DEPOOL_ABI} addOrdinaryStake {{\"stake1\":65535}}"
     ))?;
     run_command_and_decode_json("convert tokens 0.12345678a")?;
     run_command_and_decode_json(&format!(
-        "call 0:841288ed3b55d9cdafa806807f02a0ae0c169aa5edfe88a789a6482429756a95 sendGrams {{\"dest\":\"0:841288ed3b55d9cdafa806807f02a0ae0c169aa5edfe88a789a6482429756a94\",\"amount\":1111111}} --abi {}",
-        GIVER_ABI
+        "call 0:841288ed3b55d9cdafa806807f02a0ae0c169aa5edfe88a789a6482429756a95 sendGrams {{\"dest\":\"0:841288ed3b55d9cdafa806807f02a0ae0c169aa5edfe88a789a6482429756a94\",\"amount\":1111111}} --abi {GIVER_ABI}"
     ))?;
     run_command_and_decode_json(&format!(
-        "callx --addr 0:841288ed3b55d9cdafa806807f02a0ae0c169aa5edfe88a789a6482429756a95 sendGrams --dest 0:841288ed3b55d9cdafa806807f02a0ae0c169aa5edfe88a789a6482429756a94 --amount 1111111 --abi {}",
-        GIVER_ABI
+        "callx --addr 0:841288ed3b55d9cdafa806807f02a0ae0c169aa5edfe88a789a6482429756a95 sendGrams --dest 0:841288ed3b55d9cdafa806807f02a0ae0c169aa5edfe88a789a6482429756a94 --amount 1111111 --abi {GIVER_ABI}"
     ))?;
     run_command_and_decode_json(r#"config endpoint remove random"#)?;
     run_command_and_decode_json(&format!(
-        "decode msg tests/samples/wallet.boc --abi {}",
-        DEPOOL_ABI
+        "decode msg tests/samples/wallet.boc --abi {DEPOOL_ABI}"
     ))?;
     run_command_and_decode_json(&format!(
-        "decode msg tests/account_fift.tvc --abi {}",
-        DEPOOL_ABI
+        "decode msg tests/account_fift.tvc --abi {DEPOOL_ABI}"
     ))?;
     run_command_and_decode_json(&format!(
-        "decode body te6ccgEBAQEARAAAgwAAALqUCTqWL8OX7JivfJrAAzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMQAAAAAAAAAAAAAAAEeGjADA== --abi {}",
-        DEPOOL_ABI
+        "decode body te6ccgEBAQEARAAAgwAAALqUCTqWL8OX7JivfJrAAzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMQAAAAAAAAAAAAAAAEeGjADA== --abi {DEPOOL_ABI}"
     ))?;
     run_command_and_decode_json(
         r#"decode stateinit 841288ed3b55d9cdafa806807f02a0ae0c169aa5edfe88a789a6482429756a65"#,
@@ -218,20 +202,16 @@ fn test_json_output_4() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn test_json_output_5() -> Result<(), Box<dyn std::error::Error>> {
     run_command_and_decode_json(&format!(
-        "fee deploy --abi tests/samples/fakeDepool.abi.json --sign {} tests/samples/fakeDepool.tvc {{}}",
-        GIVER_V2_KEY
+        "fee deploy --abi tests/samples/fakeDepool.abi.json --sign {GIVER_V2_KEY} tests/samples/fakeDepool.tvc {{}}"
     ))?;
     run_command_and_decode_json(&format!(
-        "deploy --abi tests/samples/fakeDepool.abi.json --sign {} tests/samples/fakeDepool.tvc {{}}",
-        GIVER_V2_KEY
+        "deploy --abi tests/samples/fakeDepool.abi.json --sign {GIVER_V2_KEY} tests/samples/fakeDepool.tvc {{}}"
     ))?;
     run_command_and_decode_json(&format!(
-        "deployx --abi tests/samples/fakeDepool.abi.json --keys {} tests/samples/fakeDepool.tvc ",
-        GIVER_V2_KEY
+        "deployx --abi tests/samples/fakeDepool.abi.json --keys {GIVER_V2_KEY} tests/samples/fakeDepool.tvc "
     ))?;
     run_command_and_decode_json(&format!(
-        "deploy_message --raw --abi tests/samples/fakeDepool.abi.json --sign {} tests/account.boc {{}}",
-        GIVER_V2_KEY
+        "deploy_message --raw --abi tests/samples/fakeDepool.abi.json --sign {GIVER_V2_KEY} tests/account.boc {{}}"
     ))?;
     run_command_and_decode_json(
         r#"dump config 841288ed3b55d9cdafa806807f02a0ae0c169aa5edfe88a789a6482429756a94.boc"#,
@@ -243,8 +223,7 @@ fn test_json_output_5() -> Result<(), Box<dyn std::error::Error>> {
         r#"fee call 0:841288ed3b55d9cdafa806807f02a0ae0c169aa5edfe88a789a6482429756a95 sendGrams {"dest":"0:841288ed3b55d9cdafa806807f02a0ae0c169aa5edfe88a789a6482429756a94","amount":1111111} --abi tests/samples/giver.abi.json"#,
     )?;
     run_command_and_decode_json(&format!(
-        "genaddr tests/account.boc --abi tests/samples/wallet.abi.json --setkey {}",
-        GIVER_V2_KEY
+        "genaddr tests/account.boc --abi tests/samples/wallet.abi.json --setkey {GIVER_V2_KEY}"
     ))?;
     // run_command_and_decode_json(r#"genpubkey "jar denial ozone coil heart tattoo
     // science stay wire about act""#)?;
@@ -252,16 +231,16 @@ fn test_json_output_5() -> Result<(), Box<dyn std::error::Error>> {
     run_command_and_decode_json(
         r#"message 0:841288ed3b55d9cdafa806807f02a0ae0c169aa5edfe88a789a6482429756a94 sendansaction {"dest":"0:841288ed3b55d9cdafa806807f02a0ae0c169aa5edfe88a789a6482429756a94","value":1000000000,"bounce":true} --abi tests/samples/wallet.abi.json --raw"#,
     )?;
-    run_command_and_decode_json(&format!("multisig deploy -k {}", GIVER_V2_KEY))?;
-    run_command_and_decode_json(&format!("multisig deploy -k {} -l 1000000000", GIVER_V2_KEY))?;
+    run_command_and_decode_json(&format!("multisig deploy -k {GIVER_V2_KEY}"))?;
+    run_command_and_decode_json(&format!("multisig deploy -k {GIVER_V2_KEY} -l 1000000000"))?;
     run_command_and_decode_json(r#"nodeid --pubkey cde8fbf86c"#)?;
     run_command_and_decode_json(r#"nodeid --keypair tests/account.boc"#)?;
     // run_command_and_decode_json(&format!("proposal vote 0:28a3738f08f5b3410e92aab20f702d64160e2891aaaed881f27d59ff518078d1 12313 {}", GIVER_V2_KEY))?;
     // run_command_and_decode_json(r#"proposal decode 0:28a3738f08f5b3410e92aab20f702d64160e2891aaaed881f27d59ff518078d1 12313"#)?;
-    let command = format!("run --abi tests/samples/fakeDepool.abi.json {} getDat {{}}", GIVER_ADDR);
+    let command = format!("run --abi tests/samples/fakeDepool.abi.json {GIVER_ADDR} getDat {{}}");
     run_command_and_decode_json(&command)?;
     let command =
-        format!("runx --abi tests/samples/fakeDepool.abi.json --addr {} gtData ", GIVER_ADDR);
+        format!("runx --abi tests/samples/fakeDepool.abi.json --addr {GIVER_ADDR} gtData ");
     run_command_and_decode_json(&command)?;
     run_command_and_decode_json(r#"runget --boc tests/account_fift.boc past_election_is"#)?;
     run_command_and_decode_json(r#"send --abi tests/samples/fakeDepool.abi.json 65465"#)?;

--- a/tvm_cli/tests/test_cli.rs
+++ b/tvm_cli/tests/test_cli.rs
@@ -40,7 +40,7 @@ const SAVED_CONFIG: &str = "tests/config_contract.saved";
 fn now_ms() -> u64 {
     SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap_or_else(|e| panic!("failed to obtain system time: {}", e))
+        .unwrap_or_else(|e| panic!("failed to obtain system time: {e}"))
         .as_millis() as u64
 }
 
@@ -414,7 +414,7 @@ fn test_fee() -> Result<(), Box<dyn std::error::Error>> {
         .arg("--sign")
         .arg(GIVER_V2_KEY)
         .arg("sendTransaction")
-        .arg(format!(r#"{{"dest":"{}","value":100000000000,"bounce":false}}"#, GIVER_V2_ADDR))
+        .arg(format!(r#"{{"dest":"{GIVER_V2_ADDR}","value":100000000000,"bounce":false}}"#))
         .assert()
         .success()
         .stdout(predicate::str::contains(r#"  "in_msg_fwd_fee":"#))
@@ -677,7 +677,7 @@ fn test_deploy() -> Result<(), Box<dyn std::error::Error>> {
     let abi_path = DEPOOL_ABI;
 
     let time = now_ms();
-    let data_str = format!(r#"{{"m_seed":{}}}"#, time);
+    let data_str = format!(r#"{{"m_seed":{time}}}"#);
 
     let mut cmd = Command::cargo_bin(BIN_NAME)?;
     let out = cmd
@@ -1158,7 +1158,7 @@ fn test_decode_msg() -> Result<(), Box<dyn std::error::Error>> {
         .arg("--sign")
         .arg(GIVER_V2_KEY)
         .arg("sendTransaction")
-        .arg(format!(r#"{{"dest":"{}","value":100000000000,"bounce":false}}"#, GIVER_V2_ADDR))
+        .arg(format!(r#"{{"dest":"{GIVER_V2_ADDR}","value":100000000000,"bounce":false}}"#))
         .output()
         .expect("Failed to send message.");
 
@@ -1563,7 +1563,7 @@ fn test_depool_3() -> Result<(), Box<dyn std::error::Error>> {
         .success()
         .stdout(predicate::str::contains(format!(r#"sender": "{}"#, &wallet_addr)))
         .stdout(predicate::str::contains(r#"stake": "2000000000"#))
-        .stdout(predicate::str::contains(format!(r#"receiver": "{}"#, GIVER_V2_ADDR)))
+        .stdout(predicate::str::contains(format!(r#"receiver": "{GIVER_V2_ADDR}"#)))
         .stdout(predicate::str::contains(r#"withdrawal": "86400"#))
         .stdout(predicate::str::contains(r#"total": "86400"#));
 
@@ -1621,7 +1621,7 @@ fn test_depool_3() -> Result<(), Box<dyn std::error::Error>> {
         .success()
         .stdout(predicate::str::contains(format!(r#"sender": "{}"#, &wallet_addr)))
         .stdout(predicate::str::contains(r#"stake": "2000000000"#))
-        .stdout(predicate::str::contains(format!(r#"receiver": "{}"#, GIVER_V2_ADDR)));
+        .stdout(predicate::str::contains(format!(r#"receiver": "{GIVER_V2_ADDR}"#)));
 
     Ok(())
 }
@@ -2092,7 +2092,7 @@ fn test_run_async_call() -> Result<(), Box<dyn std::error::Error>> {
         .arg("--sign")
         .arg(GIVER_V2_KEY)
         .arg("sendTransaction")
-        .arg(format!(r#"{{"dest":"{}","value":100000000000,"bounce":false}}"#, GIVER_V2_ADDR))
+        .arg(format!(r#"{{"dest":"{GIVER_V2_ADDR}","value":100000000000,"bounce":false}}"#))
         .assert()
         .success()
         .stdout(predicate::str::contains("Local run succeeded"));
@@ -2193,7 +2193,7 @@ fn test_multisig() -> Result<(), Box<dyn std::error::Error>> {
     let seed = generate_phrase_and_key(key_path3)?;
     let key3 = generate_public_key(&seed)?;
 
-    let owners_string = format!(r#"["0x{}","0x{}","0x{}"]"#, key1, key2, key3);
+    let owners_string = format!(r#"["0x{key1}","0x{key2}","0x{key3}"]"#);
 
     let mut cmd = Command::cargo_bin(BIN_NAME)?;
     let out = cmd
@@ -2227,7 +2227,7 @@ fn test_multisig() -> Result<(), Box<dyn std::error::Error>> {
         .success()
         .stdout(predicate::str::contains("Wallet successfully deployed"));
 
-    let owners_string = format!(r#"{},{},{}"]"#, key1, key2, key3);
+    let owners_string = format!(r#"{key1},{key2},{key3}"]"#);
 
     let mut cmd = Command::cargo_bin(BIN_NAME)?;
     cmd.arg("multisig")
@@ -2244,7 +2244,7 @@ fn test_multisig() -> Result<(), Box<dyn std::error::Error>> {
         .success()
         .stdout(predicate::str::contains("Wallet successfully deployed"));
 
-    let owners_string = format!(r#"0x{},"0x{}',"{}""]"#, key1, key2, key3);
+    let owners_string = format!(r#"0x{key1},"0x{key2}',"{key3}""]"#);
 
     let mut cmd = Command::cargo_bin(BIN_NAME)?;
     cmd.arg("multisig")

--- a/tvm_client/build.rs
+++ b/tvm_client/build.rs
@@ -76,7 +76,7 @@ impl BuildInfo {
                 if build_number.is_empty() && name == "tvm_client" {
                     build_number = version
                         .split('.')
-                        .map(|x| format!("{:0>3}", x))
+                        .map(|x| format!("{x:0>3}"))
                         .collect::<Vec<_>>()
                         .join("");
                 }
@@ -92,7 +92,7 @@ impl BuildInfo {
         Ok(Self {
             build_number: build_number
                 .parse::<u32>()
-                .unwrap_or_else(|_| panic!("Invalid build number [{}]", build_number)),
+                .unwrap_or_else(|_| panic!("Invalid build number [{build_number}]")),
             dependencies,
         })
     }
@@ -109,7 +109,7 @@ fn main() -> Result<(), String> {
             root().join("src").join("build_info.json").to_str().unwrap(),
             build_info_json,
         )
-        .map_err(|err| format!("{}", err))?;
+        .map_err(|err| format!("{err}"))?;
     }
     Ok(())
 }

--- a/tvm_client/build.rs
+++ b/tvm_client/build.rs
@@ -74,11 +74,8 @@ impl BuildInfo {
                 let name = x["name"].as_str().unwrap().to_string();
                 let version = x["version"].as_str().unwrap().to_string();
                 if build_number.is_empty() && name == "tvm_client" {
-                    build_number = version
-                        .split('.')
-                        .map(|x| format!("{x:0>3}"))
-                        .collect::<Vec<_>>()
-                        .join("");
+                    build_number =
+                        version.split('.').map(|x| format!("{x:0>3}")).collect::<Vec<_>>().join("");
                 }
                 let source = x["source"].as_str().unwrap_or("");
                 let git_commit = if !source.is_empty() {

--- a/tvm_client/src/abi/decode_message.rs
+++ b/tvm_client/src/abi/decode_message.rs
@@ -239,7 +239,7 @@ fn decode_unknown_function(
             is_internal,
         )
         .map_err(|err| {
-            Error::invalid_message_for_decode(format!("Can't decode function header: {}", err))
+            Error::invalid_message_for_decode(format!("Can't decode function header: {err}"))
         })?;
         DecodedMessageBody::new(MessageBodyType::Input, input, FunctionHeader::from(&header)?)
     };

--- a/tvm_client/src/abi/encode_message.rs
+++ b/tvm_client/src/abi/encode_message.rs
@@ -177,13 +177,13 @@ fn resolve_header(
 fn header_to_string(header: &FunctionHeader) -> String {
     let mut values = Vec::<String>::new();
     if let Some(time) = header.time {
-        values.push(format!("\"time\": {}", time));
+        values.push(format!("\"time\": {time}"));
     }
     if let Some(expire) = header.expire {
-        values.push(format!("\"expire\": {}", expire));
+        values.push(format!("\"expire\": {expire}"));
     }
     if let Some(pubkey) = &header.pubkey {
-        values.push(format!("\"pubkey\": \"{}\"", pubkey));
+        values.push(format!("\"pubkey\": \"{pubkey}\""));
     }
     format!("{{{}}}", values.join(","))
 }
@@ -518,7 +518,7 @@ pub async fn encode_message(
                 .await
                 .and_then(|s| {
                     s.split_once(':')
-                        .map(|(_, part)| format!(":{}", part))
+                        .map(|(_, part)| format!(":{part}"))
                         .and_then(|s| MsgAddressExt::from_str(&s).ok())
                 })
                 .unwrap_or_default()

--- a/tvm_client/src/abi/errors.rs
+++ b/tvm_client/src/abi/errors.rs
@@ -67,10 +67,7 @@ impl Error {
     }
 
     pub fn encode_deploy_message_failed<E: Display>(err: E) -> ClientError {
-        error(
-            ErrorCode::EncodeDeployMessageFailed,
-            format!("Encode deploy message failed: {err}"),
-        )
+        error(ErrorCode::EncodeDeployMessageFailed, format!("Encode deploy message failed: {err}"))
     }
 
     pub fn encode_run_message_failed<E: Display>(err: E, function: Option<&str>) -> ClientError {
@@ -79,10 +76,7 @@ impl Error {
     }
 
     pub fn attach_signature_failed<E: Display>(err: E) -> ClientError {
-        error(
-            ErrorCode::AttachSignatureFailed,
-            format!("Encoding message with sign failed: {err}"),
-        )
+        error(ErrorCode::AttachSignatureFailed, format!("Encoding message with sign failed: {err}"))
     }
 
     pub fn invalid_tvc_image<E: Display>(err: E) -> ClientError {

--- a/tvm_client/src/abi/errors.rs
+++ b/tvm_client/src/abi/errors.rs
@@ -30,7 +30,7 @@ fn error(code: ErrorCode, message: String) -> ClientError {
 
 impl Error {
     pub fn invalid_abi<E: Display>(err: E) -> ClientError {
-        error(ErrorCode::InvalidAbi, format!("Invalid ABI specified: {}", err))
+        error(ErrorCode::InvalidAbi, format!("Invalid ABI specified: {err}"))
     }
 
     pub fn invalid_signer(message: String) -> ClientError {
@@ -59,52 +59,52 @@ impl Error {
     }
 
     pub fn invalid_json<E: Display>(err: E) -> ClientError {
-        error(ErrorCode::InvalidJson, format!("Invalid ABI JSON: {}", err))
+        error(ErrorCode::InvalidJson, format!("Invalid ABI JSON: {err}"))
     }
 
     pub fn invalid_message_for_decode<E: Display>(err: E) -> ClientError {
-        error(ErrorCode::InvalidMessage, format!("Message can't be decoded: {}", err))
+        error(ErrorCode::InvalidMessage, format!("Message can't be decoded: {err}"))
     }
 
     pub fn encode_deploy_message_failed<E: Display>(err: E) -> ClientError {
         error(
             ErrorCode::EncodeDeployMessageFailed,
-            format!("Encode deploy message failed: {}", err),
+            format!("Encode deploy message failed: {err}"),
         )
     }
 
     pub fn encode_run_message_failed<E: Display>(err: E, function: Option<&str>) -> ClientError {
-        error(ErrorCode::EncodeRunMessageFailed, format!("Create run message failed: {}", err))
+        error(ErrorCode::EncodeRunMessageFailed, format!("Create run message failed: {err}"))
             .add_function(function)
     }
 
     pub fn attach_signature_failed<E: Display>(err: E) -> ClientError {
         error(
             ErrorCode::AttachSignatureFailed,
-            format!("Encoding message with sign failed: {}", err),
+            format!("Encoding message with sign failed: {err}"),
         )
     }
 
     pub fn invalid_tvc_image<E: Display>(err: E) -> ClientError {
-        error(ErrorCode::InvalidTvcImage, format!("Invalid TVC image: {}", err))
+        error(ErrorCode::InvalidTvcImage, format!("Invalid TVC image: {err}"))
     }
 
     pub fn invalid_function_id<E: Display>(func_id: &str, err: E) -> ClientError {
-        error(ErrorCode::InvalidFunctionId, format!("Invalid function {}: {}", func_id, err))
+        error(ErrorCode::InvalidFunctionId, format!("Invalid function {func_id}: {err}"))
     }
 
     pub fn invalid_data_for_decode<E: Display>(err: E) -> ClientError {
-        error(ErrorCode::InvalidData, format!("Data can't be decoded: {}", err))
+        error(ErrorCode::InvalidData, format!("Data can't be decoded: {err}"))
     }
 
     pub fn encode_init_data_failed<E: Display>(err: E) -> ClientError {
-        error(ErrorCode::EncodeInitialDataFailed, format!("Encode initial data failed: {}", err))
+        error(ErrorCode::EncodeInitialDataFailed, format!("Encode initial data failed: {err}"))
     }
 
     pub fn invalid_function_name(func_name: &str) -> ClientError {
         error(
             ErrorCode::InvalidFunctionName,
-            format!("Function {} is not found in contract ABI", func_name),
+            format!("Function {func_name} is not found in contract ABI"),
         )
     }
 
@@ -114,8 +114,7 @@ impl Error {
         error(
             ErrorCode::PubKeyNotSupported,
             format!(
-                "Your contract ABI version is {}. You must specify initial public key in 'initial_data' (see ABI specification).",
-                abi_version
+                "Your contract ABI version is {abi_version}. You must specify initial public key in 'initial_data' (see ABI specification)."
             ),
         )
     }

--- a/tvm_client/src/abi/tests.rs
+++ b/tvm_client/src/abi/tests.rs
@@ -655,7 +655,7 @@ async fn test_encode_internal_message() -> Result<()> {
     test_encode_internal_message_run(
         &client,
         Some(&abi),
-        Some(CallSet { function_name: format!("0x{:x}", func_id), header: None, input: None }),
+        Some(CallSet { function_name: format!("0x{func_id:x}"), header: None, input: None }),
         None,
         Some(address.clone()),
         Some(expected_boc),
@@ -665,7 +665,7 @@ async fn test_encode_internal_message() -> Result<()> {
     test_encode_internal_message_run(
         &client,
         Some(&abi),
-        Some(CallSet { function_name: format!("{}", func_id), header: None, input: None }),
+        Some(CallSet { function_name: format!("{func_id}"), header: None, input: None }),
         None,
         Some(address.clone()),
         Some(expected_boc),

--- a/tvm_client/src/boc/blockchain_config.rs
+++ b/tvm_client/src/boc/blockchain_config.rs
@@ -62,11 +62,11 @@ pub(crate) fn extract_config_from_block(
 ) -> ClientResult<tvm_block::ConfigParams> {
     let extra = block
         .read_extra()
-        .map_err(|err| Error::invalid_boc(format!("can not read `extra` from block: {}", err)))?;
+        .map_err(|err| Error::invalid_boc(format!("can not read `extra` from block: {err}")))?;
 
     let master = extra
         .read_custom()
-        .map_err(|err| Error::invalid_boc(format!("can not read `master` from block: {}", err)))?
+        .map_err(|err| Error::invalid_boc(format!("can not read `master` from block: {err}")))?
         .ok_or(Error::inappropriate_block(
             "not a masterchain block. Only key block contains blockchain configuration",
         ))?;
@@ -85,7 +85,7 @@ pub(crate) fn extract_config_from_zerostate(
     let master = zerostate
         .read_custom()
         .map_err(|err| {
-            Error::invalid_boc(format!("can not read `master` from zerostate: {}", err))
+            Error::invalid_boc(format!("can not read `master` from zerostate: {err}"))
         })?
         .ok_or(Error::inappropriate_block(
             "not a masterchain state. Only masterchain states contain blockchain configuration",

--- a/tvm_client/src/boc/blockchain_config.rs
+++ b/tvm_client/src/boc/blockchain_config.rs
@@ -84,9 +84,7 @@ pub(crate) fn extract_config_from_zerostate(
 ) -> ClientResult<tvm_block::ConfigParams> {
     let master = zerostate
         .read_custom()
-        .map_err(|err| {
-            Error::invalid_boc(format!("can not read `master` from zerostate: {err}"))
-        })?
+        .map_err(|err| Error::invalid_boc(format!("can not read `master` from zerostate: {err}")))?
         .ok_or(Error::inappropriate_block(
             "not a masterchain state. Only masterchain states contain blockchain configuration",
         ))?;

--- a/tvm_client/src/boc/cache.rs
+++ b/tvm_client/src/boc/cache.rs
@@ -200,7 +200,7 @@ impl Bocs {
     ) -> ClientResult<(DeserializedBoc, Cell)> {
         if boc.starts_with('*') {
             let hash = UInt256::from_str(&boc[1..]).map_err(|err| {
-                Error::invalid_boc(format!("BOC start with `*` but contains invalid hash: {}", err))
+                Error::invalid_boc(format!("BOC start with `*` but contains invalid hash: {err}"))
             })?;
 
             let cell = self.get(&hash).ok_or(Error::boc_ref_not_found(boc))?;
@@ -253,7 +253,7 @@ impl Bocs {
         size: Option<usize>,
     ) -> ClientResult<UInt256> {
         let hash = cell.repr_hash();
-        log::debug!("Bocs::add {:x}", hash);
+        log::debug!("Bocs::add {hash:x}");
         match cache_type {
             BocCacheType::Pinned { pin } => self.add_new_pinned(hash.clone(), pin, cell),
             BocCacheType::Unpinned => {
@@ -277,7 +277,7 @@ fn parse_boc_ref(boc_ref: &str) -> ClientResult<UInt256> {
     }
 
     UInt256::from_str(&boc_ref[1..]).map_err(|err| {
-        Error::invalid_boc_ref(format!("reference contains invalid hash: {}", err), boc_ref)
+        Error::invalid_boc_ref(format!("reference contains invalid hash: {err}"), boc_ref)
     })
 }
 
@@ -309,7 +309,7 @@ pub fn cache_set(
     context
         .bocs
         .add(params.cache_type, cell, size)
-        .map(|hash| ResultOfBocCacheSet { boc_ref: format!("*{:x}", hash) })
+        .map(|hash| ResultOfBocCacheSet { boc_ref: format!("*{hash:x}") })
 }
 
 #[derive(Serialize, Deserialize, Clone, ApiType, Default)]

--- a/tvm_client/src/boc/errors.rs
+++ b/tvm_client/src/boc/errors.rs
@@ -35,15 +35,15 @@ impl Error {
     }
 
     pub fn invalid_boc<E: Display>(err: E) -> ClientError {
-        error(ErrorCode::InvalidBoc, format!("Invalid BOC: {}", err))
+        error(ErrorCode::InvalidBoc, format!("Invalid BOC: {err}"))
     }
 
     pub fn serialization_error<E: Display>(err: E, name: &str) -> ClientError {
-        error(ErrorCode::SerializationError, format!("Cannot serialize {}: {}", name, err))
+        error(ErrorCode::SerializationError, format!("Cannot serialize {name}: {err}"))
     }
 
     pub fn inappropriate_block<E: Display>(err: E) -> ClientError {
-        error(ErrorCode::InappropriateBlock, format!("Inappropriate block: {}", err))
+        error(ErrorCode::InappropriateBlock, format!("Inappropriate block: {err}"))
     }
 
     pub fn insufficient_cache_size(max_cache_size: usize, boc_size: usize) -> ClientError {
@@ -64,7 +64,7 @@ impl Error {
     }
 
     pub fn invalid_boc_ref<E: Display>(err: E, boc_ref: &str) -> ClientError {
-        let mut error = error(ErrorCode::InvalidBocRef, format!("Invalid BOC reference: {}", err));
+        let mut error = error(ErrorCode::InvalidBocRef, format!("Invalid BOC reference: {err}"));
         error.data["boc_ref"] = boc_ref.into();
         error
     }

--- a/tvm_client/src/boc/internal.rs
+++ b/tvm_client/src/boc/internal.rs
@@ -34,10 +34,10 @@ pub fn deserialize_cell_from_base64(
     name: &str,
 ) -> ClientResult<(Vec<u8>, tvm_types::Cell)> {
     let bytes = base64_decode(b64)
-        .map_err(|err| Error::invalid_boc(format!("error decode {} BOC base64: {}", name, err)))?;
+        .map_err(|err| Error::invalid_boc(format!("error decode {name} BOC base64: {err}")))?;
 
     let cell = tvm_types::boc::read_single_root_boc(&bytes).map_err(|err| {
-        Error::invalid_boc(format!("{} BOC deserialization error: {}", name, err))
+        Error::invalid_boc(format!("{name} BOC deserialization error: {err}"))
     })?;
 
     Ok((bytes, cell))
@@ -53,9 +53,9 @@ pub fn deserialize_object_from_cell<S: Deserializable>(
         }
         _ => "",
     };
-    let tip_full = if !tip.is_empty() { format!(".\nTip: {}", tip) } else { "".to_string() };
+    let tip_full = if !tip.is_empty() { format!(".\nTip: {tip}") } else { "".to_string() };
     S::construct_from_cell(cell).map_err(|err| {
-        Error::invalid_boc(format!("cannot deserialize {} from BOC: {}{}", name, err, tip_full))
+        Error::invalid_boc(format!("cannot deserialize {name} from BOC: {err}{tip_full}"))
     })
 }
 
@@ -148,7 +148,7 @@ pub fn serialize_cell_to_boc(
     boc_cache: Option<BocCacheType>,
 ) -> ClientResult<String> {
     if let Some(cache_type) = boc_cache {
-        context.bocs.add(cache_type, cell, None).map(|hash| format!("*{:x}", hash))
+        context.bocs.add(cache_type, cell, None).map(|hash| format!("*{hash:x}"))
     } else {
         serialize_cell_to_base64(&cell, name)
     }

--- a/tvm_client/src/boc/internal.rs
+++ b/tvm_client/src/boc/internal.rs
@@ -36,9 +36,8 @@ pub fn deserialize_cell_from_base64(
     let bytes = base64_decode(b64)
         .map_err(|err| Error::invalid_boc(format!("error decode {name} BOC base64: {err}")))?;
 
-    let cell = tvm_types::boc::read_single_root_boc(&bytes).map_err(|err| {
-        Error::invalid_boc(format!("{name} BOC deserialization error: {err}"))
-    })?;
+    let cell = tvm_types::boc::read_single_root_boc(&bytes)
+        .map_err(|err| Error::invalid_boc(format!("{name} BOC deserialization error: {err}")))?;
 
     Ok((bytes, cell))
 }

--- a/tvm_client/src/boc/parse.rs
+++ b/tvm_client/src/boc/parse.rs
@@ -120,14 +120,12 @@ pub fn parse_account(
     let account = if cell.cell_type() == tvm_types::CellType::MerkleProof {
         let proof = tvm_block::MerkleProof::construct_from_cell(cell).map_err(|err| {
             Error::invalid_boc(format!(
-                "Can not deserialize Merkle proof from pruned account BOC: {}",
-                err
+                "Can not deserialize Merkle proof from pruned account BOC: {err}"
             ))
         })?;
         proof.virtualize().map_err(|err| {
             Error::invalid_boc(format!(
-                "Can not virtualize pruned account from Merkle proof: {}",
-                err
+                "Can not virtualize pruned account from Merkle proof: {err}"
             ))
         })?
     } else {

--- a/tvm_client/src/boc/state_init.rs
+++ b/tvm_client/src/boc/state_init.rs
@@ -143,7 +143,7 @@ pub fn get_code_salt(
 pub(crate) fn builder_to_cell(builder: BuilderData) -> ClientResult<Cell> {
     builder
         .into_cell()
-        .map_err(|err| Error::invalid_boc(format!("can not convert builder to cell: {}", err)))
+        .map_err(|err| Error::invalid_boc(format!("can not convert builder to cell: {err}")))
 }
 
 fn set_salt(cell: Cell, salt: Cell, replace_last_ref: bool) -> ClientResult<Cell> {
@@ -265,7 +265,7 @@ pub fn get_compiler_version_from_cell(code: Cell) -> ClientResult<Option<String>
         .map(|cell| {
             let bytes = cell.data();
             String::from_utf8(bytes[..bytes.len()].to_vec()).map_err(|err| {
-                Error::invalid_boc(format!("can not convert version cell to string: {}", err))
+                Error::invalid_boc(format!("can not convert version cell to string: {err}"))
             })
         })
         .transpose()

--- a/tvm_client/src/boc/tests.rs
+++ b/tvm_client/src/boc/tests.rs
@@ -132,7 +132,7 @@ fn test_encode_boc() {
                 write_bitstring("123"),
                 write_bitstring("x2d9_"),
                 write_bitstring("80_"),
-                write_address(format!("-1:{}", burner_account_id)),
+                write_address(format!("-1:{burner_account_id}")),
                 write_cell(vec![
                     write_bitstring("n101100111000"),
                     write_bitstring("N100111000"),
@@ -163,7 +163,7 @@ fn test_encode_boc() {
                 write_bitstring("123"),
                 write_bitstring("x2d9_"),
                 write_bitstring("80_"),
-                write_address(format!("-1:{}", burner_account_id)),
+                write_address(format!("-1:{burner_account_id}")),
                 BuilderOp::CellBoc { boc: serialize_cell_to_base64(&inner_cell, "cell").unwrap() },
             ],
             boc_cache: None,

--- a/tvm_client/src/client/client_env.rs
+++ b/tvm_client/src/client/client_env.rs
@@ -47,7 +47,7 @@ impl FetchResult {
         }
         let text = self.body_as_text()?;
         serde_json::from_str(text).map_err(|err| {
-            Error::http_request_parse_error(format!("Body is not a valid JSON: {}\n{}", err, text))
+            Error::http_request_parse_error(format!("Body is not a valid JSON: {err}\n{text}"))
         })
     }
 

--- a/tvm_client/src/client/errors.rs
+++ b/tvm_client/src/client/errors.rs
@@ -79,65 +79,65 @@ impl Error {
     }
 
     pub fn invalid_hex<E: Display>(s: &str, err: E) -> ClientError {
-        error(ErrorCode::InvalidHex, format!("Invalid hex string: {}\r\nhex: [{}]", err, s))
+        error(ErrorCode::InvalidHex, format!("Invalid hex string: {err}\r\nhex: [{s}]"))
     }
 
     pub fn invalid_base64<E: Display>(s: &str, err: E) -> ClientError {
         error(
             ErrorCode::InvalidBase64,
-            format!("Invalid base64 string: {}\r\nbase64: [{}]", err, s),
+            format!("Invalid base64 string: {err}\r\nbase64: [{s}]"),
         )
     }
 
     pub fn invalid_address<E: Display>(err: E, address: &str) -> ClientError {
-        error(ErrorCode::InvalidAddress, format!("Invalid address [{}]: {}", err, address))
+        error(ErrorCode::InvalidAddress, format!("Invalid address [{err}]: {address}"))
     }
 
     pub fn callback_params_cant_be_converted_to_json<E: Display>(err: E) -> ClientError {
         error(
             ErrorCode::CallbackParamsCantBeConvertedToJson,
-            format!("Callback params can't be converted to json: {}", err),
+            format!("Callback params can't be converted to json: {err}"),
         )
     }
 
     pub fn websocket_connect_error<E: Display>(address: &str, err: E) -> ClientError {
         error(
             ErrorCode::WebsocketConnectError,
-            format!("Can not connect to websocket URL {}: {}", address, err),
+            format!("Can not connect to websocket URL {address}: {err}"),
         )
     }
 
     pub fn websocket_receive_error<E: Display>(err: E) -> ClientError {
         error(
             ErrorCode::WebsocketReceiveError,
-            format!("Can not receive message from websocket: {}", err),
+            format!("Can not receive message from websocket: {err}"),
         )
     }
 
     pub fn websocket_send_error<E: Display>(err: E) -> ClientError {
-        error(ErrorCode::WebsocketSendError, format!("Can not send message to websocket: {}", err))
+        error(ErrorCode::WebsocketSendError, format!("Can not send message to websocket: {err}"))
     }
 
     pub fn http_client_create_error<E: Display>(err: E) -> ClientError {
-        error(ErrorCode::HttpClientCreateError, format!("Can not create http client: {}", err))
+        error(ErrorCode::HttpClientCreateError, format!("Can not create http client: {err}"))
     }
 
     pub fn http_request_create_error<E: Display>(err: E) -> ClientError {
-        error(ErrorCode::HttpRequestCreateError, format!("Can not create http request: {}", err))
+        error(ErrorCode::HttpRequestCreateError, format!("Can not create http request: {err}"))
     }
 
     pub fn http_request_send_error<E: Display>(err: E) -> ClientError {
-        error(ErrorCode::HttpRequestSendError, format!("Can not send http request: {}", err))
+        error(ErrorCode::HttpRequestSendError, format!("Can not send http request: {err}"))
     }
 
     pub fn http_request_parse_error<E: Display>(err: E) -> ClientError {
-        error(ErrorCode::HttpRequestParseError, format!("Can not parse http request: {}", err))
+        error(ErrorCode::HttpRequestParseError, format!("Can not parse http request: {err}"))
     }
 
     pub fn callback_not_registered(callback_id: u32) -> ClientError {
         error(
             ErrorCode::CallbackNotRegistered,
-            format!("Callback with ID {} is not registered", callback_id),
+            format!("Callback with ID {callback_id} is not registered"),
         )
     }
 
@@ -150,15 +150,15 @@ impl Error {
     }
 
     pub fn cannot_create_runtime<E: Display>(err: E) -> ClientError {
-        error(ErrorCode::CannotCreateRuntime, format!("Can not create runtime: {}", err))
+        error(ErrorCode::CannotCreateRuntime, format!("Can not create runtime: {err}"))
     }
 
     pub fn invalid_context_handle(context: u32) -> ClientError {
-        error(ErrorCode::InvalidContextHandle, format!("Invalid context handle: {}", context))
+        error(ErrorCode::InvalidContextHandle, format!("Invalid context handle: {context}"))
     }
 
     pub fn cannot_serialize_result(err: impl Display) -> ClientError {
-        error(ErrorCode::CannotSerializeResult, format!("Can't serialize result: {}", err))
+        error(ErrorCode::CannotSerializeResult, format!("Can't serialize result: {err}"))
     }
 
     pub fn invalid_params(params_json: &str, err: impl Display) -> ClientError {
@@ -171,35 +171,34 @@ impl Error {
 
         error(
             ErrorCode::InvalidParams,
-            format!("Invalid parameters: {}\nparams: {}", err, params_json_stripped),
+            format!("Invalid parameters: {err}\nparams: {params_json_stripped}"),
         )
     }
 
     pub fn contracts_address_conversion_failed(err: impl Display) -> ClientError {
         error(
             ErrorCode::ContractsAddressConversionFailed,
-            format!("Address conversion failed: {}", err),
+            format!("Address conversion failed: {err}"),
         )
     }
 
     pub fn unknown_function(name: &str) -> ClientError {
-        error(ErrorCode::UnknownFunction, format!("Unknown function: {}", name))
+        error(ErrorCode::UnknownFunction, format!("Unknown function: {name}"))
     }
 
     pub fn app_request_error(text: &str) -> ClientError {
-        error(ErrorCode::AppRequestError, format!("Application request returned error: {}", text))
+        error(ErrorCode::AppRequestError, format!("Application request returned error: {text}"))
     }
 
     pub fn no_such_request(id: u32) -> ClientError {
-        error(ErrorCode::NoSuchRequest, format!("No such request. ID {}", id))
+        error(ErrorCode::NoSuchRequest, format!("No such request. ID {id}"))
     }
 
     pub fn can_not_send_request_result(id: u32) -> ClientError {
         error(
             ErrorCode::CanNotSendRequestResult,
             format!(
-                "Can not send request result. Probably receiver is already dropped. Request ID {}",
-                id
+                "Can not send request result. Probably receiver is already dropped. Request ID {id}"
             ),
         )
     }
@@ -207,20 +206,19 @@ impl Error {
     pub fn can_not_receive_request_result(err: impl Display) -> ClientError {
         error(
             ErrorCode::CanNotReceiveRequestResult,
-            format!("Can not receive request result: {}", err),
+            format!("Can not receive request result: {err}"),
         )
     }
 
     pub fn can_not_parse_request_result(err: impl Display) -> ClientError {
-        error(ErrorCode::CanNotParseRequestResult, format!("Can not parse request result: {}", err))
+        error(ErrorCode::CanNotParseRequestResult, format!("Can not parse request result: {err}"))
     }
 
     pub fn unexpected_callback_response(expected: &str, received: impl Debug) -> ClientError {
         error(
             ErrorCode::UnexpectedCallbackResponse,
             format!(
-                "Unexpected callback response. Expected {}, received {:#?}",
-                expected, received
+                "Unexpected callback response. Expected {expected}, received {received:#?}"
             ),
         )
     }
@@ -228,47 +226,46 @@ impl Error {
     pub fn can_not_parse_number(string: &str) -> ClientError {
         error(
             ErrorCode::CanNotParseNumber,
-            format!("Can not parse integer from string `{}`", string),
+            format!("Can not parse integer from string `{string}`"),
         )
     }
 
     pub fn cannot_convert_jsvalue_to_json(value: impl Debug) -> ClientError {
         error(
             ErrorCode::CannotConvertJsValueToJson,
-            format!("Can not convert JS value to JSON: {:#?}", value),
+            format!("Can not convert JS value to JSON: {value:#?}"),
         )
     }
 
     pub fn can_not_receive_spawned_result(err: impl Display) -> ClientError {
         error(
             ErrorCode::CannotReceiveSpawnedResult,
-            format!("Can not receive result from spawned task: {}", err),
+            format!("Can not receive result from spawned task: {err}"),
         )
     }
 
     pub fn set_timer_error(err: impl Display) -> ClientError {
-        error(ErrorCode::SetTimerError, format!("Set timer error: {}", err))
+        error(ErrorCode::SetTimerError, format!("Set timer error: {err}"))
     }
 
     pub fn invalid_handle(handle: u32, name: &str) -> ClientError {
-        error(ErrorCode::InvalidHandle, format!("Invalid {} handle: {}", name, handle))
+        error(ErrorCode::InvalidHandle, format!("Invalid {name} handle: {handle}"))
     }
 
     pub fn invalid_storage_key(key: &str) -> ClientError {
         error(
             ErrorCode::LocalStorageError,
             format!(
-                "Invalid local storage key (allowed only symbols A-Z, a-z, 0-9, _, without spaces): {}",
-                key,
+                "Invalid local storage key (allowed only symbols A-Z, a-z, 0-9, _, without spaces): {key}",
             ),
         )
     }
 
     pub fn local_storage_error(err: impl Display) -> ClientError {
-        error(ErrorCode::LocalStorageError, format!("Local storage error: {}", err,))
+        error(ErrorCode::LocalStorageError, format!("Local storage error: {err}",))
     }
 
     pub fn invalid_data(err: impl Display) -> ClientError {
-        error(ErrorCode::InvalidData, format!("Invalid data: {}", err))
+        error(ErrorCode::InvalidData, format!("Invalid data: {err}"))
     }
 }

--- a/tvm_client/src/client/errors.rs
+++ b/tvm_client/src/client/errors.rs
@@ -83,10 +83,7 @@ impl Error {
     }
 
     pub fn invalid_base64<E: Display>(s: &str, err: E) -> ClientError {
-        error(
-            ErrorCode::InvalidBase64,
-            format!("Invalid base64 string: {err}\r\nbase64: [{s}]"),
-        )
+        error(ErrorCode::InvalidBase64, format!("Invalid base64 string: {err}\r\nbase64: [{s}]"))
     }
 
     pub fn invalid_address<E: Display>(err: E, address: &str) -> ClientError {
@@ -217,17 +214,12 @@ impl Error {
     pub fn unexpected_callback_response(expected: &str, received: impl Debug) -> ClientError {
         error(
             ErrorCode::UnexpectedCallbackResponse,
-            format!(
-                "Unexpected callback response. Expected {expected}, received {received:#?}"
-            ),
+            format!("Unexpected callback response. Expected {expected}, received {received:#?}"),
         )
     }
 
     pub fn can_not_parse_number(string: &str) -> ClientError {
-        error(
-            ErrorCode::CanNotParseNumber,
-            format!("Can not parse integer from string `{string}`"),
-        )
+        error(ErrorCode::CanNotParseNumber, format!("Can not parse integer from string `{string}`"))
     }
 
     pub fn cannot_convert_jsvalue_to_json(value: impl Debug) -> ClientError {

--- a/tvm_client/src/client/network_mock.rs
+++ b/tvm_client/src/client/network_mock.rs
@@ -43,10 +43,10 @@ impl FetchMock {
             result.url = url.split('?').next().unwrap_or("").to_string();
         }
         let (text, find, replace_with) = match &result {
-            Ok(ok) => (format!("{:?}", ok), "FetchResult", "✅"),
-            Err(err) => (format!("{:?}", err), "ClientError", "❌"),
+            Ok(ok) => (format!("{ok:?}"), "FetchResult", "✅"),
+            Err(err) => (format!("{err:?}"), "ClientError", "❌"),
         };
-        println!("{}", text.replace(find, &format!("{}{}", replace_with, id)));
+        println!("{}", text.replace(find, &format!("{replace_with}{id}")));
         result
     }
 }
@@ -151,14 +151,14 @@ impl NetworkMock {
                 log.push_str(&format!(" {}", fetch.id));
             }
             if let Some(delay) = fetch.delay {
-                log.push_str(&format!(" {} ms ", delay));
+                log.push_str(&format!(" {delay} ms "));
             }
             log.push(' ');
             log.push_str(url);
             if let Some(body) = &body {
-                log.push_str(&format!("\n  ⤷ {}", body));
+                log.push_str(&format!("\n  ⤷ {body}"));
             }
-            println!("{}", log);
+            println!("{log}");
             Some(fetch)
         } else {
             None
@@ -177,7 +177,7 @@ impl NetworkMock {
         let mock = client.env.network_mock.read().await;
         if let Some(fetches) = &mock.fetches {
             if !fetches.is_empty() {
-                panic!("Mock fetches is not empty: {:?}", fetches);
+                panic!("Mock fetches is not empty: {fetches:?}");
             }
         }
     }

--- a/tvm_client/src/client/storage.rs
+++ b/tvm_client/src/client/storage.rs
@@ -51,7 +51,7 @@ impl InMemoryKeyValueStorage {
             })
             .count();
 
-        println!("Total records: {}", count);
+        println!("Total records: {count}");
     }
 }
 

--- a/tvm_client/src/client/tests.rs
+++ b/tvm_client/src/client/tests.rs
@@ -76,9 +76,8 @@ fn test_invalid_params_error_secret_stripped() {
     let error = super::errors::Error::invalid_params(
         &format!(
             r#"{{"address":"0:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-            "public":"{}",
-            "secret":"{}"}}"#,
-            public, secret
+            "public":"{public}",
+            "secret":"{secret}"}}"#
         ),
         "error",
     );

--- a/tvm_client/src/crypto/boxes/encryption_box/aes.rs
+++ b/tvm_client/src/crypto/boxes/encryption_box/aes.rs
@@ -106,7 +106,7 @@ impl AesEncryptionBox {
     {
         Self::create_block_mode::<C, B>(key, iv)?
             .encrypt(data, size)
-            .map_err(|err| Error::encrypt_data_error(format!("{:#?}", err)))
+            .map_err(|err| Error::encrypt_data_error(format!("{err:#?}")))
     }
 
     fn decrypt_data<C, B>(key: &[u8], iv: &[u8], data: &mut [u8]) -> ClientResult<()>
@@ -116,7 +116,7 @@ impl AesEncryptionBox {
     {
         Self::create_block_mode::<C, B>(key, iv)?
             .decrypt(data)
-            .map_err(|err| Error::decrypt_data_error(format!("{:#?}", err)))
+            .map_err(|err| Error::decrypt_data_error(format!("{err:#?}")))
             .map(|_| ())
     }
 

--- a/tvm_client/src/crypto/errors.rs
+++ b/tvm_client/src/crypto/errors.rs
@@ -50,16 +50,16 @@ impl Error {
     pub fn invalid_factorize_challenge<E: Display>(hex: &String, err: E) -> ClientError {
         error(
             ErrorCode::InvalidFactorizeChallenge,
-            format!("Invalid factorize challenge: {}\r\nchallenge: [{}]", err, hex),
+            format!("Invalid factorize challenge: {err}\r\nchallenge: [{hex}]"),
         )
     }
 
     pub fn invalid_big_int(hex: &String) -> ClientError {
-        error(ErrorCode::InvalidBigInt, format!("Invalid big int [{}]", hex))
+        error(ErrorCode::InvalidBigInt, format!("Invalid big int [{hex}]"))
     }
 
     pub fn scrypt_failed<E: Display>(err: E) -> ClientError {
-        error(ErrorCode::ScryptFailed, format!(r#"Scrypt failed: {}"#, err))
+        error(ErrorCode::ScryptFailed, format!(r#"Scrypt failed: {err}"#))
     }
 
     pub fn invalid_key_size(actual: usize, expected: &[usize]) -> ClientError {
@@ -74,44 +74,44 @@ impl Error {
     }
 
     pub fn nacl_secret_box_failed<E: Display>(err: E) -> ClientError {
-        error(ErrorCode::NaclSecretBoxFailed, format!("Nacl Secret Box failed: {}", err))
+        error(ErrorCode::NaclSecretBoxFailed, format!("Nacl Secret Box failed: {err}"))
     }
 
     pub fn nacl_box_failed<E: Display>(err: E) -> ClientError {
-        error(ErrorCode::NaclBoxFailed, format!("Box failed: {}", err))
+        error(ErrorCode::NaclBoxFailed, format!("Box failed: {err}"))
     }
 
     pub fn nacl_sign_failed<E: Display>(err: E) -> ClientError {
-        error(ErrorCode::NaclSignFailed, format!("Sign failed: {}", err))
+        error(ErrorCode::NaclSignFailed, format!("Sign failed: {err}"))
     }
 
     pub fn bip39_invalid_entropy<E: Display>(err: E) -> ClientError {
-        error(ErrorCode::Bip39InvalidEntropy, format!("Invalid bip39 entropy: {}", err))
+        error(ErrorCode::Bip39InvalidEntropy, format!("Invalid bip39 entropy: {err}"))
     }
 
     pub fn bip39_invalid_phrase<E: Display>(err: E) -> ClientError {
-        error(ErrorCode::Bip39InvalidPhrase, format!("Invalid bip39 phrase: {}", err))
+        error(ErrorCode::Bip39InvalidPhrase, format!("Invalid bip39 phrase: {err}"))
     }
 
     pub fn bip32_invalid_key<E: Display>(err: E) -> ClientError {
-        error(ErrorCode::Bip32InvalidKey, format!("Invalid bip32 key: {}", err))
+        error(ErrorCode::Bip32InvalidKey, format!("Invalid bip32 key: {err}"))
     }
 
     pub fn bip32_invalid_derive_path<E: Display>(path: E) -> ClientError {
-        error(ErrorCode::Bip32InvalidDerivePath, format!("Invalid bip32 derive path: {}", path))
+        error(ErrorCode::Bip32InvalidDerivePath, format!("Invalid bip32 derive path: {path}"))
     }
 
     pub fn bip39_invalid_dictionary(dictionary: u8) -> ClientError {
         error(
             ErrorCode::Bip39InvalidDictionary,
-            format!("Invalid mnemonic dictionary: {}", dictionary),
+            format!("Invalid mnemonic dictionary: {dictionary}"),
         )
     }
 
     pub fn bip39_invalid_word_count(word_count: u8) -> ClientError {
         error(
             ErrorCode::Bip39InvalidWordCount,
-            format!("Invalid mnemonic word count: {}", word_count),
+            format!("Invalid mnemonic word count: {word_count}"),
         )
     }
 
@@ -123,11 +123,11 @@ impl Error {
     }
 
     pub fn invalid_public_key<E: Display>(err: E, key: &String) -> ClientError {
-        error(ErrorCode::InvalidPublicKey, format!("Invalid public key [{}]: {}", key, err))
+        error(ErrorCode::InvalidPublicKey, format!("Invalid public key [{key}]: {err}"))
     }
 
     pub fn invalid_signature<E: Display>(err: E, signature: &String) -> ClientError {
-        error(ErrorCode::InvalidSignature, format!("Invalid signature [{}]: {}", signature, err))
+        error(ErrorCode::InvalidSignature, format!("Invalid signature [{signature}]: {err}"))
     }
 
     pub fn invalid_key<E: Display>(err: E, key: &str) -> ClientError {
@@ -141,76 +141,76 @@ impl Error {
     pub fn mnemonic_from_entropy_failed(reason: &str) -> ClientError {
         error(
             ErrorCode::MnemonicFromEntropyFailed,
-            format!("Mnemonic from entropy failed: {}", reason),
+            format!("Mnemonic from entropy failed: {reason}"),
         )
     }
 
     pub fn signing_box_not_registered(id: u32) -> ClientError {
         error(
             ErrorCode::SigningBoxNotRegistered,
-            format!("Signing box is not registered. ID {}", id),
+            format!("Signing box is not registered. ID {id}"),
         )
     }
 
     pub fn encryption_box_not_registered(id: u32) -> ClientError {
         error(
             ErrorCode::EncryptionBoxNotRegistered,
-            format!("Encryption box is not registered. ID {}", id),
+            format!("Encryption box is not registered. ID {id}"),
         )
     }
 
     pub fn invalid_iv_size(actual: usize, expected: usize) -> ClientError {
         error(
             ErrorCode::InvalidIvSize,
-            format!("Invalid IV size {}. Expected {}.", actual, expected),
+            format!("Invalid IV size {actual}. Expected {expected}."),
         )
     }
 
     pub fn unsupported_cipher_mode(mode: &str) -> ClientError {
-        error(ErrorCode::UnsupportedCipherMode, format!("Unsupported cipher mode: {}", mode))
+        error(ErrorCode::UnsupportedCipherMode, format!("Unsupported cipher mode: {mode}"))
     }
 
     pub fn cannot_create_cipher(err: impl Display) -> ClientError {
-        error(ErrorCode::CannotCreateCipher, format!("Can not create cipher: {}", err))
+        error(ErrorCode::CannotCreateCipher, format!("Can not create cipher: {err}"))
     }
 
     pub fn encrypt_data_error(err: impl Display) -> ClientError {
-        error(ErrorCode::EncryptDataError, format!("Can not encrypt data: {}", err))
+        error(ErrorCode::EncryptDataError, format!("Can not encrypt data: {err}"))
     }
 
     pub fn decrypt_data_error(err: impl Display) -> ClientError {
-        error(ErrorCode::DecryptDataError, format!("Can not decrypt data: {}", err))
+        error(ErrorCode::DecryptDataError, format!("Can not decrypt data: {err}"))
     }
 
     pub fn iv_required(mode: &CipherMode) -> ClientError {
         error(
             ErrorCode::DecryptDataError,
-            format!("initialization vector is required for {:?} cipher mode", mode),
+            format!("initialization vector is required for {mode:?} cipher mode"),
         )
     }
 
     pub fn crypto_box_not_registered(id: u32) -> ClientError {
-        error(ErrorCode::CryptoBoxNotRegistered, format!("Crypto box is not registered. ID {}", id))
+        error(ErrorCode::CryptoBoxNotRegistered, format!("Crypto box is not registered. ID {id}"))
     }
 
     pub fn invalid_crypto_box_type(crypto_box_type: impl Display) -> ClientError {
         error(
             ErrorCode::InvalidCryptoBoxType,
-            format!("Invalid crypto box type: {}", crypto_box_type),
+            format!("Invalid crypto box type: {crypto_box_type}"),
         )
     }
 
     pub fn crypto_box_secret_serialization_error(err: impl Display) -> ClientError {
         error(
             ErrorCode::CryptoBoxSecretSerializationError,
-            format!("Crypto box secret serialization error: {}", err),
+            format!("Crypto box secret serialization error: {err}"),
         )
     }
 
     pub fn crypto_box_secret_deserialization_error(err: impl Display) -> ClientError {
         error(
             ErrorCode::CryptoBoxSecretDeserializationError,
-            format!("Crypto box secret deserialization error: {}", err),
+            format!("Crypto box secret deserialization error: {err}"),
         )
     }
 

--- a/tvm_client/src/crypto/errors.rs
+++ b/tvm_client/src/crypto/errors.rs
@@ -146,10 +146,7 @@ impl Error {
     }
 
     pub fn signing_box_not_registered(id: u32) -> ClientError {
-        error(
-            ErrorCode::SigningBoxNotRegistered,
-            format!("Signing box is not registered. ID {id}"),
-        )
+        error(ErrorCode::SigningBoxNotRegistered, format!("Signing box is not registered. ID {id}"))
     }
 
     pub fn encryption_box_not_registered(id: u32) -> ClientError {
@@ -160,10 +157,7 @@ impl Error {
     }
 
     pub fn invalid_iv_size(actual: usize, expected: usize) -> ClientError {
-        error(
-            ErrorCode::InvalidIvSize,
-            format!("Invalid IV size {actual}. Expected {expected}."),
-        )
+        error(ErrorCode::InvalidIvSize, format!("Invalid IV size {actual}. Expected {expected}."))
     }
 
     pub fn unsupported_cipher_mode(mode: &str) -> ClientError {

--- a/tvm_client/src/crypto/hdkey.rs
+++ b/tvm_client/src/crypto/hdkey.rs
@@ -356,7 +356,7 @@ impl HDPrivateKey {
         Self::from_serialized(
             &string
                 .from_base58()
-                .map_err(|err| crypto::Error::bip32_invalid_key(format!("{:?}", err)))?,
+                .map_err(|err| crypto::Error::bip32_invalid_key(format!("{err:?}")))?,
         )
     }
 

--- a/tvm_client/src/crypto/keys.rs
+++ b/tvm_client/src/crypto/keys.rs
@@ -31,7 +31,7 @@ use crate::error::ClientResult;
 pub(crate) fn strip_secret(secret: &str) -> String {
     const SECRET_SHOW_LEN: usize = 8;
     if secret.len() <= SECRET_SHOW_LEN {
-        return format!(r#""{}""#, secret);
+        return format!(r#""{secret}""#);
     }
 
     format!(r#""{}..." ({} chars)"#, &secret[..SECRET_SHOW_LEN], secret.len(),)

--- a/tvm_client/src/crypto/math.rs
+++ b/tvm_client/src/crypto/math.rs
@@ -154,7 +154,7 @@ pub fn factorize(
         if p1 > p2 {
             std::mem::swap(&mut p1, &mut p2);
         }
-        Ok(ResultOfFactorize { factors: [format!("{:X}", p1), format!("{:X}", p2)] })
+        Ok(ResultOfFactorize { factors: [format!("{p1:X}"), format!("{p2:X}")] })
     } else {
         Err(invalid_composite(&params.composite, "Composite number can't be factorized"))
     }

--- a/tvm_client/src/crypto/tests.rs
+++ b/tvm_client/src/crypto/tests.rs
@@ -788,7 +788,7 @@ fn test_debug_keypair_secret_stripped() {
     );
 
     assert_eq!(
-        format!("{:?}", keypair),
+        format!("{keypair:?}"),
         "KeyPair { \
             public: \"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\", \
             secret: \"91234567...\" (64 chars) \
@@ -1476,7 +1476,7 @@ async fn test_crypto_box_derive_key_cache() -> tvm_types::Result<()> {
             .request_async_callback(
                 "crypto.create_crypto_box",
                 ParamsOfCreateCryptoBox {
-                    secret_encryption_salt: format!("{}{}", salt, i),
+                    secret_encryption_salt: format!("{salt}{i}"),
                     secret: CryptoBoxSecret::PredefinedSeedPhrase {
                         dictionary: MnemonicDictionary::English,
                         wordcount: 12,

--- a/tvm_client/src/debot/action.rs
+++ b/tvm_client/src/debot/action.rs
@@ -156,5 +156,5 @@ where
         AcType::Unknown => 255,
     };
 
-    s.serialize_str(&format!("{:x}", num))
+    s.serialize_str(&format!("{num:x}"))
 }

--- a/tvm_client/src/debot/base64_interface.rs
+++ b/tvm_client/src/debot/base64_interface.rs
@@ -67,7 +67,7 @@ impl Base64Interface {
 
     fn encode(&self, args: &Value) -> InterfaceResult {
         let answer_id = decode_answer_id(args)?;
-        let data_to_encode = hex::decode(get_arg(args, "data")?).map_err(|e| format!("{}", e))?;
+        let data_to_encode = hex::decode(get_arg(args, "data")?).map_err(|e| format!("{e}"))?;
         let encoded = base64_encode(data_to_encode);
         Ok((answer_id, json!({ "base64": encoded })))
     }
@@ -75,7 +75,7 @@ impl Base64Interface {
     fn decode(&self, args: &Value) -> InterfaceResult {
         let answer_id = decode_answer_id(args)?;
         let str_to_decode = get_arg(args, "base64")?;
-        let decoded = base64_decode(str_to_decode).map_err(|e| format!("invalid base64: {}", e))?;
+        let decoded = base64_decode(str_to_decode).map_err(|e| format!("invalid base64: {e}"))?;
         Ok((answer_id, json!({ "data": hex::encode(decoded) })))
     }
 }
@@ -94,7 +94,7 @@ impl DebotInterface for Base64Interface {
         match func {
             "encode" => self.encode(args),
             "decode" => self.decode(args),
-            _ => Err(format!("function \"{}\" is not implemented", func)),
+            _ => Err(format!("function \"{func}\" is not implemented")),
         }
     }
 }

--- a/tvm_client/src/debot/calltype.rs
+++ b/tvm_client/src/debot/calltype.rs
@@ -81,8 +81,7 @@ impl TryFrom<MsgAddressExt> for Metadata {
                 let abi_ver = slice.get_next_byte().map_err(msg_err)?;
                 if (abi_ver & 0x0F) != SUPPORTED_ABI_VERSION {
                     return Err(msg_err(format!(
-                        "unsupported major ABI version in src address (must be {})",
-                        SUPPORTED_ABI_VERSION
+                        "unsupported major ABI version in src address (must be {SUPPORTED_ABI_VERSION})"
                     )));
                 }
                 let is_timestamp = slice.get_next_bit().map_err(msg_err)?;
@@ -139,7 +138,7 @@ pub fn prepare_ext_in_message(
 
     let result = tvm_client.env.block_on(future);
 
-    let (func_id, msg) = result.map_err(|e| format!("prepare_ext_in_message: {:?}", e))?;
+    let (func_id, msg) = result.map_err(|e| format!("prepare_ext_in_message: {e:?}"))?;
 
     Ok((func_id, meta.answer_id, meta.onerror_id, dst_addr, msg))
 }
@@ -357,7 +356,7 @@ impl ContractCall {
         }
         let browser = self.browser.clone();
         let callback = move |event| {
-            debug!("{:?}", event);
+            debug!("{event:?}");
             let browser = browser.clone();
             async move {
                 if let ProcessingEvent::WillSend {
@@ -379,7 +378,7 @@ impl ContractCall {
         )
         .await
         .map(|e| {
-            error!("{:?}", e);
+            error!("{e:?}");
             e
         })?;
         let msg_id =
@@ -431,7 +430,7 @@ impl ContractCall {
                     build_internal_message(&self.dest_addr, &self.debot_addr, new_body)
                 }
                 Err(e) => {
-                    debug!("Transaction failed: {:?}", e);
+                    debug!("Transaction failed: {e:?}");
                     self.build_error_answer_msg(e)
                 }
             }

--- a/tvm_client/src/debot/dengine.rs
+++ b/tvm_client/src/debot/dengine.rs
@@ -229,9 +229,8 @@ impl DEngine {
         let result = self.run_debot_external("fetch", None).await;
         let mut context_vec: Vec<DContext> = if let Ok(res) = result {
             let mut output = res.return_value.unwrap_or(json!({}));
-            serde_json::from_value(output["contexts"].take()).map_err(|e| {
-                format!("failed to parse \"contexts\" returned from \"fetch\": {e}")
-            })?
+            serde_json::from_value(output["contexts"].take())
+                .map_err(|e| format!("failed to parse \"contexts\" returned from \"fetch\": {e}"))?
         } else {
             vec![]
         };

--- a/tvm_client/src/debot/dinterface.rs
+++ b/tvm_client/src/debot/dinterface.rs
@@ -102,7 +102,7 @@ pub trait DebotInterfaceExecutor {
         abi_version: &str,
     ) -> InterfaceResult {
         let parsed = parse_message(client.clone(), ParamsOfParse { boc: msg.to_owned() })
-            .map_err(|e| format!("{}", e))?;
+            .map_err(|e| format!("{e}"))?;
 
         let body = parsed.parsed["body"]
             .as_str()
@@ -117,7 +117,7 @@ pub trait DebotInterfaceExecutor {
                 let (answer_id, mut ret_args) = object
                     .call(&func, &args)
                     .await
-                    .map_err(|e| format!("interface {}.{} failed: {}", interface_id, func, e))?;
+                    .map_err(|e| format!("interface {interface_id}.{func} failed: {e}"))?;
                 if abi_version == "2.0" {
                     if let Abi::Json(json_str) = abi {
                         let _ = convert_return_args(json_str.as_str(), &func, &mut ret_args)?;
@@ -126,7 +126,7 @@ pub trait DebotInterfaceExecutor {
                 Ok((answer_id, ret_args))
             }
             None => {
-                debug!("interface {} not implemented", interface_id);
+                debug!("interface {interface_id} not implemented");
                 Ok((0, json!({})))
             }
         }
@@ -134,10 +134,10 @@ pub trait DebotInterfaceExecutor {
 }
 
 fn convert_return_args(abi: &str, fname: &str, ret_args: &mut Value) -> Result<(), String> {
-    let contract = Contract::load(abi.as_bytes()).map_err(|e| format!("{}", e))?;
+    let contract = Contract::load(abi.as_bytes()).map_err(|e| format!("{e}"))?;
     let func = contract
         .function(fname)
-        .map_err(|_| format!("function with name '{}' not found", fname))?;
+        .map_err(|_| format!("function with name '{fname}' not found"))?;
     let output = func.outputs.iter();
     for val in output {
         let pointer = "";
@@ -196,11 +196,11 @@ pub fn decode_answer_id(args: &Value) -> Result<u32, String> {
     decode_abi_number::<u32>(
         args["answerId"].as_str().ok_or("answer id not found in argument list".to_string())?,
     )
-    .map_err(|e| format!("{}", e))
+    .map_err(|e| format!("{e}"))
 }
 
 pub fn get_arg(args: &Value, name: &str) -> Result<String, String> {
-    args[name].as_str().ok_or(format!("\"{}\" not found", name)).map(|v| v.to_string())
+    args[name].as_str().ok_or(format!("\"{name}\" not found")).map(|v| v.to_string())
 }
 
 pub fn get_num_arg<T>(args: &Value, name: &str) -> Result<T, String>
@@ -209,15 +209,15 @@ where
 {
     let num_str = get_arg(args, name)?;
     decode_abi_number::<T>(&num_str)
-        .map_err(|e| format!("failed to parse integer \"{}\": {}", num_str, e))
+        .map_err(|e| format!("failed to parse integer \"{num_str}\": {e}"))
 }
 
 pub fn get_bool_arg(args: &Value, name: &str) -> Result<bool, String> {
-    args[name].as_bool().ok_or(format!("\"{}\" not found", name))
+    args[name].as_bool().ok_or(format!("\"{name}\" not found"))
 }
 
 pub fn get_array_strings(args: &Value, name: &str) -> Result<Vec<String>, String> {
-    let array = args[name].as_array().ok_or(format!("\"{}\" is invalid: must be array", name))?;
+    let array = args[name].as_array().ok_or(format!("\"{name}\" is invalid: must be array"))?;
     let mut strings = vec![];
     for elem in array {
         let string =

--- a/tvm_client/src/debot/dinterface.rs
+++ b/tvm_client/src/debot/dinterface.rs
@@ -135,9 +135,8 @@ pub trait DebotInterfaceExecutor {
 
 fn convert_return_args(abi: &str, fname: &str, ret_args: &mut Value) -> Result<(), String> {
     let contract = Contract::load(abi.as_bytes()).map_err(|e| format!("{e}"))?;
-    let func = contract
-        .function(fname)
-        .map_err(|_| format!("function with name '{fname}' not found"))?;
+    let func =
+        contract.function(fname).map_err(|_| format!("function with name '{fname}' not found"))?;
     let output = func.outputs.iter();
     for val in output {
         let pointer = "";

--- a/tvm_client/src/debot/errors.rs
+++ b/tvm_client/src/debot/errors.rs
@@ -37,43 +37,43 @@ pub fn error(code: ErrorCode, message: String) -> ClientError {
 
 impl Error {
     pub fn start_failed(err: impl Display) -> ClientError {
-        error(ErrorCode::DebotStartFailed, format!("Debot start failed: {}", err))
+        error(ErrorCode::DebotStartFailed, format!("Debot start failed: {err}"))
     }
 
     pub fn fetch_failed(err: impl Display) -> ClientError {
-        error(ErrorCode::DebotFetchFailed, format!("Debot fetch failed: {}", err))
+        error(ErrorCode::DebotFetchFailed, format!("Debot fetch failed: {err}"))
     }
 
     pub fn execute_failed(err: impl Display) -> ClientError {
-        error(ErrorCode::DebotExecutionFailed, format!("Debot execution failed: {}", err))
+        error(ErrorCode::DebotExecutionFailed, format!("Debot execution failed: {err}"))
     }
 
     pub fn invalid_handle(handle: u32) -> ClientError {
-        error(ErrorCode::DebotInvalidHandle, format!("Invalid debot handle: {}", handle))
+        error(ErrorCode::DebotInvalidHandle, format!("Invalid debot handle: {handle}"))
     }
 
     pub fn invalid_json_params(err: impl Display) -> ClientError {
-        error(ErrorCode::DebotInvalidJsonParams, format!("Invalid json parameters: {}", err))
+        error(ErrorCode::DebotInvalidJsonParams, format!("Invalid json parameters: {err}"))
     }
 
     pub fn invalid_function_id(err: impl Display) -> ClientError {
-        error(ErrorCode::DebotInvalidFunctionId, format!("Invalid function id: {}", err))
+        error(ErrorCode::DebotInvalidFunctionId, format!("Invalid function id: {err}"))
     }
 
     pub fn invalid_debot_abi(err: impl Display) -> ClientError {
-        error(ErrorCode::DebotInvalidAbi, format!("Invalid debot ABI: {}", err))
+        error(ErrorCode::DebotInvalidAbi, format!("Invalid debot ABI: {err}"))
     }
 
     pub fn get_method_failed(err: impl Display) -> ClientError {
-        error(ErrorCode::DebotGetMethodFailed, format!("get-method call failed: {}", err))
+        error(ErrorCode::DebotGetMethodFailed, format!("get-method call failed: {err}"))
     }
 
     pub fn invalid_msg(err: impl Display) -> ClientError {
-        error(ErrorCode::DebotInvalidMsg, format!("invalid msg ({})", err))
+        error(ErrorCode::DebotInvalidMsg, format!("invalid msg ({err})"))
     }
 
     pub fn external_call_failed(err: impl Display) -> ClientError {
-        error(ErrorCode::DebotExternalCallFailed, format!("external call failed: ({})", err))
+        error(ErrorCode::DebotExternalCallFailed, format!("external call failed: ({err})"))
     }
 
     pub fn operation_rejected() -> ClientError {
@@ -83,7 +83,7 @@ impl Error {
     pub fn browser_callback_failed(err: impl Display) -> ClientError {
         error(
             ErrorCode::DebotBrowserCallbackFailed,
-            format!("Debot browser callback failed: {}", err),
+            format!("Debot browser callback failed: {err}"),
         )
     }
 

--- a/tvm_client/src/debot/hex_interface.rs
+++ b/tvm_client/src/debot/hex_interface.rs
@@ -56,7 +56,7 @@ impl HexInterface {
     fn decode(&self, args: &Value) -> InterfaceResult {
         let answer_id = decode_answer_id(args)?;
         let str_to_decode = get_arg(args, "hexstr")?;
-        let decoded = hex::decode(str_to_decode).map_err(|e| format!("invalid hex: {}", e))?;
+        let decoded = hex::decode(str_to_decode).map_err(|e| format!("invalid hex: {e}"))?;
         Ok((answer_id, json!({ "data": hex::encode(decoded) })))
     }
 }
@@ -75,7 +75,7 @@ impl DebotInterface for HexInterface {
         match func {
             "encode" => self.encode(args),
             "decode" => self.decode(args),
-            _ => Err(format!("function \"{}\" is not implemented", func)),
+            _ => Err(format!("function \"{func}\" is not implemented")),
         }
     }
 }

--- a/tvm_client/src/debot/info.rs
+++ b/tvm_client/src/debot/info.rs
@@ -60,7 +60,7 @@ fn convert_to_utf8(hex_str: &mut Option<String>) -> Result<(), String> {
 pub(crate) fn parse_debot_info(value: Option<JsonValue>) -> Result<DInfo, String> {
     let value = value.unwrap_or(json!({}));
     let mut info: DInfo = serde_json::from_value(value)
-        .map_err(|e| format!("failed to parse \"DebotInfo\": {}", e))?;
+        .map_err(|e| format!("failed to parse \"DebotInfo\": {e}"))?;
     // Ignore error because debot ABI can be loaded in 2 ways: as string or as
     // bytes.
     let _ = convert_to_utf8(&mut info.dabi);

--- a/tvm_client/src/debot/info.rs
+++ b/tvm_client/src/debot/info.rs
@@ -59,8 +59,8 @@ fn convert_to_utf8(hex_str: &mut Option<String>) -> Result<(), String> {
 
 pub(crate) fn parse_debot_info(value: Option<JsonValue>) -> Result<DInfo, String> {
     let value = value.unwrap_or(json!({}));
-    let mut info: DInfo = serde_json::from_value(value)
-        .map_err(|e| format!("failed to parse \"DebotInfo\": {e}"))?;
+    let mut info: DInfo =
+        serde_json::from_value(value).map_err(|e| format!("failed to parse \"DebotInfo\": {e}"))?;
     // Ignore error because debot ABI can be loaded in 2 ways: as string or as
     // bytes.
     let _ = convert_to_utf8(&mut info.dabi);

--- a/tvm_client/src/debot/json_interface.rs
+++ b/tvm_client/src/debot/json_interface.rs
@@ -58,7 +58,7 @@ impl JsonInterface {
         let answer_id = decode_answer_id(args)?;
         let json_str = get_arg(args, "json")?;
         let mut json_obj: JsonValue = serde_json::from_str(&json_str)
-            .map_err(|e| format!("argument \"json\" is not a valid json: {}", e))?;
+            .map_err(|e| format!("argument \"json\" is not a valid json: {e}"))?;
         self.deserialize_json(&mut json_obj, answer_id)?;
         Ok((
             answer_id,
@@ -73,7 +73,7 @@ impl JsonInterface {
         let answer_id = decode_answer_id(args)?;
         let json_str = get_arg(args, "json")?;
         let json_obj: JsonValue = serde_json::from_str(&json_str)
-            .map_err(|e| format!("argument \"json\" is not a valid json: {}", e))?;
+            .map_err(|e| format!("argument \"json\" is not a valid json: {e}"))?;
         let result = pack(json_obj);
         Ok((
             answer_id,
@@ -85,10 +85,10 @@ impl JsonInterface {
     }
 
     fn deserialize_json(&self, json_obj: &mut JsonValue, answer_id: u32) -> Result<(), String> {
-        let contract = Contract::load(self.debot_abi.as_bytes()).map_err(|e| format!("{}", e))?;
+        let contract = Contract::load(self.debot_abi.as_bytes()).map_err(|e| format!("{e}"))?;
         let func = contract
             .function_by_id(answer_id, true)
-            .map_err(|_| format!("function with id {} not found", answer_id))?;
+            .map_err(|_| format!("function with id {answer_id} not found"))?;
         let obj = func
             .inputs
             .iter()
@@ -118,7 +118,7 @@ impl DebotInterface for JsonInterface {
         match func {
             "deserialize" => self.deserialize(args),
             "parse" => self.parse(args),
-            _ => Err(format!("function \"{}\" is not implemented", func)),
+            _ => Err(format!("function \"{func}\" is not implemented")),
         }
     }
 }

--- a/tvm_client/src/debot/json_lib_utils.rs
+++ b/tvm_client/src/debot/json_lib_utils.rs
@@ -158,7 +158,7 @@ fn try_replace_hyphens(obj: &mut JsonValue, pointer: &str, name: &str) -> Result
                     map.insert(name.to_owned(), value);
                 }
             }
-            None => Err(format!("key not found: \"{}\"", name))?,
+            None => Err(format!("key not found: \"{name}\""))?,
         }
     }
     Ok(())
@@ -198,7 +198,7 @@ pub(crate) fn bypass_json(
         ParamType::Array(ref elem_type) => {
             let elem_count = obj
                 .pointer(&pointer)
-                .ok_or_else(|| format!("\"{}\" not found", pointer))?
+                .ok_or_else(|| format!("\"{pointer}\" not found"))?
                 .as_array()
                 .ok_or_else(|| String::from("Failed to retrieve an array"))?
                 .len();
@@ -214,7 +214,7 @@ pub(crate) fn bypass_json(
         ParamType::Map(_, ref value) => {
             let keys: Vec<String> = obj
                 .pointer(&pointer)
-                .ok_or_else(|| format!("\"{}\" not found", pointer))?
+                .ok_or_else(|| format!("\"{pointer}\" not found"))?
                 .as_object()
                 .ok_or_else(|| String::from("Failed to retrieve an object"))?
                 .keys()

--- a/tvm_client/src/debot/msg_interface.rs
+++ b/tvm_client/src/debot/msg_interface.rs
@@ -111,8 +111,7 @@ impl MsgInterface {
         .map_err(|e| format!("failed to decode message: {e}"))?;
         let abi_str = self.debot_abi.json_string().unwrap();
         let contract = Contract::load(abi_str.as_bytes()).map_err(|e| format!("{e}"))?;
-        let answer_id =
-            contract.function(&result.name).map_err(|e| format!("{e}"))?.get_input_id();
+        let answer_id = contract.function(&result.name).map_err(|e| format!("{e}"))?.get_input_id();
         Ok((answer_id, result.value.unwrap_or_default()))
     }
 
@@ -149,8 +148,7 @@ impl MsgInterface {
         .map_err(|e| format!("failed to decode message: {e}"))?;
         let abi_str = self.debot_abi.json_string().unwrap();
         let contract = Contract::load(abi_str.as_bytes()).map_err(|e| format!("{e}"))?;
-        let answer_id =
-            contract.function(&result.name).map_err(|e| format!("{e}"))?.get_input_id();
+        let answer_id = contract.function(&result.name).map_err(|e| format!("{e}"))?.get_input_id();
         Ok((answer_id, result.value.unwrap_or_default()))
     }
 }

--- a/tvm_client/src/debot/msg_interface.rs
+++ b/tvm_client/src/debot/msg_interface.rs
@@ -74,14 +74,14 @@ impl MsgInterface {
     async fn send_with_keypair(&self, args: &Value) -> InterfaceResult {
         let message = get_arg(args, "message")?;
         let public = get_arg(args, "pub")?;
-        let public = decode_abi_bigint(&public).map_err(|e| format!("{}", e))?;
+        let public = decode_abi_bigint(&public).map_err(|e| format!("{e}"))?;
         let secret = get_arg(args, "sec")?;
-        let secret = decode_abi_bigint(&secret).map_err(|e| format!("{}", e))?;
-        let kpair = KeyPair::new(format!("{:064x}", public), format!("{:064x}", secret));
+        let secret = decode_abi_bigint(&secret).map_err(|e| format!("{e}"))?;
+        let kpair = KeyPair::new(format!("{public:064x}"), format!("{secret:064x}"));
         let signing_box =
-            get_signing_box(self.ton.clone(), kpair).await.map_err(|e| format!("{}", e))?.handle;
+            get_signing_box(self.ton.clone(), kpair).await.map_err(|e| format!("{e}"))?.handle;
         let parsed_msg = parse_message(self.ton.clone(), ParamsOfParse { boc: message.clone() })
-            .map_err(|e| format!("{}", e))?
+            .map_err(|e| format!("{e}"))?
             .parsed;
         let dest =
             parsed_msg["dst"].as_str().ok_or("failed to parse dst address".to_string())?.to_owned();
@@ -97,8 +97,8 @@ impl MsgInterface {
             false,
         )
         .await
-        .map_err(|e| format!("{}", e))?;
-        let answer_msg = callobj.execute(true).await.map_err(|e| format!("{}", e))?;
+        .map_err(|e| format!("{e}"))?;
+        let answer_msg = callobj.execute(true).await.map_err(|e| format!("{e}"))?;
 
         let result = decode_message(
             self.ton.clone(),
@@ -108,18 +108,18 @@ impl MsgInterface {
                 ..Default::default()
             },
         )
-        .map_err(|e| format!("failed to decode message: {}", e))?;
+        .map_err(|e| format!("failed to decode message: {e}"))?;
         let abi_str = self.debot_abi.json_string().unwrap();
-        let contract = Contract::load(abi_str.as_bytes()).map_err(|e| format!("{}", e))?;
+        let contract = Contract::load(abi_str.as_bytes()).map_err(|e| format!("{e}"))?;
         let answer_id =
-            contract.function(&result.name).map_err(|e| format!("{}", e))?.get_input_id();
+            contract.function(&result.name).map_err(|e| format!("{e}"))?.get_input_id();
         Ok((answer_id, result.value.unwrap_or_default()))
     }
 
     async fn send_async(&self, args: &Value) -> InterfaceResult {
         let message = get_arg(args, "message")?;
         let parsed_msg = parse_message(self.ton.clone(), ParamsOfParse { boc: message.clone() })
-            .map_err(|e| format!("{}", e))?
+            .map_err(|e| format!("{e}"))?
             .parsed;
         let dest =
             parsed_msg["dst"].as_str().ok_or("failed to parse dst address".to_string())?.to_owned();
@@ -135,8 +135,8 @@ impl MsgInterface {
             false,
         )
         .await
-        .map_err(|e| format!("{}", e))?;
-        let answer_msg = callobj.execute(false).await.map_err(|e| format!("{}", e))?;
+        .map_err(|e| format!("{e}"))?;
+        let answer_msg = callobj.execute(false).await.map_err(|e| format!("{e}"))?;
 
         let result = decode_message(
             self.ton.clone(),
@@ -146,11 +146,11 @@ impl MsgInterface {
                 ..Default::default()
             },
         )
-        .map_err(|e| format!("failed to decode message: {}", e))?;
+        .map_err(|e| format!("failed to decode message: {e}"))?;
         let abi_str = self.debot_abi.json_string().unwrap();
-        let contract = Contract::load(abi_str.as_bytes()).map_err(|e| format!("{}", e))?;
+        let contract = Contract::load(abi_str.as_bytes()).map_err(|e| format!("{e}"))?;
         let answer_id =
-            contract.function(&result.name).map_err(|e| format!("{}", e))?.get_input_id();
+            contract.function(&result.name).map_err(|e| format!("{e}"))?.get_input_id();
         Ok((answer_id, result.value.unwrap_or_default()))
     }
 }
@@ -169,7 +169,7 @@ impl DebotInterface for MsgInterface {
         match func {
             "sendWithKeypair" => self.send_with_keypair(args).await,
             "sendAsync" => self.send_async(args).await,
-            _ => Err(format!("function \"{}\" is not implemented", func)),
+            _ => Err(format!("function \"{func}\" is not implemented")),
         }
     }
 }

--- a/tvm_client/src/debot/network_interface.rs
+++ b/tvm_client/src/debot/network_interface.rs
@@ -104,11 +104,11 @@ impl NetworkInterface {
                 self.client.config.network.query_timeout,
             )
             .await
-            .map_err(|e| format!("{}", e))?;
+            .map_err(|e| format!("{e}"))?;
 
         let mut ret_headers: Vec<String> = vec![];
         for (k, v) in response.headers.iter() {
-            ret_headers.push(format!("{}: {:?}", k, v));
+            ret_headers.push(format!("{k}: {v:?}"));
         }
         let status = response.status;
         let content = response.body;
@@ -134,7 +134,7 @@ impl DebotInterface for NetworkInterface {
         match func {
             "get" => self.get(args).await,
             "post" => self.post(args).await,
-            _ => Err(format!("function \"{}\" is not implemented", func)),
+            _ => Err(format!("function \"{func}\" is not implemented")),
         }
     }
 }

--- a/tvm_client/src/debot/query_interface.rs
+++ b/tvm_client/src/debot/query_interface.rs
@@ -284,7 +284,7 @@ impl DebotInterface for QueryInterface {
             "collection" => self.collection(args).await,
             "waitForCollection" => self.wait_for_collection(args).await,
             "query" => self.query(args).await,
-            _ => Err(format!("function \"{}\" is not implemented", func)),
+            _ => Err(format!("function \"{func}\" is not implemented")),
         }
     }
 }

--- a/tvm_client/src/debot/routines.rs
+++ b/tvm_client/src/debot/routines.rs
@@ -75,8 +75,7 @@ pub async fn call_routine(
             let args = if arg_json.is_err() { json!({ "addr": arg }) } else { arg_json? };
             debug!("getAccountState({args})");
             let acc = get_account_state(ton, &args).await;
-            serde_json::to_value(acc)
-                .map_err(|e| format!("failed to serialize account state: {e}"))
+            serde_json::to_value(acc).map_err(|e| format!("failed to serialize account state: {e}"))
         }
         "loadBocFromFile" => {
             debug!("loadBocFromFile({arg})");
@@ -188,8 +187,7 @@ pub(super) fn format_arg(params: &serde_json::Value, i: usize) -> String {
 }
 
 pub(super) fn load_boc_from_file(_ton: TonClient, arg: &str) -> Result<String, String> {
-    let boc =
-        std::fs::read(arg).map_err(|e| format!(r#"failed to read boc file "{arg}": {e}"#))?;
+    let boc = std::fs::read(arg).map_err(|e| format!(r#"failed to read boc file "{arg}": {e}"#))?;
     Ok(base64_encode(boc))
 }
 

--- a/tvm_client/src/debot/sdk_interface.rs
+++ b/tvm_client/src/debot/sdk_interface.rs
@@ -663,8 +663,7 @@ impl SdkInterface {
     async fn encrypt_or_decrypt(&self, args: &Value, encrypt: bool) -> InterfaceResult {
         let answer_id = decode_answer_id(args)?;
         let encryption_box = EncryptionBoxHandle(get_num_arg::<u32>(args, "boxHandle")?);
-        let data =
-            base64_encode(hex::decode(get_arg(args, "data")?).map_err(|e| format!("{e}"))?);
+        let data = base64_encode(hex::decode(get_arg(args, "data")?).map_err(|e| format!("{e}"))?);
         let result = if encrypt {
             encryption_box_encrypt(
                 self.ton.clone(),

--- a/tvm_client/src/debot/sdk_interface.rs
+++ b/tvm_client/src/debot/sdk_interface.rs
@@ -406,7 +406,7 @@ impl SdkInterface {
         let code_hash_str = match &res {
             Ok(acc) => acc["code_hash"].as_str().unwrap_or("0"),
             Err(e) => {
-                debug!("get_account_code_hash failed: {}", e);
+                debug!("get_account_code_hash failed: {e}");
                 "0"
             }
         };
@@ -417,7 +417,7 @@ impl SdkInterface {
         let answer_id = decode_answer_id(args)?;
         let rnd = routines::generate_random(self.ton.clone(), args)?;
         let buf = base64_decode(rnd)
-            .map_err(|e| format!("failed to decode random buffer to byte array: {}", e))?;
+            .map_err(|e| format!("failed to decode random buffer to byte array: {e}"))?;
         Ok((answer_id, json!({ "buffer": hex::encode(buf) })))
     }
 
@@ -427,7 +427,7 @@ impl SdkInterface {
         let nonce = get_arg(args, "nonce")?;
         let key = get_arg(args, "key")?;
         let result = chacha20(self.ton.clone(), ParamsOfChaCha20 { data, key, nonce })
-            .map_err(|e| format!("{}", e))?;
+            .map_err(|e| format!("{e}"))?;
         Ok((answer_id, json!({ "output": hex::encode(base64_decode(result.data).unwrap()) })))
     }
 
@@ -441,7 +441,7 @@ impl SdkInterface {
             self.ton.clone(),
             ParamsOfMnemonicFromRandom { dictionary: Some(dict), word_count: Some(word_count) },
         )
-        .map_err(|e| format!("{}", e))?;
+        .map_err(|e| format!("{e}"))?;
         Ok((answer_id, json!({ "phrase": result.phrase })))
     }
 
@@ -458,7 +458,7 @@ impl SdkInterface {
                 word_count: None,
             },
         )
-        .map_err(|e| format!("{}", e))?;
+        .map_err(|e| format!("{e}"))?;
 
         Ok((
             answer_id,
@@ -476,7 +476,7 @@ impl SdkInterface {
             self.ton.clone(),
             ParamsOfMnemonicVerify { phrase, dictionary: None, word_count: None },
         )
-        .map_err(|e| format!("{}", e))?;
+        .map_err(|e| format!("{e}"))?;
         Ok((answer_id, json!({ "valid": result.valid })))
     }
 
@@ -487,7 +487,7 @@ impl SdkInterface {
             self.ton.clone(),
             ParamsOfHDKeyXPrvFromMnemonic { phrase, dictionary: None, word_count: None },
         )
-        .map_err(|e| format!("{}", e))?;
+        .map_err(|e| format!("{e}"))?;
         Ok((answer_id, json!({ "xprv": result.xprv })))
     }
 
@@ -495,7 +495,7 @@ impl SdkInterface {
         let answer_id = decode_answer_id(args)?;
         let xprv = get_arg(args, "xprv")?;
         let result = hdkey_public_from_xprv(self.ton.clone(), ParamsOfHDKeyPublicFromXPrv { xprv })
-            .map_err(|e| format!("{}", e))?;
+            .map_err(|e| format!("{e}"))?;
         Ok((answer_id, json!({ "pub": format!("0x{}", result.public) })))
     }
 
@@ -508,7 +508,7 @@ impl SdkInterface {
             self.ton.clone(),
             ParamsOfHDKeyDeriveFromXPrv { xprv, child_index, hardened },
         )
-        .map_err(|e| format!("{}", e))?;
+        .map_err(|e| format!("{e}"))?;
         Ok((answer_id, json!({ "xprv": result.xprv })))
     }
 
@@ -520,7 +520,7 @@ impl SdkInterface {
             self.ton.clone(),
             ParamsOfHDKeyDeriveFromXPrvPath { xprv, path },
         )
-        .map_err(|e| format!("{}", e))?;
+        .map_err(|e| format!("{e}"))?;
         Ok((answer_id, json!({ "xprv": result.xprv })))
     }
 
@@ -528,18 +528,18 @@ impl SdkInterface {
         let answer_id = decode_answer_id(args)?;
         let xprv = get_arg(args, "xprv")?;
         let result = hdkey_secret_from_xprv(self.ton.clone(), ParamsOfHDKeySecretFromXPrv { xprv })
-            .map_err(|e| format!("{}", e))?;
+            .map_err(|e| format!("{e}"))?;
         Ok((answer_id, json!({ "sec": format!("0x{}", result.secret) })))
     }
 
     fn nacl_sign_keypair_from_secret_key(&self, args: &Value) -> InterfaceResult {
         let answer_id = decode_answer_id(args)?;
-        let secret = decode_abi_bigint(&get_arg(args, "secret")?).map_err(|e| format!("{}", e))?;
+        let secret = decode_abi_bigint(&get_arg(args, "secret")?).map_err(|e| format!("{e}"))?;
         let result = nacl_sign_keypair_from_secret_key(
             self.ton.clone(),
-            ParamsOfNaclSignKeyPairFromSecret { secret: format!("{:064x}", secret) },
+            ParamsOfNaclSignKeyPairFromSecret { secret: format!("{secret:064x}") },
         )
-        .map_err(|e| format!("{}", e))?;
+        .map_err(|e| format!("{e}"))?;
         Ok((
             answer_id,
             json!({
@@ -571,7 +571,7 @@ impl SdkInterface {
     fn nacl_box(&self, args: &Value) -> InterfaceResult {
         let answer_id = decode_answer_id(args)?;
         let decrypted =
-            base64_encode(hex::decode(get_arg(args, "decrypted")?).map_err(|e| format!("{}", e))?);
+            base64_encode(hex::decode(get_arg(args, "decrypted")?).map_err(|e| format!("{e}"))?);
         let nonce = get_arg(args, "nonce")?;
         let public = decode_abi_bigint(&get_arg(args, "publicKey")?).map_err(|e| e.to_string())?;
         let secret = decode_abi_bigint(&get_arg(args, "secretKey")?).map_err(|e| e.to_string())?;
@@ -580,21 +580,21 @@ impl SdkInterface {
             ParamsOfNaclBox {
                 decrypted,
                 nonce,
-                their_public: format!("{:064x}", public),
-                secret: format!("{:064x}", secret),
+                their_public: format!("{public:064x}"),
+                secret: format!("{secret:064x}"),
             },
         )
-        .map_err(|e| format!("{}", e))?;
+        .map_err(|e| format!("{e}"))?;
         Ok((
             answer_id,
-            json!({ "encrypted": hex::encode(base64_decode(result.encrypted).map_err(|e| format!("{}", e))?) }),
+            json!({ "encrypted": hex::encode(base64_decode(result.encrypted).map_err(|e| format!("{e}"))?) }),
         ))
     }
 
     fn nacl_box_open(&self, args: &Value) -> InterfaceResult {
         let answer_id = decode_answer_id(args)?;
         let encrypted =
-            base64_encode(hex::decode(get_arg(args, "encrypted")?).map_err(|e| format!("{}", e))?);
+            base64_encode(hex::decode(get_arg(args, "encrypted")?).map_err(|e| format!("{e}"))?);
         let nonce = get_arg(args, "nonce")?;
         let public = decode_abi_bigint(&get_arg(args, "publicKey")?).map_err(|e| e.to_string())?;
         let secret = decode_abi_bigint(&get_arg(args, "secretKey")?).map_err(|e| e.to_string())?;
@@ -603,25 +603,25 @@ impl SdkInterface {
             ParamsOfNaclBoxOpen {
                 encrypted,
                 nonce,
-                their_public: format!("{:064x}", public),
-                secret: format!("{:064x}", secret),
+                their_public: format!("{public:064x}"),
+                secret: format!("{secret:064x}"),
             },
         )
-        .map_err(|e| format!("{}", e))?;
+        .map_err(|e| format!("{e}"))?;
         Ok((
             answer_id,
-            json!({ "decrypted": hex::encode(base64_decode(result.decrypted).map_err(|e| format!("{}", e))?) }),
+            json!({ "decrypted": hex::encode(base64_decode(result.decrypted).map_err(|e| format!("{e}"))?) }),
         ))
     }
 
     fn nacl_box_keypair_from_secret_key(&self, args: &Value) -> InterfaceResult {
         let answer_id = decode_answer_id(args)?;
-        let secret = decode_abi_bigint(&get_arg(args, "secret")?).map_err(|e| format!("{}", e))?;
+        let secret = decode_abi_bigint(&get_arg(args, "secret")?).map_err(|e| format!("{e}"))?;
         let result = nacl_box_keypair_from_secret_key(
             self.ton.clone(),
-            ParamsOfNaclBoxKeyPairFromSecret { secret: format!("{:064x}", secret) },
+            ParamsOfNaclBoxKeyPairFromSecret { secret: format!("{secret:064x}") },
         )
-        .map_err(|e| format!("{}", e))?;
+        .map_err(|e| format!("{e}"))?;
         Ok((
             answer_id,
             json!({
@@ -664,7 +664,7 @@ impl SdkInterface {
         let answer_id = decode_answer_id(args)?;
         let encryption_box = EncryptionBoxHandle(get_num_arg::<u32>(args, "boxHandle")?);
         let data =
-            base64_encode(hex::decode(get_arg(args, "data")?).map_err(|e| format!("{}", e))?);
+            base64_encode(hex::decode(get_arg(args, "data")?).map_err(|e| format!("{e}"))?);
         let result = if encrypt {
             encryption_box_encrypt(
                 self.ton.clone(),
@@ -687,7 +687,7 @@ impl SdkInterface {
             Ok(data) => {
                 let data = base64_decode(data)
                     .map(hex::encode)
-                    .map_err(|e| format!("failed to decode base64: {}", e))?;
+                    .map_err(|e| format!("failed to decode base64: {e}"))?;
                 (0, data)
             }
             Err(code) => (code, "".to_owned()),
@@ -706,7 +706,7 @@ impl SdkInterface {
         let code_hash = get_arg(args, "codeHash")?;
         let gt_addr = get_arg(args, "gt")?;
         let code_hash = decode_abi_bigint(&code_hash)
-            .map_err(|e| format!("failed to parse integer \"{}\": {}", code_hash, e))?;
+            .map_err(|e| format!("failed to parse integer \"{code_hash}\": {e}"))?;
 
         let accounts = query_collection(
             self.ton.clone(),
@@ -722,7 +722,7 @@ impl SdkInterface {
             },
         )
         .await
-        .map_err(|e| format!("account query failed: {}", e))?
+        .map_err(|e| format!("account query failed: {e}"))?
         .result;
 
         Ok((answer_id, json!({ "accounts": accounts })))
@@ -732,7 +732,7 @@ impl SdkInterface {
         let res = self
             .query_accounts(args, "id data")
             .await
-            .map_err(|e| format!("query account failed: {}", e))?;
+            .map_err(|e| format!("query account failed: {e}"))?;
         Ok(res)
     }
 
@@ -756,7 +756,7 @@ impl SdkInterface {
         let answer_id = decode_answer_id(args)?;
         let box_handle = get_num_arg::<u32>(args, "boxHandle")?;
         let sign_int = decode_abi_bigint(&get_arg(args, "hash")?).map_err(|e| e.to_string())?;
-        let sign_hash = hex::decode(format!("{:064x}", sign_int)).map_err(|e| e.to_string())?;
+        let sign_hash = hex::decode(format!("{sign_int:064x}")).map_err(|e| e.to_string())?;
 
         let signature = signing_box_sign(
             self.ton.clone(),
@@ -766,7 +766,7 @@ impl SdkInterface {
             },
         )
         .await
-        .map_err(|e| format!("{}", e))?
+        .map_err(|e| format!("{e}"))?
         .signature;
 
         Ok((answer_id, json!({ "signature": signature })))
@@ -816,7 +816,7 @@ impl DebotInterface for SdkInterface {
 
             "getAccountsDataByHash" => self.get_accounts_data_by_hash(args).await,
 
-            _ => Err(format!("function \"{}\" is not implemented", func)),
+            _ => Err(format!("function \"{func}\" is not implemented")),
         }
     }
 }

--- a/tvm_client/src/debot/tests.rs
+++ b/tvm_client/src/debot/tests.rs
@@ -111,7 +111,7 @@ impl TestBrowser {
         let state_copy = state.clone();
         let client_copy = client.clone();
         let callback = move |params, response_type| {
-            log::debug!("received from debot: {:#}", params);
+            log::debug!("received from debot: {params:#}");
             let client = client_copy.clone();
             let state = state_copy.clone();
             async move {
@@ -193,7 +193,7 @@ impl TestBrowser {
                 step.outputs.clear();
                 step.available_actions[step.step.choice as usize - 1].clone()
             };
-            log::info!("Executing action: {:#?}", action);
+            log::info!("Executing action: {action:#?}");
             let _: () = client
                 .request_async(
                     "debot.execute",
@@ -304,7 +304,7 @@ impl TestBrowser {
             ParamsOfAppDebotBrowser::Send { message } => {
                 state.msg_queue.lock().await.push_back(message);
             }
-            _ => panic!("invalid notification {:#?}", params),
+            _ => panic!("invalid notification {params:#?}"),
         }
     }
 
@@ -384,7 +384,7 @@ impl TestBrowser {
                 }
                 ResultOfAppDebotBrowser::Approve { approved }
             }
-            _ => panic!("invalid call {:#?}", params),
+            _ => panic!("invalid call {params:#?}"),
         }
     }
 
@@ -433,7 +433,7 @@ impl TestBrowser {
                     .await
                     .unwrap();
                 let (func, args) = (decoded.name, decoded.value.unwrap());
-                log::info!("request: {} ({})", func, args);
+                log::info!("request: {func} ({args})");
                 let (func_id, return_args) = if SUPPORTED_INTERFACES[0] == interface_id {
                     state.echo.call(&func, &args)
                 } else if SUPPORTED_INTERFACES[1] == interface_id {
@@ -443,12 +443,12 @@ impl TestBrowser {
                 } else {
                     state.encrypt_box_input.call(&func, &args).await
                 };
-                log::info!("response: {} ({})", func_id, return_args);
+                log::info!("response: {func_id} ({return_args})");
 
                 let call_set = match func_id {
                     0 => None,
                     _ => CallSet::some_with_function_and_input(
-                        &format!("0x{:x}", func_id),
+                        &format!("0x{func_id:x}"),
                         return_args,
                     ),
                 };
@@ -1739,7 +1739,7 @@ async fn test_debot_sign_hash() {
 }
 
 fn build_info(abi: String, n: u32, interfaces: Vec<String>) -> DebotInfo {
-    let name = format!("TestDeBot{}", n);
+    let name = format!("TestDeBot{n}");
     DebotInfo {
         name: Some(name.clone()),
         version: Some("0.1.0".to_owned()),
@@ -1759,7 +1759,7 @@ fn build_info(abi: String, n: u32, interfaces: Vec<String>) -> DebotInfo {
 }
 
 fn build_info_abi2_2(abi: String, n: u32, interfaces: Vec<String>) -> DebotInfo {
-    let name = format!("TestDeBot{}", n);
+    let name = format!("TestDeBot{n}");
     DebotInfo {
         name: Some(name.clone()),
         version: Some("0.1.0".to_owned()),

--- a/tvm_client/src/debot/tests_interfaces.rs
+++ b/tvm_client/src/debot/tests_interfaces.rs
@@ -372,7 +372,7 @@ impl Terminal {
     }
 
     fn print(&mut self, answer_id: u32, message: &str) -> (u32, Value) {
-        assert!(!self.messages.is_empty(), "Unexpected terminal message received: \"{}\"", message);
+        assert!(!self.messages.is_empty(), "Unexpected terminal message received: \"{message}\"");
         assert_eq!(self.messages.remove(0), message, "Terminal message assert failed");
         (answer_id, json!({}))
     }

--- a/tvm_client/src/encoding.rs
+++ b/tvm_client/src/encoding.rs
@@ -127,7 +127,7 @@ pub(crate) fn base64_decode(base64: &str) -> ClientResult<Vec<u8>> {
 }
 
 pub(crate) fn long_num_to_json_string(num: u64) -> String {
-    format!("0x{:x}", num)
+    format!("0x{num:x}")
 }
 
 pub fn decode_abi_bigint(string: &str) -> ClientResult<BigInt> {

--- a/tvm_client/src/error.rs
+++ b/tvm_client/src/error.rs
@@ -154,9 +154,9 @@ impl ClientError {
                     .filter_map(|v| {
                         v.as_str().map(|s| {
                             if s.find(':').is_some() {
-                                format!("http://{}/bk/v2/messages", s)
+                                format!("http://{s}/bk/v2/messages")
                             } else {
-                                format!("http://{}:8600/bk/v2/messages", s)
+                                format!("http://{s}:8600/bk/v2/messages")
                             }
                         })
                     })

--- a/tvm_client/src/json_interface/debot.rs
+++ b/tvm_client/src/json_interface/debot.rs
@@ -141,9 +141,9 @@ impl BrowserCallbacks for DebotBrowserAdapter {
         match response {
             Ok(r) => match r {
                 ResultOfAppDebotBrowser::Input { value: v } => *value = v,
-                _ => error!("unexpected debot browser response: {:?}", r),
+                _ => error!("unexpected debot browser response: {r:?}"),
             },
-            Err(e) => error!("debot browser failed to show action: {}", e),
+            Err(e) => error!("debot browser failed to show action: {e}"),
         }
     }
 
@@ -152,7 +152,7 @@ impl BrowserCallbacks for DebotBrowserAdapter {
             .app_object
             .call(ParamsOfAppDebotBrowser::GetSigningBox)
             .await
-            .map_err(|err| format!("debot browser failed to load keys: {}", err))?;
+            .map_err(|err| format!("debot browser failed to load keys: {err}"))?;
 
         match response {
             ResultOfAppDebotBrowser::GetSigningBox { signing_box } => Ok(signing_box),
@@ -166,13 +166,13 @@ impl BrowserCallbacks for DebotBrowserAdapter {
             .app_object
             .call(ParamsOfAppDebotBrowser::InvokeDebot { debot_addr: debot, action: action.into() })
             .await
-            .map_err(|e| format!("debot browser failed to invoke debot: {}", e))?;
+            .map_err(|e| format!("debot browser failed to invoke debot: {e}"))?;
 
         match response {
             ResultOfAppDebotBrowser::InvokeDebot => Ok(()),
             _ => {
-                error!("unexpected debot browser response: {:?}", response);
-                Err(format!("unexpected debot browser response: {:?}", response))
+                error!("unexpected debot browser response: {response:?}");
+                Err(format!("unexpected debot browser response: {response:?}"))
             }
         }
     }

--- a/tvm_client/src/json_interface/handlers.rs
+++ b/tvm_client/src/json_interface/handlers.rs
@@ -50,7 +50,7 @@ fn parse_params<P: DeserializeOwned + ApiType>(params_json: &str) -> ClientResul
                     &mut suggest_use_helper_for,
                 );
                 for error_message in errors.iter() {
-                    error.message.push_str(&format!("\nTip: {}", error_message));
+                    error.message.push_str(&format!("\nTip: {error_message}"));
                 }
                 if !suggest_use_helper_for.is_empty() {
                     error.data["suggest_use_helper_for"] = Value::Array(
@@ -183,8 +183,7 @@ fn check_type(
                         Some(type_name) => type_name,
                         None => {
                             errors.push(format!(
-                                "Field \"{}\" is expected to be `String`.",
-                                ENUM_TYPE_TAG
+                                "Field \"{ENUM_TYPE_TAG}\" is expected to be `String`."
                             ));
                             return;
                         }
@@ -232,14 +231,11 @@ fn get_incorrect_enum_errors(
     static SUGGEST_USE_HELPER_FOR_SORTED: &[&str] = &["Abi", "Signer"];
 
     errors.push(format!(
-        "Field \"{field}\" must be a structure:\n\
+        "Field \"{field_name}\" must be a structure:\n\
         {{\n    \
-            \"{type_tag}\": one of {types},\n    \
+            \"{ENUM_TYPE_TAG}\": one of {types_str},\n    \
             ... fields of a corresponding structure, or \"value\" in a case of scalar\n\
         }}.",
-        field = field_name,
-        type_tag = ENUM_TYPE_TAG,
-        types = types_str,
     ));
 
     let class_name = match *class_name {

--- a/tvm_client/src/json_interface/tests.rs
+++ b/tvm_client/src/json_interface/tests.rs
@@ -122,15 +122,12 @@ fn check_client_error_msg(
         assert_eq!(
             actual_classes.len(),
             expected_helpers_suggestions.len(),
-            "Helpers suggestions mismatch. Expected: {:?}, actual: {:?}.",
-            expected_helpers_suggestions,
-            actual_classes,
+            "Helpers suggestions mismatch. Expected: {expected_helpers_suggestions:?}, actual: {actual_classes:?}.",
         );
         for i in 0..expected_helpers_suggestions.len() {
             assert_eq!(
                 actual_classes[i], expected_helpers_suggestions[i],
-                r#"Helpers' suggestions mismatch. Expected: {:?}, actual: {:?}."#,
-                expected_helpers_suggestions, actual_classes,
+                r#"Helpers' suggestions mismatch. Expected: {expected_helpers_suggestions:?}, actual: {actual_classes:?}."#,
             )
         }
     }

--- a/tvm_client/src/json_interface/utils.rs
+++ b/tvm_client/src/json_interface/utils.rs
@@ -41,7 +41,7 @@ pub fn compress_zstd(
     params: ParamsOfCompressZstd,
 ) -> ClientResult<ResultOfCompressZstd> {
     let uncompressed = base64_decode(&params.uncompressed).map_err(|err| {
-        crate::utils::Error::compression_error(format!("Unable to decode BASE64: {}", err))
+        crate::utils::Error::compression_error(format!("Unable to decode BASE64: {err}"))
     })?;
 
     let compressed =
@@ -69,7 +69,7 @@ pub fn decompress_zstd(
     params: ParamsOfDecompressZstd,
 ) -> ClientResult<ResultOfDecompressZstd> {
     let compressed = base64_decode(params.compressed).map_err(|err| {
-        crate::utils::Error::decompression_error(format!("Unable to decode BASE64: {}", err))
+        crate::utils::Error::decompression_error(format!("Unable to decode BASE64: {err}"))
     })?;
 
     let decompressed = crate::utils::compression::decompress_zstd(compressed.as_slice())?;

--- a/tvm_client/src/net/endpoint.rs
+++ b/tvm_client/src/net/endpoint.rs
@@ -117,13 +117,7 @@ impl Endpoint {
             headers.insert(name, value);
         }
         let response = client_env
-            .fetch(
-                &format!("{query_url}{query}"),
-                FetchMethod::Get,
-                Some(headers),
-                None,
-                timeout,
-            )
+            .fetch(&format!("{query_url}{query}"), FetchMethod::Get, Some(headers), None, timeout)
             .await?;
         if response.status == 401 {
             return Err(Error::unauthorized(&response));

--- a/tvm_client/src/net/endpoint.rs
+++ b/tvm_client/src/net/endpoint.rs
@@ -99,9 +99,9 @@ impl Endpoint {
             } else {
                 HTTPS_PROTOCOL
             };
-            base_url = format!("{}{}", protocol, base_url);
+            base_url = format!("{protocol}{base_url}");
         };
-        if base_url.ends_with("/graphql") { base_url } else { format!("{}/graphql", base_url) }
+        if base_url.ends_with("/graphql") { base_url } else { format!("{base_url}/graphql") }
     }
 
     async fn fetch_info_with_url(
@@ -118,7 +118,7 @@ impl Endpoint {
         }
         let response = client_env
             .fetch(
-                &format!("{}{}", query_url, query),
+                &format!("{query_url}{query}"),
                 FetchMethod::Get,
                 Some(headers),
                 None,
@@ -194,8 +194,7 @@ impl Endpoint {
             let parse_part = |i: usize| {
                 parts[i].parse::<u32>().map_err(|err| {
                     Error::invalid_server_response(format!(
-                        "Can not parse version {}: {}",
-                        version, err
+                        "Can not parse version {version}: {err}"
                     ))
                 })
             };

--- a/tvm_client/src/net/errors.rs
+++ b/tvm_client/src/net/errors.rs
@@ -97,7 +97,7 @@ impl Error {
         if err.code != ErrorCode::Unauthorized as u32 {
             err.code = ErrorCode::QueryFailed as u32;
         }
-        err.message = format!("Query failed: {}", err);
+        err.message = format!("Query failed: {err}");
         err
     }
 
@@ -105,7 +105,7 @@ impl Error {
         if err.code != ErrorCode::Unauthorized as u32 {
             err.code = ErrorCode::SubscribeFailed as u32;
         }
-        err.message = format!("Subscribe failed: {}", err);
+        err.message = format!("Subscribe failed: {err}");
         err
     }
 
@@ -119,7 +119,7 @@ impl Error {
         {
             err.code = ErrorCode::WaitForFailed as u32;
         }
-        err.message = format!("WaitFor failed: {}", err);
+        err.message = format!("WaitFor failed: {err}");
         err.data["filter"] = filter.into();
         err.data["timestamp"] = format_time(timestamp).into();
         err
@@ -128,12 +128,12 @@ impl Error {
     pub fn queries_get_subscription_result_failed<E: Display>(err: E) -> ClientError {
         error(
             ErrorCode::GetSubscriptionResultFailed,
-            format!("Receive subscription result failed: {}", err),
+            format!("Receive subscription result failed: {err}"),
         )
     }
 
     pub fn invalid_server_response<E: Display>(err: E) -> ClientError {
-        error(ErrorCode::InvalidServerResponse, format!("Invalid server response: {}", err))
+        error(ErrorCode::InvalidServerResponse, format!("Invalid server response: {err}"))
     }
 
     pub fn wait_for_timeout() -> ClientError {
@@ -182,10 +182,10 @@ impl Error {
         let (message, code, details) = Self::try_get_error_details(errors);
         let message = match (operation, message) {
             (None, None) => "Graphql server returned error.".to_string(),
-            (None, Some(message)) => format!("Graphql server returned error: {}.", message),
-            (Some(operation), None) => format!("Graphql {} error.", operation),
+            (None, Some(message)) => format!("Graphql server returned error: {message}."),
+            (Some(operation), None) => format!("Graphql {operation} error."),
             (Some(operation), Some(message)) => {
-                format!("Graphql {} error: {}.", operation, message)
+                format!("Graphql {operation} error: {message}.")
             }
         };
         let mut err = error(ErrorCode::GraphqlError, message);
@@ -218,7 +218,7 @@ impl Error {
     pub fn websocket_disconnected<E: Display>(err: E) -> ClientError {
         error(
             ErrorCode::WebsocketDisconnected,
-            format!("Websocket unexpectedly disconnected: {}", err),
+            format!("Websocket unexpectedly disconnected: {err}"),
         )
     }
 
@@ -229,7 +229,7 @@ impl Error {
     pub fn not_supported(request: &str) -> ClientError {
         error(
             ErrorCode::NotSupported,
-            format!("Server does not support the following request: {}", request),
+            format!("Server does not support the following request: {request}"),
         )
     }
 
@@ -239,7 +239,7 @@ impl Error {
 
     pub fn graphql_websocket_init_error(mut err: ClientError) -> ClientError {
         err.code = ErrorCode::GraphqlWebsocketInitError as u32;
-        err.message = format!("GraphQL websocket init failed: {}", err);
+        err.message = format!("GraphQL websocket init failed: {err}");
         err
     }
 
@@ -259,20 +259,20 @@ impl Error {
     pub fn wrong_ws_protocol_sequence(err: &str) -> ClientError {
         error(
             ErrorCode::WrongWebscoketProtocolSequence,
-            format!("Wrong webscoket protocol sequence: {}", err),
+            format!("Wrong webscoket protocol sequence: {err}"),
         )
     }
 
     pub fn parse_url_failed<E: Display>(err: E) -> ClientError {
-        error(ErrorCode::ParseUrlFailed, format!("Failed to parse url: {}", err))
+        error(ErrorCode::ParseUrlFailed, format!("Failed to parse url: {err}"))
     }
 
     pub fn modify_url_failed(err: &str) -> ClientError {
-        error(ErrorCode::ParseUrlFailed, format!("Failed to modify url: {}", err))
+        error(ErrorCode::ParseUrlFailed, format!("Failed to modify url: {err}"))
     }
 
     pub fn not_found(err: &str) -> ClientError {
-        error(ErrorCode::NotFound, format!("Not found: {}", err))
+        error(ErrorCode::NotFound, format!("Not found: {err}"))
     }
 
     pub fn all_attempts_failed() -> ClientError {

--- a/tvm_client/src/net/iterators/block.rs
+++ b/tvm_client/src/net/iterators/block.rs
@@ -305,7 +305,7 @@ impl MasterBlock {
                 collection: "blocks".to_string(),
                 filter: Some(filter),
                 order: Some(vec![OrderBy { path: "gen_utime".to_string(), direction }]),
-                result: format!("{} {}", BLOCK_MASTER_FIELDS, fields),
+                result: format!("{BLOCK_MASTER_FIELDS} {fields}"),
                 limit: Some(limit),
             },
         )
@@ -395,5 +395,5 @@ where
 {
     let string = d.deserialize_str(StringVisitor)?;
     shard_ident_parse(&string)
-        .map_err(|err| Error::custom(format!("Error parsing shard ident: {}", err)))
+        .map_err(|err| Error::custom(format!("Error parsing shard ident: {err}")))
 }

--- a/tvm_client/src/net/iterators/block_iterator/mod.rs
+++ b/tvm_client/src/net/iterators/block_iterator/mod.rs
@@ -115,8 +115,7 @@ impl BlockIterator {
     pub(crate) fn get_resume_state_value(&self) -> ClientResult<Value> {
         serde_json::to_value(self.get_resume_state()).map_err(|e| {
             crate::client::Error::internal_error(format!(
-                "Can't serialize iterator resume state: {}",
-                e
+                "Can't serialize iterator resume state: {e}"
             ))
         })
     }
@@ -147,7 +146,7 @@ impl BlockIterator {
         params: ParamsOfResumeBlockIterator,
     ) -> ClientResult<Self> {
         let resume = ResumeState::deserialize(&params.resume_state).map_err(|e| {
-            crate::client::Error::internal_error(format!("Invalid iterator resume state: {}", e))
+            crate::client::Error::internal_error(format!("Invalid iterator resume state: {e}"))
         })?;
         Self::from_resume_state(context, resume).await
     }
@@ -157,7 +156,7 @@ impl BlockIterator {
         block_ids: Vec<String>,
         fields: &str,
     ) -> ClientResult<Vec<Value>> {
-        query_by_ids(context, "blocks", block_ids, &format!("{} {}", BLOCK_TRAVERSE_FIELDS, fields))
+        query_by_ids(context, "blocks", block_ids, &format!("{BLOCK_TRAVERSE_FIELDS} {fields}"))
             .await
     }
 

--- a/tvm_client/src/net/iterators/mod.rs
+++ b/tvm_client/src/net/iterators/mod.rs
@@ -187,8 +187,7 @@ pub(crate) async fn query_by_ids(
             for item in portion {
                 let id = item["id"].as_str().ok_or_else(|| {
                     crate::net::Error::invalid_server_response(format!(
-                        "required `{}.id` field is missing",
-                        collection
+                        "required `{collection}.id` field is missing"
                     ))
                 })?;
                 query_queue.remove(id);
@@ -198,8 +197,7 @@ pub(crate) async fn query_by_ids(
         for id in &head_ids {
             items.push(head_by_id.remove(id).ok_or_else(|| {
                 crate::net::Error::invalid_server_response(format!(
-                    "missing required {}[{}]",
-                    collection, id
+                    "missing required {collection}[{id}]"
                 ))
             })?);
         }

--- a/tvm_client/src/net/iterators/tests.rs
+++ b/tvm_client/src/net/iterators/tests.rs
@@ -20,7 +20,7 @@ async fn query_ids_in_range(
                     filter: Some(json!({
                         time_field: { "eq": start_time },
                     })),
-                    result: format!("id {}", time_field),
+                    result: format!("id {time_field}"),
                     ..Default::default()
                 },
             )

--- a/tvm_client/src/net/iterators/transaction_iterator/mod.rs
+++ b/tvm_client/src/net/iterators/transaction_iterator/mod.rs
@@ -87,8 +87,7 @@ impl TransactionIterator {
     pub fn get_resume_state_value(&self) -> ClientResult<Value> {
         serde_json::to_value(self.get_resume_state()).map_err(|e| {
             crate::client::Error::internal_error(format!(
-                "Can't serialize iterator resume state: {}",
-                e
+                "Can't serialize iterator resume state: {e}"
             ))
         })
     }
@@ -116,7 +115,7 @@ impl TransactionIterator {
         params: ParamsOfResumeTransactionIterator,
     ) -> ClientResult<Self> {
         let resume = ResumeState::deserialize(&params.resume_state).map_err(|e| {
-            crate::client::Error::internal_error(format!("Invalid iterator resume state: {}", e))
+            crate::client::Error::internal_error(format!("Invalid iterator resume state: {e}"))
         })?;
         Self::from_resume_state(context, resume, params.accounts_filter).await
     }
@@ -130,7 +129,7 @@ impl TransactionIterator {
             context,
             "transactions",
             transaction_ids,
-            &format!("{} {}", TRANSACTION_FIELDS, fields),
+            &format!("{TRANSACTION_FIELDS} {fields}"),
         )
         .await
     }

--- a/tvm_client/src/net/queries.rs
+++ b/tvm_client/src/net/queries.rs
@@ -46,7 +46,7 @@ where
     match result {
         Ok(result) => {
             T::deserialize(result.clone())
-                .map_err(|err| Error::invalid_server_response(format!("{}: {}.", err, result)))
+                .map_err(|err| Error::invalid_server_response(format!("{err}: {result}.")))
                 .add_network_url(server_link)
                 .await
         }

--- a/tvm_client/src/net/server_link.rs
+++ b/tvm_client/src/net/server_link.rs
@@ -107,7 +107,7 @@ async fn query_by_url(
     timeout: u32,
 ) -> ClientResult<Value> {
     let response = client_env
-        .fetch(&format!("{}?query={}", address, query), FetchMethod::Get, None, None, timeout)
+        .fetch(&format!("{address}?query={query}"), FetchMethod::Get, None, None, timeout)
         .await?;
 
     response.body_as_json(false)
@@ -194,7 +194,7 @@ impl NetworkState {
         self.suspend(&regulation.sender).await;
 
         let timeout = self.next_resume_timeout();
-        log::debug!("Internal resume timeout {}", timeout);
+        log::debug!("Internal resume timeout {timeout}");
 
         let env = self.client_env.clone();
         let regulation = self.suspend_regulation.clone();
@@ -460,7 +460,7 @@ fn construct_rest_api_endpoint(original: &str, use_https: bool) -> ClientResult<
     let original = if original.contains("://") {
         original.to_string()
     } else {
-        format!("http://{}", original)
+        format!("http://{original}")
     };
     let mut rest_api_endpoint = Url::parse(&original).map_err(Error::parse_url_failed)?;
 
@@ -479,7 +479,7 @@ fn construct_bm_send_message_endpoint(original: &str, use_https: bool) -> Client
     let original = if original.contains("://") {
         original.to_string()
     } else {
-        format!("http://{}", original)
+        format!("http://{original}")
     };
 
     let mut url = reqwest::Url::parse(&original).map_err(Error::parse_url_failed)?;
@@ -506,9 +506,9 @@ fn get_redirection_data(data: &Value) -> (Option<String>, Option<String>) {
         .and_then(|v| v.as_str())
         .map(|s| {
             if s.contains(':') {
-                format!("http://{}/bk/v2/messages", s)
+                format!("http://{s}/bk/v2/messages")
             } else {
-                format!("http://{}:8600/bk/v2/messages", s)
+                format!("http://{s}:8600/bk/v2/messages")
             }
         });
 
@@ -572,7 +572,7 @@ impl ServerLink {
     ) -> ClientResult<Subscription> {
         self.subscribe_operation(
             GraphQLQuery::with_collection_subscription(table, filter, fields),
-            format!("/{}", table),
+            format!("/{table}"),
         )
         .await
     }
@@ -1076,8 +1076,7 @@ impl ServerLink {
 
         serde_json::from_value(result["data"]["info"]["endpoints"].clone()).map_err(|_| {
             Error::invalid_server_response(format!(
-                "Can not parse endpoints from response: {}",
-                result
+                "Can not parse endpoints from response: {result}"
             ))
         })
     }

--- a/tvm_client/src/net/server_link.rs
+++ b/tvm_client/src/net/server_link.rs
@@ -457,11 +457,8 @@ fn replace_endpoints(endpoints: Vec<String>) -> Vec<String> {
 }
 
 fn construct_rest_api_endpoint(original: &str, use_https: bool) -> ClientResult<Url> {
-    let original = if original.contains("://") {
-        original.to_string()
-    } else {
-        format!("http://{original}")
-    };
+    let original =
+        if original.contains("://") { original.to_string() } else { format!("http://{original}") };
     let mut rest_api_endpoint = Url::parse(&original).map_err(Error::parse_url_failed)?;
 
     let scheme = if use_https { "https" } else { "http" };
@@ -476,11 +473,8 @@ fn construct_rest_api_endpoint(original: &str, use_https: bool) -> ClientResult<
 }
 
 fn construct_bm_send_message_endpoint(original: &str, use_https: bool) -> ClientResult<String> {
-    let original = if original.contains("://") {
-        original.to_string()
-    } else {
-        format!("http://{original}")
-    };
+    let original =
+        if original.contains("://") { original.to_string() } else { format!("http://{original}") };
 
     let mut url = reqwest::Url::parse(&original).map_err(Error::parse_url_failed)?;
 

--- a/tvm_client/src/net/tests.rs
+++ b/tvm_client/src/net/tests.rs
@@ -36,7 +36,7 @@ async fn bad_request() {
         .await;
 
     if let Err(err) = result {
-        println!("{:?}", err);
+        println!("{err:?}");
         assert_eq!(err.code, ErrorCode::QueryFailed as u32);
         assert_eq!(
             err.message,
@@ -131,7 +131,7 @@ async fn not_authorized() {
         )
         .await
         .unwrap();
-    println!("{:?}", result)
+    println!("{result:?}")
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -152,7 +152,7 @@ async fn auth_header() {
         }
     }));
     assert_eq!(
-        Some(("Authorization".to_string(), format!("Bearer {}", jwt))),
+        Some(("Authorization".to_string(), format!("Bearer {jwt}"))),
         client.context().config.network.get_auth_header()
     );
     let client = TestClient::new();
@@ -173,7 +173,7 @@ async fn endpoints_with_graphql_suffix() {
 
     assert_eq!(
         endpoint.query_url.trim_start_matches("http://").trim_start_matches("https://"),
-        format!("{}/graphql", url).trim_start_matches("http://").trim_start_matches("https://"),
+        format!("{url}/graphql").trim_start_matches("http://").trim_start_matches("https://"),
     );
 
     let client = TestClient::new_with_config(json!({
@@ -184,7 +184,7 @@ async fn endpoints_with_graphql_suffix() {
     let endpoint = client.context().get_server_link().unwrap().get_query_endpoint().await.unwrap();
     assert_eq!(
         endpoint.query_url.trim_start_matches("http://").trim_start_matches("https://"),
-        format!("{}/graphql", url).trim_start_matches("http://").trim_start_matches("https://"),
+        format!("{url}/graphql").trim_start_matches("http://").trim_start_matches("https://"),
     );
 }
 
@@ -450,7 +450,7 @@ async fn subscribe_for_transactions_with_addresses() {
     let notifications_copy2 = notifications.clone();
     let address1 = msg.address.clone();
     let address2 = msg.address.clone();
-    println!("Account address {}", address1);
+    println!("Account address {address1}");
 
     let callback1 = move |result: serde_json::Value, response_type: SubscriptionResponseType| {
         let result = match response_type {
@@ -472,7 +472,7 @@ async fn subscribe_for_transactions_with_addresses() {
                     transactions_copy.lock().await.push(result.result);
                 }
                 Err(err) => {
-                    println!(">>> {}", err);
+                    println!(">>> {err}");
                     notifications_copy.lock().await.push(err);
                 }
             }
@@ -529,7 +529,7 @@ async fn subscribe_for_transactions_with_addresses() {
                     transactions_copy.lock().await.push(result.result);
                 }
                 Err(err) => {
-                    println!(">>> {}", err);
+                    println!(">>> {err}");
                     notifications_copy.lock().await.push(err);
                 }
             }
@@ -1452,7 +1452,7 @@ async fn order_by_fallback() {
         )
         .await;
     if let Err(err) = &result {
-        println!("{:?}", err);
+        println!("{err:?}");
     }
     assert!(result.is_err());
 }

--- a/tvm_client/src/net/transaction_tree.rs
+++ b/tvm_client/src/net/transaction_tree.rs
@@ -34,7 +34,7 @@ fn get_string(v: &Value, name: &str) -> Option<String> {
 
 fn required_string(v: &Value, name: &str) -> ClientResult<String> {
     v[name].as_str().map(|x| x.to_string()).ok_or_else(|| {
-        crate::net::Error::invalid_server_response(format!("Missing required field {}", name))
+        crate::net::Error::invalid_server_response(format!("Missing required field {name}"))
     })
 }
 

--- a/tvm_client/src/net/tvm_gql.rs
+++ b/tvm_client/src/net/tvm_gql.rs
@@ -497,7 +497,9 @@ impl GraphQLQuery {
     pub fn with_collection_subscription(table: &str, filter: &Value, fields: &str) -> Self {
         let filter_type = Self::filter_type_for_collection(table);
 
-        let query = format!("subscription {table}($filter: {filter_type}) {{ {table}(filter: $filter) {{ {fields} }} }}");
+        let query = format!(
+            "subscription {table}($filter: {filter_type}) {{ {table}(filter: $filter) {{ {fields} }} }}"
+        );
         let query = query.split_whitespace().collect::<Vec<&str>>().join(" ");
         let variables = Some(json!({
             "filter" : filter,

--- a/tvm_client/src/net/tvm_gql.rs
+++ b/tvm_client/src/net/tvm_gql.rs
@@ -387,10 +387,10 @@ impl QueryOperationBuilder {
         self.add_header(if self.param_count == 0 { "(" } else { "," });
         self.param_count += 1;
         let param_name = format!("p{}", self.param_count);
-        self.add_header(&format!("${}: {}", param_name, type_decl));
+        self.add_header(&format!("${param_name}: {type_decl}"));
         self.add_body(if self.op_param_count == 0 { "(" } else { "," });
         self.op_param_count += 1;
-        self.add_body(&format!("{}: ${}", name, param_name));
+        self.add_body(&format!("{name}: ${param_name}"));
         if let Some(ref mut variables) = self.variables {
             variables[param_name] = value.clone();
         } else {
@@ -449,8 +449,7 @@ impl GraphQLQuery {
         let mut result_data = &result["data"][result_name.as_str()];
         if result_data.is_null() {
             return Err(crate::net::Error::invalid_server_response(format!(
-                "Missing data.{} in: {}",
-                result_name, result
+                "Missing data.{result_name} in: {result}"
             )));
         }
         if let Some(ParamsOfQueryOperation::WaitForCollection(_)) = param {
@@ -498,10 +497,7 @@ impl GraphQLQuery {
     pub fn with_collection_subscription(table: &str, filter: &Value, fields: &str) -> Self {
         let filter_type = Self::filter_type_for_collection(table);
 
-        let query = format!("subscription {table}($filter: {type}) {{ {table}(filter: $filter) {{ {fields} }} }}",
-            type=filter_type,
-            table=table,
-            fields=fields);
+        let query = format!("subscription {table}($filter: {filter_type}) {{ {table}(filter: $filter) {{ {fields} }} }}");
         let query = query.split_whitespace().collect::<Vec<&str>>().join(" ");
         let variables = Some(json!({
             "filter" : filter,
@@ -518,7 +514,7 @@ impl GraphQLQuery {
 
     pub fn filter_type_for_collection(collection: &str) -> String {
         let mut filter_type = if let Some(prefix) = collection.strip_suffix("ies") {
-            format!("{}yFilter", prefix)
+            format!("{prefix}yFilter")
         } else {
             format!("{}Filter", &collection[0..collection.len() - 1])
         };

--- a/tvm_client/src/net/types.rs
+++ b/tvm_client/src/net/types.rs
@@ -327,9 +327,9 @@ impl NetworkConfig {
         if let Some(key) = &self.access_key {
             let is_jwt = key.contains('.');
             let auth = if is_jwt {
-                format!("Bearer {}", key)
+                format!("Bearer {key}")
             } else {
-                format!("Basic {}", base64_encode(format!(":{}", key).as_bytes()))
+                format!("Basic {}", base64_encode(format!(":{key}").as_bytes()))
             };
             Some(("Authorization".into(), auth))
         } else {

--- a/tvm_client/src/net/websocket_link.rs
+++ b/tvm_client/src/net/websocket_link.rs
@@ -57,7 +57,7 @@ enum HandlerAction {
 impl HandlerAction {
     async fn send(self, sender: &mut Sender<Self>) {
         if let Err(err) = sender.send(self).await {
-            log::error!("HandlerAction.send failed {}", err);
+            log::error!("HandlerAction.send failed {err}");
         }
     }
 }
@@ -463,7 +463,7 @@ impl LinkHandler {
     }
 
     fn start_keep_alive_timer(&mut self, timeout: u64) {
-        log::trace!("WS keep alive timer {}", timeout);
+        log::trace!("WS keep alive timer {timeout}");
         let sender = self.internal_action_sender.clone();
         self.keep_alive = KeepAlive::WaitNext { timeout };
         let env = self.client_env.clone();

--- a/tvm_client/src/processing/blocks_walking.rs
+++ b/tvm_client/src/processing/blocks_walking.rs
@@ -99,8 +99,7 @@ pub(crate) async fn find_last_shard_block(
 
             if blocks[0].is_null() {
                 return Err(Error::block_not_found(format!(
-                    "No blocks for workchain {} found",
-                    workchain
+                    "No blocks for workchain {workchain} found"
                 )));
             }
             // if workchain is sharded, then it is not Evernode SE and masterchain blocks
@@ -139,7 +138,7 @@ pub(crate) async fn find_last_shard_block(
 
             let shard_block =
                 tvm_sdk::Contract::find_matching_shard(shards, address).map_err(|err| {
-                    Error::invalid_data(format!("find matching shard failed {}", err))
+                    Error::invalid_data(format!("find matching shard failed {err}"))
                 })?;
             if shard_block.is_null() {
                 return Err(Error::invalid_data(format!(
@@ -205,11 +204,11 @@ pub async fn wait_next_block(
             .await
             .and_then(|val| {
                 serde_json::from_value(val)
-                    .map_err(|err| Error::invalid_data(format!("Can not parse block: {}", err)))
+                    .map_err(|err| Error::invalid_data(format!("Can not parse block: {err}")))
             })
     } else {
         serde_json::from_value(block)
-            .map_err(|err| Error::invalid_data(format!("Can not parse block: {}", err)))
+            .map_err(|err| Error::invalid_data(format!("Can not parse block: {err}")))
     }
 }
 

--- a/tvm_client/src/processing/blocks_walking.rs
+++ b/tvm_client/src/processing/blocks_walking.rs
@@ -136,10 +136,8 @@ pub(crate) async fn find_last_shard_block(
                 .as_array()
                 .ok_or(Error::invalid_data("No `shard_hashes` field in masterchain block"))?;
 
-            let shard_block =
-                tvm_sdk::Contract::find_matching_shard(shards, address).map_err(|err| {
-                    Error::invalid_data(format!("find matching shard failed {err}"))
-                })?;
+            let shard_block = tvm_sdk::Contract::find_matching_shard(shards, address)
+                .map_err(|err| Error::invalid_data(format!("find matching shard failed {err}")))?;
             if shard_block.is_null() {
                 return Err(Error::invalid_data(format!(
                     "No matching shard for account {} in block {}",

--- a/tvm_client/src/processing/errors.rs
+++ b/tvm_client/src/processing/errors.rs
@@ -90,7 +90,7 @@ impl Error {
     pub fn fetch_first_block_failed<E: std::fmt::Display>(err: E, message_id: &str) -> ClientError {
         Self::processing_error(
             ErrorCode::FetchBlockFailed,
-            format!("Fetch first block failed: {}", err),
+            format!("Fetch first block failed: {err}"),
             message_id,
             None,
         )
@@ -103,7 +103,7 @@ impl Error {
     ) -> ClientError {
         Self::processing_error(
             ErrorCode::FetchBlockFailed,
-            format!("Fetch block failed: {}", err),
+            format!("Fetch block failed: {err}"),
             message_id,
             Some(shard_block_id),
         )
@@ -116,18 +116,18 @@ impl Error {
     ) -> ClientError {
         Self::processing_error(
             ErrorCode::SendMessageFailed,
-            format!("Send message failed: {}", err),
+            format!("Send message failed: {err}"),
             message_id,
             Some(shard_block_id),
         )
     }
 
     pub fn invalid_message_boc<E: std::fmt::Display>(err: E) -> ClientError {
-        error(ErrorCode::InvalidMessageBoc, format!("Invalid message BOC: {}", err))
+        error(ErrorCode::InvalidMessageBoc, format!("Invalid message BOC: {err}"))
     }
 
     pub fn can_not_build_message_cell<E: std::fmt::Display>(err: E) -> ClientError {
-        error(ErrorCode::CanNotBuildMessageCell, format!("Can't build message cell: {}", err))
+        error(ErrorCode::CanNotBuildMessageCell, format!("Can't build message cell: {err}"))
     }
 
     pub fn invalid_block_received<E: std::fmt::Display>(
@@ -137,7 +137,7 @@ impl Error {
     ) -> ClientError {
         Self::processing_error(
             ErrorCode::InvalidBlockReceived,
-            format!("Invalid block received: {}", err),
+            format!("Invalid block received: {err}"),
             message_id,
             Some(shard_block_id),
         )
@@ -201,7 +201,7 @@ impl Error {
     }
 
     pub fn can_not_check_block_shard<E: std::fmt::Display>(err: E) -> ClientError {
-        error(ErrorCode::CanNotCheckBlockShard, format!("Can't check block shard: {}", err))
+        error(ErrorCode::CanNotCheckBlockShard, format!("Can't check block shard: {err}"))
     }
 
     pub fn block_not_found(message: String) -> ClientError {
@@ -209,20 +209,20 @@ impl Error {
     }
 
     pub fn invalid_data<E: std::fmt::Display>(err: E) -> ClientError {
-        error(ErrorCode::InvalidData, format!("Invalid data: {}", err))
+        error(ErrorCode::InvalidData, format!("Invalid data: {err}"))
     }
 
     pub fn message_rejected(message_id: &str, err: &str) -> ClientError {
         Self::processing_error(
             ErrorCode::MessageRejected,
-            format!("message has been rejected: {}", err),
+            format!("message has been rejected: {err}"),
             message_id,
             None,
         )
     }
 
     pub fn invalid_remp_status<E: std::fmt::Display>(err: E) -> ClientError {
-        error(ErrorCode::InvalidRempStatus, format!("Invalid REMP status: {}", err))
+        error(ErrorCode::InvalidRempStatus, format!("Invalid REMP status: {err}"))
     }
 
     pub fn next_remp_status_timeout() -> ClientError {
@@ -230,6 +230,6 @@ impl Error {
     }
 
     pub fn invalid_thread<E: std::fmt::Display>(err: E) -> ClientError {
-        error(ErrorCode::InvalidThread, format!("Invalid thread id: {}", err))
+        error(ErrorCode::InvalidThread, format!("Invalid thread id: {err}"))
     }
 }

--- a/tvm_client/src/processing/fetching.rs
+++ b/tvm_client/src/processing/fetching.rs
@@ -133,7 +133,7 @@ impl TransactionBoc {
     fn from(value: Value, message_id: &str, shard_block_id: &str) -> ClientResult<Self> {
         serde_json::from_value::<TransactionBoc>(value).map_err(|err| {
             Error::fetch_transaction_result_failed(
-                format!("Transaction can't be parsed: {}", err),
+                format!("Transaction can't be parsed: {err}"),
                 message_id,
                 shard_block_id,
             )
@@ -149,7 +149,7 @@ pub(crate) async fn fetch_account(
     let mut result = crate::net::query(
         context,
         crate::net::ParamsOfQuery {
-            query: format!("query account($address:String!){{blockchain{{account(address:$address){{info{{{}}}}}}}}}", result),
+            query: format!("query account($address:String!){{blockchain{{account(address:$address){{info{{{result}}}}}}}}}"),
             variables: Some(json!({
                 "address": address.to_string(),
             })),
@@ -177,7 +177,7 @@ async fn fetch_contract_balance(
     let account = fetch_account(context, address, "balance").await?;
 
     let balance: AccountBalance = serde_json::from_value(account)
-        .map_err(|err| Error::invalid_data(format!("can not parse account balance: {}", err)))?;
+        .map_err(|err| Error::invalid_data(format!("can not parse account balance: {err}")))?;
 
     Ok(balance.balance)
 }

--- a/tvm_client/src/processing/internal.rs
+++ b/tvm_client/src/processing/internal.rs
@@ -98,7 +98,7 @@ async fn get_local_error(
     }
 
     let account: Account = serde_json::from_value(account).map_err(|err| {
-        Error::invalid_data(format!("Can not parse account for error resolving: {}", err))
+        Error::invalid_data(format!("Can not parse account for error resolving: {err}"))
     })?;
 
     if let Some(last_paid) = account.last_paid {
@@ -195,7 +195,7 @@ pub(crate) async fn resolve_error(
 /// original error
 fn remove_exit_code(exit_code: &Option<i64>, internal_error: &str) -> String {
     if let Some(exit_code) = exit_code {
-        regex::Regex::new(&format!(r#"(?i)([,\.]\s*)?exit\s+code(:\s*|\s+){}"#, exit_code))
+        regex::Regex::new(&format!(r#"(?i)([,\.]\s*)?exit\s+code(:\s*|\s+){exit_code}"#))
             .unwrap()
             .replace(internal_error, "")
             .to_string()

--- a/tvm_client/src/processing/wait_for_transaction.rs
+++ b/tvm_client/src/processing/wait_for_transaction.rs
@@ -109,12 +109,11 @@ async fn wait_by_remp<F: futures::Future<Output = ()> + Send>(
             subscription: format!(
                 r#"
                 subscription {{
-                    rempReceipts(messageId: "{}") {{
+                    rempReceipts(messageId: "{message_id}") {{
                         messageId kind timestamp json
                     }}
                 }}
-                "#,
-                message_id
+                "#
             ),
             variables: None,
         },
@@ -209,7 +208,7 @@ async fn process_remp_message<F: futures::Future<Output = ()> + Send>(
 ) -> ClientResult<Option<ClientResult<ResultOfProcessMessage>>> {
     let remp_message = remp_message?;
     let status: RempStatus = serde_json::from_value(remp_message).map_err(|err| {
-        Error::invalid_remp_status(format!("can not parse REMP status message: {}", err))
+        Error::invalid_remp_status(format!("can not parse REMP status message: {err}"))
     })?;
 
     match status {
@@ -325,7 +324,7 @@ async fn wait_by_block_walking<F: futures::Future<Output = ()> + Send>(
         let now = context.env.now_ms();
         let timeout = std::cmp::max(max_block_time, now) - now + processing_timeout as u64;
         let fetch_block_timeout = timeout.try_into().unwrap_or(u32::MAX);
-        log::debug!("fetch_block_timeout {}", fetch_block_timeout);
+        log::debug!("fetch_block_timeout {fetch_block_timeout}");
 
         let block = fetching::fetch_next_shard_block(
             &context,

--- a/tvm_client/src/proofs/engine.rs
+++ b/tvm_client/src/proofs/engine.rs
@@ -116,15 +116,15 @@ impl ProofHelperEngineImpl {
     }
 
     fn mc_proof_key(mc_seq_no: u32) -> String {
-        format!("proof_mc_{}", mc_seq_no)
+        format!("proof_mc_{mc_seq_no}")
     }
 
     fn block_key(root_hash: &str) -> String {
-        format!("temp_block_{}", root_hash)
+        format!("temp_block_{root_hash}")
     }
 
     fn trusted_block_right_bound_key(seq_no: u32) -> String {
-        format!("trusted_{}_right_boundary_seq_no", seq_no)
+        format!("trusted_{seq_no}_right_boundary_seq_no")
     }
 
     fn filter_for_block(root_hash: &str) -> Value {
@@ -613,7 +613,7 @@ impl ProofHelperEngineImpl {
         }
 
         result.ok_or_else(|| {
-            failure::err_msg(format!("Top block for the given shard ({}) not found", shard))
+            failure::err_msg(format!("Top block for the given shard ({shard}) not found"))
         })
     }
 

--- a/tvm_client/src/proofs/errors.rs
+++ b/tvm_client/src/proofs/errors.rs
@@ -18,18 +18,18 @@ fn error(code: ErrorCode, message: String) -> ClientError {
 
 impl Error {
     pub fn invalid_data(err: impl Display) -> ClientError {
-        error(ErrorCode::InvalidData, format!("Invalid data: {}", err))
+        error(ErrorCode::InvalidData, format!("Invalid data: {err}"))
     }
 
     pub fn proof_check_failed(err: impl Display) -> ClientError {
-        error(ErrorCode::ProofCheckFailed, format!("Proof check failed: {}", err))
+        error(ErrorCode::ProofCheckFailed, format!("Proof check failed: {err}"))
     }
 
     pub fn data_differs_from_proven(err: impl Display) -> ClientError {
-        error(ErrorCode::DataDiffersFromProven, format!("Data differs from the proven: {}", err))
+        error(ErrorCode::DataDiffersFromProven, format!("Data differs from the proven: {err}"))
     }
 
     pub fn internal_error(err: impl Display) -> ClientError {
-        error(ErrorCode::InternalError, format!("Internal error during proof checking: {}", err))
+        error(ErrorCode::InternalError, format!("Internal error during proof checking: {err}"))
     }
 }

--- a/tvm_client/src/proofs/json.rs
+++ b/tvm_client/src/proofs/json.rs
@@ -231,8 +231,8 @@ impl<'a, 'b> JsonPath<'a, 'b> {
     fn gen_display_str(&self) -> String {
         match self {
             JsonPath::InitialEntity(name) => name.to_string(),
-            JsonPath::Field { parent, field_name } => format!("{}.{}", parent, field_name),
-            JsonPath::Index { parent, index } => format!("{}[{}]", parent, index),
+            JsonPath::Field { parent, field_name } => format!("{parent}.{field_name}"),
+            JsonPath::Index { parent, index } => format!("{parent}[{index}]"),
         }
     }
 }
@@ -289,9 +289,6 @@ pub(crate) fn compare_values(
 
     Err(Error::data_differs_from_proven(format!(
         "field `{path}`: expected {expected:?}, actual {actual:?}",
-        path = path,
-        actual = actual,
-        expected = expected,
     )))
 }
 
@@ -358,7 +355,7 @@ fn get_string(value: &Value, is_numeric: bool) -> Cow<str> {
             if value < 0 {
                 return Cow::Owned(format!("-0x{:x}", value.abs()));
             }
-            return Cow::Owned(format!("0x{:x}", value));
+            return Cow::Owned(format!("0x{value:x}"));
         }
     }
 
@@ -394,7 +391,7 @@ fn add_time_strings(value: &mut Value, paths: &HashSet<&'static str>, path: Json
                     _ => continue,
                 };
 
-                map.insert(format!("{}_string", key), unix_time_to_string(unix_time).into());
+                map.insert(format!("{key}_string"), unix_time_to_string(unix_time).into());
             }
             for (key, value) in map.iter_mut() {
                 add_time_strings(value, paths, path.join_field(key));

--- a/tvm_client/src/proofs/mod.rs
+++ b/tvm_client/src/proofs/mod.rs
@@ -317,8 +317,7 @@ pub async fn proof_message_data(
         &Value::String(root_hash.as_hex_string()),
     ) {
         return Err(Error::proof_check_failed(format!(
-            "Message with `id` = {} not found in transaction with `id` = {}",
-            root_hash, transaction_id,
+            "Message with `id` = {root_hash} not found in transaction with `id` = {transaction_id}",
         )));
     }
 

--- a/tvm_client/src/proofs/tests/mod.rs
+++ b/tvm_client/src/proofs/tests/mod.rs
@@ -51,8 +51,7 @@ fn test_check_master_blocks_proof() -> Result<()> {
 
     for seq_no in 3082182..=3082200 {
         let block_proof = BlockProof::read_from_file(format!(
-            "src/proofs/tests/data/test_master_block_proof/proof__{}",
-            seq_no
+            "src/proofs/tests/data/test_master_block_proof/proof__{seq_no}"
         ))?;
         let (virt_block, virt_block_info) = block_proof.pre_check_block_proof()?;
         block_proof.check_with_prev_key_block_proof(
@@ -73,8 +72,7 @@ fn test_check_master_blocks_proof_shuffle() -> Result<()> {
 
     for seq_no in 3236531..=3236550 {
         let block_proof = BlockProof::read_from_file(format!(
-            "src/proofs/tests/data/test_master_block_proof_shuffle/proof__{}",
-            seq_no
+            "src/proofs/tests/data/test_master_block_proof_shuffle/proof__{seq_no}"
         ))?;
 
         let (virt_block, virt_block_info) = block_proof.pre_check_block_proof()?;
@@ -706,7 +704,7 @@ fn print_object_type(
         }
         let type_name = resolve_type_name(&field.field_type);
         let field_ident = format!("{}:{}", field.name, type_name);
-        if path.contains(&format!("/{}/", field_ident)) {
+        if path.contains(&format!("/{field_ident}/")) {
             continue;
         }
         if i != 0 {
@@ -715,7 +713,7 @@ fn print_object_type(
         output.push_str(&field.name);
         if let Some(typ) = known_types.get(&type_name) {
             output.push('{');
-            print_object_type(typ, known_types, format!("{}{}/", path, field_ident), output);
+            print_object_type(typ, known_types, format!("{path}{field_ident}/"), output);
             output.push('}');
         }
     }

--- a/tvm_client/src/tests/mod.rs
+++ b/tvm_client/src/tests/mod.rs
@@ -351,9 +351,9 @@ impl TestClient {
         match Self::auth_project() {
             Some(project) => {
                 if endpoint.ends_with('/') {
-                    format!("{}{}", endpoint, project)
+                    format!("{endpoint}{project}")
                 } else {
-                    format!("{}/{}", endpoint, project)
+                    format!("{endpoint}/{project}")
                 }
             }
             None => endpoint.to_string(),
@@ -400,7 +400,7 @@ impl TestClient {
         let image_base64 = base64_encode(
             std::fs::read(format!("{}{}.png", Self::contracts_path(abi_version), name)).unwrap(),
         );
-        format!("data:image/png;base64,{}", image_base64)
+        format!("data:image/png;base64,{image_base64}")
     }
 
     pub fn package(name: &str, abi_version: Option<u8>) -> (Abi, Option<String>) {
@@ -510,7 +510,7 @@ impl TestClient {
         {
             (request.callback)(params_json, response_type).await
         } else {
-            panic!("Unsupported response type: {}", response_type);
+            panic!("Unsupported response type: {response_type}");
         }
 
         if finished {

--- a/tvm_client/src/tvm/call_tvm.rs
+++ b/tvm_client/src/tvm/call_tvm.rs
@@ -52,7 +52,7 @@ pub(crate) fn call_tvm(
     let mut ctrls = SaveList::new();
     ctrls
         .put(4, &mut StackItem::Cell(data))
-        .map_err(|err| Error::internal_error(format!("can not put data to registers: {}", err)))?;
+        .map_err(|err| Error::internal_error(format!("can not put data to registers: {err}")))?;
 
     let mut sci = build_contract_info(
         options.blockchain_config.raw_config(),
@@ -67,7 +67,7 @@ pub(crate) fn call_tvm(
     sci.capabilities = options.blockchain_config.capabilites();
     ctrls
         .put(7, &mut sci.into_temp_data_item())
-        .map_err(|err| Error::internal_error(format!("can not put SCI to registers: {}", err)))?;
+        .map_err(|err| Error::internal_error(format!("can not put SCI to registers: {err}")))?;
 
     let gas_limit = 1_000_000_000;
     let gas = Gas::new(gas_limit, 0, gas_limit, 10);
@@ -120,7 +120,7 @@ pub(crate) fn call_tvm_msg(
 ) -> ClientResult<Vec<Message>> {
     let msg_cell = msg
         .serialize()
-        .map_err(|err| Error::internal_error(format!("can not serialize message: {}", err)))?;
+        .map_err(|err| Error::internal_error(format!("can not serialize message: {err}")))?;
 
     let mut stack = Stack::new();
     let balance = account.balance().map_or(0, |cc| cc.grams.as_u128());
@@ -142,10 +142,10 @@ pub(crate) fn call_tvm_msg(
     let actions_cell = engine
         .get_actions()
         .as_cell()
-        .map_err(|err| Error::internal_error(format!("can not get actions: {}", err)))?
+        .map_err(|err| Error::internal_error(format!("can not get actions: {err}")))?
         .clone();
     let mut actions = OutActions::construct_from_cell(actions_cell)
-        .map_err(|err| Error::internal_error(format!("can not parse actions: {}", err)))?;
+        .map_err(|err| Error::internal_error(format!("can not parse actions: {err}")))?;
 
     let mut msgs = vec![];
     for action in actions.iter_mut() {

--- a/tvm_client/src/tvm/errors.rs
+++ b/tvm_client/src/tvm/errors.rs
@@ -50,48 +50,48 @@ impl Error {
     pub fn invalid_input_stack<E: Display>(err: E, stack: &Value) -> ClientError {
         error(
             ErrorCode::InvalidInputStack,
-            format!("Invalid JSON value for stack item ({}): {}", stack, err),
+            format!("Invalid JSON value for stack item ({stack}): {err}"),
         )
     }
 
     pub fn invalid_account_boc<E: Display>(err: E) -> ClientError {
-        error(ErrorCode::InvalidAccountBoc, format!("Invalid account BOC: {}", err))
+        error(ErrorCode::InvalidAccountBoc, format!("Invalid account BOC: {err}"))
     }
 
     pub fn can_not_read_transaction<E: Display>(err: E) -> ClientError {
-        error(ErrorCode::CanNotReadTransaction, format!("Can not read transaction: {}", err))
+        error(ErrorCode::CanNotReadTransaction, format!("Can not read transaction: {err}"))
     }
 
     pub fn can_not_read_blockchain_config<E: Display>(err: E) -> ClientError {
         error(
             ErrorCode::CanNotReadBlockchainConfig,
-            format!("Can not read blockchain config: {}", err),
+            format!("Can not read blockchain config: {err}"),
         )
     }
 
     pub fn can_not_read_blockchain_config_from_file<E: Display>(err: E) -> ClientError {
         error(
             ErrorCode::CanNotReadBlockchainConfig,
-            format!("Can not read blockchain config from file: {}", err),
+            format!("Can not read blockchain config from file: {err}"),
         )
     }
 
     pub fn json_deserialization_failed<E: Display>(err: E) -> ClientError {
         error(
             ErrorCode::CanNotReadBlockchainConfig,
-            format!("Deserialization blockchain config was failed: {}", err),
+            format!("Deserialization blockchain config was failed: {err}"),
         )
     }
 
     pub fn can_not_parse_config<E: Display>(err: E) -> ClientError {
         error(
             ErrorCode::CanNotReadBlockchainConfig,
-            format!("Can not parse blockchain config: {}", err),
+            format!("Can not parse blockchain config: {err}"),
         )
     }
 
     pub fn can_not_convert_config<E: Display>(err: E) -> ClientError {
-        error(ErrorCode::CanNotReadBlockchainConfig, format!("Can not convert config: {}", err))
+        error(ErrorCode::CanNotReadBlockchainConfig, format!("Can not convert config: {err}"))
     }
 
     pub fn transaction_aborted() -> ClientError {
@@ -133,14 +133,14 @@ impl Error {
         let mut error = error(
             ErrorCode::ContractExecutionError,
             if show_tips {
-                format!("Contract execution was terminated with error: {}", err)
+                format!("Contract execution was terminated with error: {err}")
             } else {
                 err.to_string()
             },
         );
 
         if show_tips && !error.message.to_lowercase().contains("exit code") {
-            error.message.push_str(&format!(", exit code: {}", exit_code));
+            error.message.push_str(&format!(", exit code: {exit_code}"));
 
             let tip = match exit_code {
                 0 => Some(
@@ -165,7 +165,7 @@ impl Error {
             };
 
             if let Some(tip) = tip {
-                error.message.push_str(&format!("\nTip: {}", tip));
+                error.message.push_str(&format!("\nTip: {tip}"));
             }
         }
 
@@ -180,7 +180,7 @@ impl Error {
         if let Some(error_code) = ExceptionCode::from_usize(exit_code as usize)
             .or(ExceptionCode::from_usize(!exit_code as usize))
         {
-            error.message.push_str(&format!(" ({})", error_code));
+            error.message.push_str(&format!(" ({error_code})"));
             error.data["description"] = error_code.to_string().into();
             if error_code == ExceptionCode::OutOfGas {
                 error.message.push_str(". Check account balance");
@@ -189,7 +189,7 @@ impl Error {
                 }
             }
         } else if let Some(code) = StdContractError::from_usize(exit_code as usize) {
-            error.message.push_str(&format!(" ({})", code));
+            error.message.push_str(&format!(" ({code})"));
             error.data["description"] = code.to_string().into();
             if let Some(tip) = code.tip() {
                 error.message.push_str(". ");
@@ -197,7 +197,7 @@ impl Error {
             }
         } else if let Some(ref exit_arg) = exit_arg {
             if let Some(error_message) = Self::read_error_message(exit_arg) {
-                error.message.push_str(&format!(", contract error: \"{}\"", error_message));
+                error.message.push_str(&format!(", contract error: \"{error_message}\""));
                 error.data["contract_error"] = error_message.into();
             }
         }
@@ -316,7 +316,7 @@ impl Error {
     pub fn unknown_execution_error<E: Display>(err: E) -> ClientError {
         error(
             ErrorCode::UnknownExecutionError,
-            format!("Transaction execution failed with unknown error: {}", err),
+            format!("Transaction execution failed with unknown error: {err}"),
         )
     }
 
@@ -329,7 +329,7 @@ impl Error {
     }
 
     pub fn internal_error<E: Display>(err: E) -> ClientError {
-        error(ErrorCode::InternalError, format!("TVM internal error: {}", err))
+        error(ErrorCode::InternalError, format!("TVM internal error: {err}"))
     }
 
     fn read_error_message(exit_arg: &Value) -> Option<String> {

--- a/tvm_client/src/tvm/stack.rs
+++ b/tvm_client/src/tvm/stack.rs
@@ -113,11 +113,11 @@ fn serialize_integer_data(data: &IntegerData) -> String {
     } else {
         // positive numbers between u128::MAX and u256::MAX are padded to 64 hex symbols
         if hex.len() <= 64 {
-            format!("0x{:0>64}", hex)
+            format!("0x{hex:0>64}")
         } else {
             // positive numbers between u256::MAX and u512::MAX are padded to 128 symbols
             // positive numbers above u512::MAX are not padded
-            format!("0x{:0>128}", hex)
+            format!("0x{hex:0>128}")
         }
     }
 }
@@ -136,7 +136,7 @@ fn process_item(item: &StackItem) -> ClientResult<ProcessingResult> {
         StackItem::Builder(value) => {
             ProcessingResult::Serialized(json!(ComplexType::Builder(serialize_cell_to_base64(
                 &value.deref().clone().into_cell().map_err(
-                    |err| Error::unknown_execution_error(format!("Can not parse object: {}", err))
+                    |err| Error::unknown_execution_error(format!("Can not parse object: {err}"))
                 )?,
                 "stack item `Builder`"
             )?)))
@@ -171,14 +171,14 @@ pub fn deserialize_item(value: &Value) -> ClientResult<StackItem> {
         Value::Array(array) => StackItem::tuple(deserialize_items(array.iter())?),
         Value::Object(_) => {
             let object = serde_json::from_value(value.clone()).map_err(|err| {
-                Error::invalid_input_stack(format!("Can not parse object: {}", err), value)
+                Error::invalid_input_stack(format!("Can not parse object: {err}"), value)
             })?;
             match object {
                 ComplexType::Builder(string) => {
                     let cell = deserialize_cell_from_base64(&string, "Builder")?.1;
                     StackItem::builder(BuilderData::from_cell(&cell).map_err(|err| {
                         Error::invalid_input_stack(
-                            format!("Can't create Builder from cell: {}", err),
+                            format!("Can't create Builder from cell: {err}"),
                             value,
                         )
                     })?)

--- a/tvm_client/src/tvm/tests.rs
+++ b/tvm_client/src/tvm/tests.rs
@@ -932,7 +932,7 @@ async fn test_my_code() {
         .await
         .unwrap();
 
-    println!("{:?}", get_my_code);
+    println!("{get_my_code:?}");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/tvm_client/src/utils/calc_storage_fee.rs
+++ b/tvm_client/src/utils/calc_storage_fee.rs
@@ -51,7 +51,7 @@ pub async fn calc_storage_fee(
     let fee = config
         .calc_storage_fee(storage, addr.is_masterchain(), storage.last_paid() + params.period)
         .map_err(|err| {
-            Error::invalid_account_boc(format!("can not calculate storage fee: {}", err))
+            Error::invalid_account_boc(format!("can not calculate storage fee: {err}"))
         })?;
 
     Ok(ResultOfCalcStorageFee { fee: format!("{}", fee.as_u128()) })

--- a/tvm_client/src/utils/compression.rs
+++ b/tvm_client/src/utils/compression.rs
@@ -20,8 +20,7 @@ pub fn compress_zstd(uncompressed: &[u8], level: Option<i32>) -> ClientResult<Ve
         Some(level) => {
             if !(1..=21).contains(&level) {
                 return Err(super::errors::Error::compression_error(format!(
-                    "Invalid compression level: {}",
-                    level
+                    "Invalid compression level: {level}"
                 )));
             }
             level

--- a/tvm_client/src/utils/errors.rs
+++ b/tvm_client/src/utils/errors.rs
@@ -26,10 +26,10 @@ fn error(code: ErrorCode, message: String) -> ClientError {
 
 impl Error {
     pub fn compression_error<E: Display>(err: E) -> ClientError {
-        error(ErrorCode::CompressionError, format!("Compression error: {}", err))
+        error(ErrorCode::CompressionError, format!("Compression error: {err}"))
     }
 
     pub fn decompression_error<E: Display>(err: E) -> ClientError {
-        error(ErrorCode::CompressionError, format!("Decompression error: {}", err))
+        error(ErrorCode::CompressionError, format!("Decompression error: {err}"))
     }
 }

--- a/tvm_client/src/utils/json.rs
+++ b/tvm_client/src/utils/json.rs
@@ -19,9 +19,9 @@ pub trait JsonHelper {
 
 impl JsonHelper for Value {
     fn get_u64(&self, field: &str) -> Result<u64> {
-        self[field].as_u64().ok_or_else(|| {
-            failure::err_msg(format!("`{field}` field must be an unsigned integer"))
-        })
+        self[field]
+            .as_u64()
+            .ok_or_else(|| failure::err_msg(format!("`{field}` field must be an unsigned integer")))
     }
 
     fn get_i64(&self, field: &str) -> Result<i64> {

--- a/tvm_client/src/utils/json.rs
+++ b/tvm_client/src/utils/json.rs
@@ -20,26 +20,26 @@ pub trait JsonHelper {
 impl JsonHelper for Value {
     fn get_u64(&self, field: &str) -> Result<u64> {
         self[field].as_u64().ok_or_else(|| {
-            failure::err_msg(format!("`{}` field must be an unsigned integer", field))
+            failure::err_msg(format!("`{field}` field must be an unsigned integer"))
         })
     }
 
     fn get_i64(&self, field: &str) -> Result<i64> {
         self[field]
             .as_i64()
-            .ok_or_else(|| failure::err_msg(format!("`{}` field must be an integer", field)))
+            .ok_or_else(|| failure::err_msg(format!("`{field}` field must be an integer")))
     }
 
     fn get_str(&self, field: &str) -> Result<&str> {
         self[field]
             .as_str()
-            .ok_or_else(|| failure::err_msg(format!("`{}` field must be a string", field)))
+            .ok_or_else(|| failure::err_msg(format!("`{field}` field must be a string")))
     }
 
     fn get_array(&self, field: &str) -> Result<&Vec<Value>> {
         self[field]
             .as_array()
-            .ok_or_else(|| failure::err_msg(format!("`{}` field must be an array", field)))
+            .ok_or_else(|| failure::err_msg(format!("`{field}` field must be an array")))
     }
 
     fn take_string(&mut self) -> Option<String> {

--- a/tvm_client_processing/src/error.rs
+++ b/tvm_client_processing/src/error.rs
@@ -11,7 +11,7 @@ pub struct Error {
 
 impl Error {
     pub fn invalid_boc<E: Display>(err: E) -> Self {
-        Self::with_code_message(201, format!("Invalid BOC: {}", err))
+        Self::with_code_message(201, format!("Invalid BOC: {err}"))
     }
 }
 

--- a/tvm_client_processing/src/sdk_services/mock_sdk_services.rs
+++ b/tvm_client_processing/src/sdk_services/mock_sdk_services.rs
@@ -93,12 +93,11 @@ impl State {
     }
 
     fn cell_from_boc(boc: &str, name: &str) -> error::Result<Cell> {
-        let bytes = base64::engine::general_purpose::STANDARD.decode(boc).map_err(|err| {
-            Error::invalid_boc(format!("error decode {name} BOC base64: {err}"))
-        })?;
-        tvm_types::boc::read_single_root_boc(bytes).map_err(|err| {
-            Error::invalid_boc(format!("{name} BOC deserialization error: {err}"))
-        })
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(boc)
+            .map_err(|err| Error::invalid_boc(format!("error decode {name} BOC base64: {err}")))?;
+        tvm_types::boc::read_single_root_boc(bytes)
+            .map_err(|err| Error::invalid_boc(format!("{name} BOC deserialization error: {err}")))
     }
 }
 

--- a/tvm_client_processing/src/sdk_services/mock_sdk_services.rs
+++ b/tvm_client_processing/src/sdk_services/mock_sdk_services.rs
@@ -94,10 +94,10 @@ impl State {
 
     fn cell_from_boc(boc: &str, name: &str) -> error::Result<Cell> {
         let bytes = base64::engine::general_purpose::STANDARD.decode(boc).map_err(|err| {
-            Error::invalid_boc(format!("error decode {} BOC base64: {}", name, err))
+            Error::invalid_boc(format!("error decode {name} BOC base64: {err}"))
         })?;
         tvm_types::boc::read_single_root_boc(bytes).map_err(|err| {
-            Error::invalid_boc(format!("{} BOC deserialization error: {}", name, err))
+            Error::invalid_boc(format!("{name} BOC deserialization error: {err}"))
         })
     }
 }

--- a/tvm_common/src/build.rs
+++ b/tvm_common/src/build.rs
@@ -16,9 +16,9 @@ pub fn common_build() {
     let build_time = get_value("date", &["+%Y-%m-%d %T %z"]);
     let rust_version = get_value("rustc", &["--version"]);
 
-    println!("cargo:rustc-env=BUILD_GIT_BRANCH={}", git_branch);
-    println!("cargo:rustc-env=BUILD_GIT_COMMIT={}", git_commit);
-    println!("cargo:rustc-env=BUILD_GIT_DATE={}", commit_date);
-    println!("cargo:rustc-env=BUILD_TIME={}", build_time);
-    println!("cargo:rustc-env=BUILD_RUST_VERSION={}", rust_version);
+    println!("cargo:rustc-env=BUILD_GIT_BRANCH={git_branch}");
+    println!("cargo:rustc-env=BUILD_GIT_COMMIT={git_commit}");
+    println!("cargo:rustc-env=BUILD_GIT_DATE={commit_date}");
+    println!("cargo:rustc-env=BUILD_TIME={build_time}");
+    println!("cargo:rustc-env=BUILD_RUST_VERSION={rust_version}");
 }

--- a/tvm_common/src/log.rs
+++ b/tvm_common/src/log.rs
@@ -2,7 +2,7 @@
 fn init_log(config: &str) {
     if !log::log_enabled!(log::Level::Error) {
         log4rs::init_file(config, Default::default())
-            .unwrap_or_else(|_| panic!("Cannot read logging configuration from {}", config));
+            .unwrap_or_else(|_| panic!("Cannot read logging configuration from {config}"));
     }
 }
 

--- a/tvm_debugger/build.rs
+++ b/tvm_debugger/build.rs
@@ -30,8 +30,8 @@ fn main() {
         build_time = String::from_utf8(b_time.stdout).unwrap_or_else(|_| "Unknown".to_string());
     }
 
-    println!("cargo:rustc-env=BUILD_GIT_BRANCH={}", git_branch);
-    println!("cargo:rustc-env=BUILD_GIT_COMMIT={}", git_commit);
-    println!("cargo:rustc-env=BUILD_GIT_DATE={}", commit_date);
-    println!("cargo:rustc-env=BUILD_TIME={}", build_time);
+    println!("cargo:rustc-env=BUILD_GIT_BRANCH={git_branch}");
+    println!("cargo:rustc-env=BUILD_GIT_COMMIT={git_commit}");
+    println!("cargo:rustc-env=BUILD_GIT_DATE={commit_date}");
+    println!("cargo:rustc-env=BUILD_TIME={build_time}");
 }

--- a/tvm_debugger/src/decode.rs
+++ b/tvm_debugger/src/decode.rs
@@ -227,7 +227,7 @@ fn print_cc(cc: &CurrencyCollection) -> String {
         result += " other: {";
         cc.other
             .iterate_with_keys(|key: u32, value| {
-                result += &format!(" \"{}\": \"{}\",", key, value);
+                result += &format!(" \"{key}\": \"{value}\",");
                 Ok(true)
             })
             .ok();

--- a/tvm_debugger/src/execute.rs
+++ b/tvm_debugger/src/execute.rs
@@ -57,7 +57,7 @@ pub(crate) fn execute(args: &RunArgs, res: &mut ExecutionResult) -> anyhow::Resu
 
     let exit_code = engine.execute().unwrap_or_else(|error| match tvm_exception(error) {
         Ok(exception) => {
-            res.log(format!("Unhandled exception: {}", exception));
+            res.log(format!("Unhandled exception: {exception}"));
             exception.exception_or_custom_code()
         }
         _ => -1,

--- a/tvm_debugger/src/helper.rs
+++ b/tvm_debugger/src/helper.rs
@@ -82,7 +82,7 @@ pub(crate) fn trace_callback(
     // }
     println!("\n--- Stack trace ------------------------");
     for item in info.stack.iter() {
-        println!("{}", item);
+        println!("{item}");
     }
     println!("----------------------------------------\n");
 }

--- a/tvm_debugger/src/main.rs
+++ b/tvm_debugger/src/main.rs
@@ -220,9 +220,9 @@ fn main() {
     };
 
     match output {
-        Ok(output) => println!("{}", output),
+        Ok(output) => println!("{output}"),
         Err(e) => {
-            eprintln!("{}", e);
+            eprintln!("{e}");
             std::process::exit(1);
         }
     }

--- a/tvm_debugger/src/result.rs
+++ b/tvm_debugger/src/result.rs
@@ -32,12 +32,12 @@ impl ExecutionResult {
 
     pub fn exit_code(&mut self, code: i32) {
         self.response_code = code;
-        self.log(format!("TVM terminated with exit code {}", code));
+        self.log(format!("TVM terminated with exit code {code}"));
     }
 
     pub fn vm_success(&mut self, is_vm_success: bool) {
         self.is_vm_success = is_vm_success;
-        self.log(format!("Computing phase is success: {}", is_vm_success));
+        self.log(format!("Computing phase is success: {is_vm_success}"));
     }
 
     pub fn gas_used(&mut self, gas: i64) {

--- a/tvm_executor/build.rs
+++ b/tvm_executor/build.rs
@@ -16,9 +16,9 @@ fn main() {
     let build_time = get_value("date", &["+%Y-%m-%d %T %z"]);
     let rust_version = get_value("rustc", &["--version"]);
 
-    println!("cargo:rustc-env=BUILD_GIT_BRANCH={}", git_branch);
-    println!("cargo:rustc-env=BUILD_GIT_COMMIT={}", git_commit);
-    println!("cargo:rustc-env=BUILD_GIT_DATE={}", commit_date);
-    println!("cargo:rustc-env=BUILD_TIME={}", build_time);
-    println!("cargo:rustc-env=BUILD_RUST_VERSION={}", rust_version);
+    println!("cargo:rustc-env=BUILD_GIT_BRANCH={git_branch}");
+    println!("cargo:rustc-env=BUILD_GIT_COMMIT={git_commit}");
+    println!("cargo:rustc-env=BUILD_GIT_DATE={commit_date}");
+    println!("cargo:rustc-env=BUILD_TIME={build_time}");
+    println!("cargo:rustc-env=BUILD_RUST_VERSION={rust_version}");
 }

--- a/tvm_executor/src/ordinary_transaction.rs
+++ b/tvm_executor/src/ordinary_transaction.rs
@@ -118,7 +118,7 @@ impl TransactionExecutor for OrdinaryTransactionExecutor {
         })?;
         let account_id = match account.get_id() {
             Some(account_id) => {
-                log::debug!(target: "executor", "Account = {:x}", account_id);
+                log::debug!(target: "executor", "Account = {account_id:x}");
                 account_id
             }
             None => {
@@ -214,8 +214,7 @@ impl TransactionExecutor for OrdinaryTransactionExecutor {
             ) {
                 Ok(credit_ph) => Some(credit_ph),
                 Err(e) => fail!(ExecutorError::TrExecutorError(format!(
-                    "cannot create credit phase of a new transaction for smart contract for reason {}",
-                    e
+                    "cannot create credit phase of a new transaction for smart contract for reason {e}"
                 ))),
             };
         }
@@ -243,8 +242,7 @@ impl TransactionExecutor for OrdinaryTransactionExecutor {
                 Some(storage_ph)
             }
             Err(e) => fail!(ExecutorError::TrExecutorError(format!(
-                "cannot create storage phase of a new transaction for smart contract for reason {}",
-                e
+                "cannot create storage phase of a new transaction for smart contract for reason {e}"
             ))),
         };
         if description.credit_first && msg_balance.grams > acc_balance.grams {
@@ -265,8 +263,7 @@ impl TransactionExecutor for OrdinaryTransactionExecutor {
             ) {
                 Ok(credit_ph) => Some(credit_ph),
                 Err(e) => fail!(ExecutorError::TrExecutorError(format!(
-                    "cannot create credit phase of a new transaction for smart contract for reason {}",
-                    e
+                    "cannot create credit phase of a new transaction for smart contract for reason {e}"
                 ))),
             };
         }
@@ -322,7 +319,7 @@ impl TransactionExecutor for OrdinaryTransactionExecutor {
         ) {
             Ok((compute_ph, actions, new_data)) => (compute_ph, actions, new_data),
             Err(e) => {
-                log::debug!(target: "executor", "compute_phase error: {}", e);
+                log::debug!(target: "executor", "compute_phase error: {e}");
                 match e.downcast_ref::<ExecutorError>() {
                     Some(ExecutorError::NoAcceptError(_, _))
                     | Some(ExecutorError::TerminationDeadlineReached) => return Err(e),
@@ -342,7 +339,7 @@ impl TransactionExecutor for OrdinaryTransactionExecutor {
                 tr.add_fee_grams(&phase.gas_fees)?;
                 if phase.success {
                     log::debug!(target: "executor", "compute_phase: success");
-                    log::debug!(target: "executor", "action_phase: lt={}", lt);
+                    log::debug!(target: "executor", "action_phase: lt={lt}");
                     action_phase_processed = true;
 
                     let message_src_dapp_id = if let Some(AccountState::AccountActive {
@@ -386,8 +383,7 @@ impl TransactionExecutor for OrdinaryTransactionExecutor {
                             Some(phase)
                         }
                         Err(e) => fail!(ExecutorError::TrExecutorError(format!(
-                            "cannot create action phase of a new transaction for smart contract for reason {}",
-                            e
+                            "cannot create action phase of a new transaction for smart contract for reason {e}"
                         ))),
                     }
                 } else {
@@ -429,7 +425,7 @@ impl TransactionExecutor for OrdinaryTransactionExecutor {
                 true
             }
         };
-        log::debug!(target: "executor", "Balance and need_to_burn {}, {}", acc_balance, need_to_burn);
+        log::debug!(target: "executor", "Balance and need_to_burn {acc_balance}, {need_to_burn}");
         if acc_balance.grams >= need_to_burn {
             acc_balance.grams -= need_to_burn;
         } else {
@@ -471,8 +467,7 @@ impl TransactionExecutor for OrdinaryTransactionExecutor {
                     }
                     Ok((bounce_ph, None)) => Some(bounce_ph),
                     Err(e) => fail!(ExecutorError::TrExecutorError(format!(
-                        "cannot create bounce phase of a new transaction for smart contract for reason {}",
-                        e
+                        "cannot create bounce phase of a new transaction for smart contract for reason {e}"
                     ))),
                 };
             }

--- a/tvm_executor/src/tick_tock_transaction.rs
+++ b/tvm_executor/src/tick_tock_transaction.rs
@@ -75,7 +75,7 @@ impl TransactionExecutor for TickTockTransactionExecutor {
             None => fail!("Account {:x} is not special account for tick tock", account_id),
         }
         let account_address = account.get_addr().cloned().unwrap_or_default();
-        log::debug!(target: "executor", "tick tock transation account {:x}", account_id);
+        log::debug!(target: "executor", "tick tock transation account {account_id:x}");
         let mut acc_balance = account.balance().cloned().unwrap_or_default();
 
         let is_masterchain = true;
@@ -109,8 +109,7 @@ impl TransactionExecutor for TickTockTransactionExecutor {
             }
             Err(e) => fail!(ExecutorError::TrExecutorError(format!(
                 "cannot create storage phase of a new transaction for \
-                         smart contract for reason {}",
-                e
+                         smart contract for reason {e}"
             ))),
         };
         let mut description = TransactionDescrTickTock {
@@ -149,7 +148,7 @@ impl TransactionExecutor for TickTockTransactionExecutor {
             )))
             .push(boolean!(self.tt.is_tock()))
             .push(int!(-2));
-        log::debug!(target: "executor", "compute_phase {}", lt);
+        log::debug!(target: "executor", "compute_phase {lt}");
         let (compute_ph, actions, new_data) = match self.compute_phase(
             None,
             account,
@@ -164,7 +163,7 @@ impl TransactionExecutor for TickTockTransactionExecutor {
         ) {
             Ok((compute_ph, actions, new_data)) => (compute_ph, actions, new_data),
             Err(e) => {
-                log::debug!(target: "executor", "compute_phase error: {}", e);
+                log::debug!(target: "executor", "compute_phase error: {e}");
                 match e.downcast_ref::<ExecutorError>() {
                     Some(ExecutorError::NoAcceptError(_, _)) => return Err(e),
                     _ => fail!(ExecutorError::TrExecutorError(e.to_string())),
@@ -178,7 +177,7 @@ impl TransactionExecutor for TickTockTransactionExecutor {
                 tr.add_fee_grams(&phase.gas_fees)?;
                 if phase.success {
                     log::debug!(target: "executor", "compute_phase: TrComputePhase::Vm success");
-                    log::debug!(target: "executor", "action_phase {}", lt);
+                    log::debug!(target: "executor", "action_phase {lt}");
                     match self.action_phase_with_copyleft(
                         &mut tr,
                         account,
@@ -202,8 +201,7 @@ impl TransactionExecutor for TickTockTransactionExecutor {
                         }
                         Err(e) => fail!(ExecutorError::TrExecutorError(format!(
                             "cannot create action phase of a new transaction \
-                                     for smart contract for reason {}",
-                            e
+                                     for smart contract for reason {e}"
                         ))),
                     }
                 } else {

--- a/tvm_executor/src/transaction_executor.rs
+++ b/tvm_executor/src/transaction_executor.rs
@@ -1527,13 +1527,12 @@ fn outmsg_action_handler(
     let compute_fwd_fee = if is_special {
         Grams::default()
     } else {
-        msg
-            .serialize()
-            .and_then(|cell| config.calc_fwd_fee(msg.is_masterchain(), &cell))
-            .map_err(|err| {
+        msg.serialize().and_then(|cell| config.calc_fwd_fee(msg.is_masterchain(), &cell)).map_err(
+            |err| {
                 log::error!(target: "executor", "cannot serialize message in action phase : {err}");
                 RESULT_CODE_ACTIONLIST_INVALID
-            })?
+            },
+        )?
     };
 
     if let Some(int_header) = msg.int_header_mut() {

--- a/tvm_executor/src/transaction_executor.rs
+++ b/tvm_executor/src/transaction_executor.rs
@@ -468,7 +468,7 @@ pub trait TransactionExecutor {
             debug_assert!(!result_acc.is_none());
             false
         };
-        log::debug!(target: "executor", "acc balance: {:#?}", acc_balance);
+        log::debug!(target: "executor", "acc balance: {acc_balance:#?}");
         log::debug!(target: "executor", "msg balance: {}", msg_balance.grams);
         let is_ordinary = self.ordinary_transaction();
         if acc_balance.grams.is_zero() && !params.is_same_thread_id {
@@ -575,11 +575,11 @@ pub trait TransactionExecutor {
         }
 
         let result = vm.execute();
-        log::trace!(target: "executor", "execute result: {:?}", result);
+        log::trace!(target: "executor", "execute result: {result:?}");
         let mut raw_exit_arg = None;
         match result {
             Err(err) => {
-                log::debug!(target: "executor", "VM terminated with exception: {}", err);
+                log::debug!(target: "executor", "VM terminated with exception: {err}");
                 if let Some(TvmError::TerminationDeadlineReached) = err.downcast_ref() {
                     fail!(ExecutorError::TerminationDeadlineReached);
                 }
@@ -737,8 +737,7 @@ pub trait TransactionExecutor {
             Err(err) => {
                 log::debug!(
                     target: "executor",
-                    "cannot parse action list: format is invalid, err: {}",
-                    err
+                    "cannot parse action list: format is invalid, err: {err}"
                 );
                 // Here you can select only one of 2 error codes:
                 // RESULT_CODE_UNKNOWN_OR_INVALID_ACTION or RESULT_CODE_ACTIONLIST_INVALID
@@ -754,8 +753,7 @@ pub trait TransactionExecutor {
             return Ok(ActionPhaseResult::from_phase(phase));
         }
         phase.tot_actions = actions.len() as i16;
-        log::debug!(target: "executor", "\nActions {:#?}",
-                actions
+        log::debug!(target: "executor", "\nActions {actions:#?}"
         );
 
         let process_err_code =
@@ -764,7 +762,7 @@ pub trait TransactionExecutor {
                     err_code = RESULT_CODE_UNKNOWN_OR_INVALID_ACTION;
                 }
                 if err_code != 0 {
-                    log::debug!(target: "executor", "action failed: error_code={}", err_code);
+                    log::debug!(target: "executor", "action failed: error_code={err_code}");
                     phase.valid = true;
                     phase.result_code = err_code;
                     if i != 0 {
@@ -839,7 +837,7 @@ pub trait TransactionExecutor {
                     }
                 }
                 OutAction::ReserveCurrency { mode, mut value } => {
-                    log::debug!(target: "executor", "RESERVE: mode {:?}, value {:?}, acc_remaining {:?}, original_acc_balance {:?}, need_to_reserve {:?}", mode, value, acc_remaining_balance, original_acc_balance, need_to_reserve);
+                    log::debug!(target: "executor", "RESERVE: mode {mode:?}, value {value:?}, acc_remaining {acc_remaining_balance:?}, original_acc_balance {original_acc_balance:?}, need_to_reserve {need_to_reserve:?}");
                     match reserve_action_handler(
                         mode,
                         &mut value,
@@ -1034,14 +1032,14 @@ pub trait TransactionExecutor {
             balance_to_string(&total_reserved_value)
         );
         if let Err(err) = acc_remaining_balance.add(&total_reserved_value) {
-            log::debug!(target: "executor", "failed to add account balance with reserved value {}", err);
+            log::debug!(target: "executor", "failed to add account balance with reserved value {err}");
             fail!("failed to add account balance with reserved value {}", err)
         }
 
         log::debug!(target: "executor", "Final:    {}", balance_to_string(&acc_remaining_balance));
 
         let fee = phase.total_action_fees();
-        log::debug!(target: "executor", "Total action fees: {}", fee);
+        log::debug!(target: "executor", "Total action fees: {fee}");
         tr.add_fee_grams(&fee)?;
 
         if account_deleted {
@@ -1139,12 +1137,11 @@ pub trait TransactionExecutor {
         let fwd_mine_fees = fwd_prices.mine_fee_checked(&fwd_full_fees)?;
         let fwd_fees = fwd_full_fees - fwd_mine_fees;
 
-        log::debug!(target: "executor", "get fee {} from bounce msg {}", fwd_full_fees, remaining_msg_balance);
+        log::debug!(target: "executor", "get fee {fwd_full_fees} from bounce msg {remaining_msg_balance}");
 
         if remaining_msg_balance.grams < fwd_full_fees + *compute_phase_fees {
             log::debug!(
-                target: "executor", "bounce phase - not enough grams {} to get fwd fee {}",
-                remaining_msg_balance, fwd_full_fees
+                target: "executor", "bounce phase - not enough grams {remaining_msg_balance} to get fwd fee {fwd_full_fees}"
             );
             return Ok((TrBouncePhase::no_funds(storage, fwd_full_fees), None));
         }
@@ -1196,14 +1193,13 @@ pub trait TransactionExecutor {
                     }
                     log::debug!(
                         target: "executor",
-                        "Found copyleft action: license: {}, address: {}",
-                        license, address
+                        "Found copyleft action: license: {license}, address: {address}"
                     );
                     copyleft_reward = (*compute_phase_fees * copyleft_percent as u128) / 100;
                     copyleft_address = address.clone();
                     was_copyleft_instruction = true;
                 } else {
-                    log::debug!(target: "executor", "Not found license {} in config", license);
+                    log::debug!(target: "executor", "Not found license {license} in config");
                     phase.result_code = RESULT_CODE_NOT_FOUND_LICENSE;
                     phase.result_arg = Some(i as i32);
                     return Ok(None);
@@ -1290,7 +1286,7 @@ fn compute_new_state(
                 }
                 match acc.try_activate_by_init_code_hash(state_init, init_code_hash) {
                     Err(err) => {
-                        log::debug!(target: "executor", "reason: {}", err);
+                        log::debug!(target: "executor", "reason: {err}");
                         Ok(Some(ComputeSkipReason::BadState))
                     }
                     Ok(_) => Ok(None),
@@ -1315,7 +1311,7 @@ fn compute_new_state(
                     log::debug!(target: "executor", "message for frozen: activated");
                     return match acc.try_activate_by_init_code_hash(state_init, init_code_hash) {
                         Err(err) => {
-                            log::debug!(target: "executor", "reason: {}", err);
+                            log::debug!(target: "executor", "reason: {err}");
                             Ok(Some(ComputeSkipReason::BadState))
                         }
                         Ok(_) => Ok(None),
@@ -1395,8 +1391,7 @@ fn check_rewrite_dest_addr(
         {
             log::debug!(
                 target: "executor",
-                "cannot send message from {} to {} it doesn't allow yet",
-                my_addr, dst
+                "cannot send message from {my_addr} to {dst} it doesn't allow yet"
             );
             return Err(IncorrectCheckRewrite::Other);
         }
@@ -1405,8 +1400,7 @@ fn check_rewrite_dest_addr(
             if !wc.accept_msgs {
                 log::debug!(
                     target: "executor",
-                    "destination address belongs to workchain {} not accepting new messages",
-                    workchain_id
+                    "destination address belongs to workchain {workchain_id} not accepting new messages"
                 );
                 return Err(IncorrectCheckRewrite::Other);
             }
@@ -1419,16 +1413,14 @@ fn check_rewrite_dest_addr(
             if !is_valid_addr_len(addr_len, min_addr_len, max_addr_len, addr_len_step) {
                 log::debug!(
                     target: "executor",
-                    "destination address has length {} invalid for destination workchain {}",
-                    addr_len, workchain_id
+                    "destination address has length {addr_len} invalid for destination workchain {workchain_id}"
                 );
                 return Err(IncorrectCheckRewrite::Other);
             }
         } else {
             log::debug!(
                 target: "executor",
-                "destination address contains unknown workchain_id {}",
-                workchain_id
+                "destination address contains unknown workchain_id {workchain_id}"
             );
             return Err(IncorrectCheckRewrite::Other);
         }
@@ -1447,8 +1439,7 @@ fn check_rewrite_dest_addr(
         if addr_len != 256 {
             log::debug!(
                 target: "executor",
-                "destination address has length {} invalid for destination workchain {}",
-                addr_len, workchain_id
+                "destination address has length {addr_len} invalid for destination workchain {workchain_id}"
             );
             return Err(IncorrectCheckRewrite::Other);
         }
@@ -1540,7 +1531,7 @@ fn outmsg_action_handler(
             .serialize()
             .and_then(|cell| config.calc_fwd_fee(msg.is_masterchain(), &cell))
             .map_err(|err| {
-                log::error!(target: "executor", "cannot serialize message in action phase : {}", err);
+                log::error!(target: "executor", "cannot serialize message in action phase : {err}");
                 RESULT_CODE_ACTIONLIST_INVALID
             })?
     };
@@ -1652,7 +1643,7 @@ fn outmsg_action_handler(
         Ok(false) | Err(_) => {
             log::warn!(
                 target: "executor",
-                "account balance {} is too small, cannot send {}", acc_balance, result_value
+                "account balance {acc_balance} is too small, cannot send {result_value}"
             );
             return Err(skip.map(|_| RESULT_CODE_NOT_ENOUGH_EXTRA).unwrap_or_default());
         }
@@ -1689,7 +1680,7 @@ fn outmsg_action_handler(
     phase.add_action_fees(fwd_mine_fee);
 
     let msg_cell = msg.serialize().map_err(|err| {
-        log::error!(target: "executor", "cannot serialize message in action phase : {}", err);
+        log::error!(target: "executor", "cannot serialize message in action phase : {err}");
         RESULT_CODE_ACTIONLIST_INVALID
     })?;
     phase.tot_msg_size.append(&msg_cell);
@@ -1789,7 +1780,7 @@ fn change_library_action_handler(
 ) -> Option<i32> {
     let result = match (code, hash) {
         (Some(code), None) => {
-            log::debug!(target: "executor", "OutAction::ChangeLibrary mode: {}, code: {}", mode, code);
+            log::debug!(target: "executor", "OutAction::ChangeLibrary mode: {mode}, code: {code}");
             if mode == 0 {
                 // TODO: Wrong codes. Look tvm_block/out_actions::SET_LIB_CODE_REMOVE
                 acc.delete_library(&code.repr_hash())
@@ -1798,7 +1789,7 @@ fn change_library_action_handler(
             }
         }
         (None, Some(hash)) => {
-            log::debug!(target: "executor", "OutAction::ChangeLibrary mode: {}, hash: {:x}", mode, hash);
+            log::debug!(target: "executor", "OutAction::ChangeLibrary mode: {mode}, hash: {hash:x}");
             if mode == 0 {
                 acc.delete_library(&hash)
             } else {

--- a/tvm_sdk/src/json_helper.rs
+++ b/tvm_sdk/src/json_helper.rs
@@ -113,7 +113,7 @@ pub mod opt_cell {
     {
         if let Some(cell) = value {
             let str_value = base64_encode(tvm_types::boc::write_boc(cell).map_err(|err| {
-                serde::ser::Error::custom(format!("Cannot serialize BOC: {}", err))
+                serde::ser::Error::custom(format!("Cannot serialize BOC: {err}"))
             })?);
             serializer.serialize_some(&str_value)
         } else {
@@ -127,10 +127,10 @@ where
     D: serde::Deserializer<'de>,
 {
     let bytes = base64_decode(b64)
-        .map_err(|err| D::Error::custom(format!("error decode base64: {}", err)))?;
+        .map_err(|err| D::Error::custom(format!("error decode base64: {err}")))?;
 
     tvm_types::boc::read_single_root_boc(bytes)
-        .map_err(|err| D::Error::custom(format!("BOC read error: {}", err)))
+        .map_err(|err| D::Error::custom(format!("BOC read error: {err}")))
 }
 
 pub mod address {
@@ -143,7 +143,7 @@ pub mod address {
         let string = d.deserialize_string(StringVisitor)?;
 
         MsgAddressInt::from_str(&string)
-            .map_err(|err| D::Error::custom(format!("Address parsing error: {}", err)))
+            .map_err(|err| D::Error::custom(format!("Address parsing error: {err}")))
     }
 
     pub fn serialize<S>(value: &MsgAddressInt, serializer: S) -> Result<S::Ok, S::Error>
@@ -169,20 +169,19 @@ pub mod uint {
 
         if !string.starts_with("0x") {
             return Err(D::Error::custom(format!(
-                "Number parsing error: number must be prefixed with 0x ({})",
-                string
+                "Number parsing error: number must be prefixed with 0x ({string})"
             )));
         }
 
         u64::from_str_radix(&string[2..], 16)
-            .map_err(|err| D::Error::custom(format!("Error parsing number: {}", err)))
+            .map_err(|err| D::Error::custom(format!("Error parsing number: {err}")))
     }
 
     pub fn serialize<S>(value: &u64, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(&format!("0x{:x}", value))
+        serializer.serialize_str(&format!("0x{value:x}"))
     }
 }
 
@@ -197,7 +196,7 @@ where
         Ok(2) => Ok(TransactionProcessingStatus::Proposed),
         Ok(3) => Ok(TransactionProcessingStatus::Finalized),
         Ok(4) => Ok(TransactionProcessingStatus::Refused),
-        Ok(num) => Err(D::Error::custom(format!("Invalid transaction state: {}", num))),
+        Ok(num) => Err(D::Error::custom(format!("Invalid transaction state: {num}"))),
     }
 }
 
@@ -221,7 +220,7 @@ where
         0 => Ok(AccStatusChange::Unchanged),
         1 => Ok(AccStatusChange::Frozen),
         2 => Ok(AccStatusChange::Deleted),
-        num => Err(D::Error::custom(format!("Invalid account change state: {}", num))),
+        num => Err(D::Error::custom(format!("Invalid account change state: {num}"))),
     }
 }
 
@@ -234,7 +233,7 @@ where
         Ok(0) => Ok(Some(ComputeSkipReason::NoState)),
         Ok(1) => Ok(Some(ComputeSkipReason::BadState)),
         Ok(2) => Ok(Some(ComputeSkipReason::NoGas)),
-        Ok(num) => Err(D::Error::custom(format!("Invalid skip reason: {}", num))),
+        Ok(num) => Err(D::Error::custom(format!("Invalid skip reason: {num}"))),
     }
 }
 
@@ -248,7 +247,7 @@ where
         0 => Ok(MessageType::Internal),
         1 => Ok(MessageType::ExternalInbound),
         2 => Ok(MessageType::ExternalOutbound),
-        num => Err(D::Error::custom(format!("Invalid message type: {}", num))),
+        num => Err(D::Error::custom(format!("Invalid message type: {num}"))),
     }
 }
 
@@ -266,7 +265,7 @@ pub mod account_status {
             1 => Ok(AccountStatus::AccStateActive),
             2 => Ok(AccountStatus::AccStateFrozen),
             3 => Ok(AccountStatus::AccStateNonexist),
-            num => Err(D::Error::custom(format!("Invalid account status: {}", num))),
+            num => Err(D::Error::custom(format!("Invalid account status: {num}"))),
         }
     }
 
@@ -299,5 +298,5 @@ where
     let string = d.deserialize_string(StringVisitor)?;
 
     u64::from_str_radix(&string, 16)
-        .map_err(|err| D::Error::custom(format!("Error parsing shard: {}", err)))
+        .map_err(|err| D::Error::custom(format!("Error parsing shard: {err}")))
 }

--- a/tvm_sdk/src/types.rs
+++ b/tvm_sdk/src/types.rs
@@ -72,6 +72,6 @@ impl StringId {
 
 pub fn grams_to_u64(grams: &tvm_block::types::Grams) -> Result<u64> {
     grams.as_u128().to_u64().ok_or_else(|| {
-        SdkError::InvalidData { msg: format!("Cannot convert grams value {}", grams) }.into()
+        SdkError::InvalidData { msg: format!("Cannot convert grams value {grams}") }.into()
     })
 }

--- a/tvm_tl_codegen/src/bin/codegen_test.rs
+++ b/tvm_tl_codegen/src/bin/codegen_test.rs
@@ -19,7 +19,7 @@ const TL_DIR: &str = "tvm_api/tl";
 
 fn main() {
     let mut files = fs::read_dir(TL_DIR)
-        .unwrap_or_else(|_| panic!("Unable to read directory contents: {}", TL_DIR))
+        .unwrap_or_else(|_| panic!("Unable to read directory contents: {TL_DIR}"))
         .filter_map(Result::ok)
         .map(|d| d.path())
         .filter(|path| path.to_str().unwrap().ends_with(".tl"))

--- a/tvm_tl_codegen/src/lib.rs
+++ b/tvm_tl_codegen/src/lib.rs
@@ -504,9 +504,7 @@ fn reformat(filename: &Path) {
         Ok(status) => status,
         Err(err) => {
             if !WARNING_PRINTED.swap(true, Ordering::Relaxed) {
-                println!(
-                    "cargo:warning=rustfmt failed to start: {err:?}. {INSTALL_INSTRUCTIONS}"
-                );
+                println!("cargo:warning=rustfmt failed to start: {err:?}. {INSTALL_INSTRUCTIONS}");
             }
             return;
         }
@@ -535,9 +533,9 @@ impl Namespace {
                 .or_insert_with(|| NamespaceItem::AnotherNamespace(Default::default()))
             {
                 &mut NamespaceItem::AnotherNamespace(ref mut ns) => ns,
-                other => panic!(
-                    "descend_tree: duplicate namespace item {name} {other:?} {names:?}"
-                ),
+                other => {
+                    panic!("descend_tree: duplicate namespace item {name} {other:?} {names:?}")
+                }
             }
         })
     }

--- a/tvm_tl_codegen/src/lib.rs
+++ b/tvm_tl_codegen/src/lib.rs
@@ -78,7 +78,7 @@ pub mod parser {
         fn get_repeated_name(repeat_count: Option<u32>, fields: &[Field]) -> String {
             let mut result = String::new();
             if let Some(value) = repeat_count {
-                result = format!("{} * ", value);
+                result = format!("{value} * ");
             }
             result += "[ ";
             for field in fields {
@@ -432,7 +432,7 @@ pub mod parser {
         }
 
         pub fn trim_common_prefix(&mut self, other: &Self) {
-            assert!(self.0.starts_with(&other.0), "{:?} not a prefix of {:?}", self, other);
+            assert!(self.0.starts_with(&other.0), "{self:?} not a prefix of {other:?}");
             self.0.drain(0..(other.0.len()));
         }
     }
@@ -505,8 +505,7 @@ fn reformat(filename: &Path) {
         Err(err) => {
             if !WARNING_PRINTED.swap(true, Ordering::Relaxed) {
                 println!(
-                    "cargo:warning=rustfmt failed to start: {:?}. {}",
-                    err, INSTALL_INSTRUCTIONS
+                    "cargo:warning=rustfmt failed to start: {err:?}. {INSTALL_INSTRUCTIONS}"
                 );
             }
             return;
@@ -537,8 +536,7 @@ impl Namespace {
             {
                 &mut NamespaceItem::AnotherNamespace(ref mut ns) => ns,
                 other => panic!(
-                    "descend_tree: duplicate namespace item {} {:?} {:?}",
-                    name, other, names
+                    "descend_tree: duplicate namespace item {name} {other:?} {names:?}"
                 ),
             }
         })
@@ -548,7 +546,7 @@ impl Namespace {
         let leaf = names.pop().unwrap();
         let namespace = self.descend_tree(&names);
         if namespace.0.contains_key(&leaf) {
-            println!("cargo:warning=insert: duplicate namespace item {:?}", names);
+            println!("cargo:warning=insert: duplicate namespace item {names:?}");
             return;
         }
         namespace.0.insert(leaf, item);
@@ -854,7 +852,7 @@ impl TypeName {
         F: FnOnce(&Tokens) -> Tokens,
     {
         let tokens = self.transformed_tokens(func);
-        let tokens_canon = format!("{}", tokens);
+        let tokens_canon = format!("{tokens}");
         TypeName { tokens, tokens_canon, idents: None }
     }
 }
@@ -894,7 +892,7 @@ where
         for ident in &idents {
             tokens = quote!(#tokens::#ident);
         }
-        let tokens_canon = format!("{}", tokens);
+        let tokens_canon = format!("{tokens}");
 
         TypeName { tokens, tokens_canon, idents: Some(idents) }
     }
@@ -1412,7 +1410,7 @@ impl Constructor<TypeIR, FieldIR> {
         match self.fields.iter().filter(|f| f.ty.is_flags()).count() {
             0 => return None,
             1 => (),
-            n => panic!("{} flags fields found on {:?}", n, self),
+            n => panic!("{n} flags fields found on {self:?}"),
         }
         let determination = {
             let fields = self.fields.iter().filter_map(|f| {
@@ -1729,7 +1727,7 @@ impl Constructor<TypeIR, FieldIR> {
 
     fn tl_id(&self) -> Option<Tokens> {
         self.tl_id.as_ref().map(|tl_id| {
-            let tl_id: syn::LitInt = syn::parse_str(&format!("0x{:08x}", tl_id)).unwrap();
+            let tl_id: syn::LitInt = syn::parse_str(&format!("0x{tl_id:08x}")).unwrap();
             quote!(crate::ConstructorNumber(#tl_id))
         })
     }

--- a/tvm_types/build.rs
+++ b/tvm_types/build.rs
@@ -16,9 +16,9 @@ fn main() {
     let build_time = get_value("date", &["+%Y-%m-%d %T %z"]);
     let rust_version = get_value("rustc", &["--version"]);
 
-    println!("cargo:rustc-env=BUILD_GIT_BRANCH={}", git_branch);
-    println!("cargo:rustc-env=BUILD_GIT_COMMIT={}", git_commit);
-    println!("cargo:rustc-env=BUILD_GIT_DATE={}", commit_date);
-    println!("cargo:rustc-env=BUILD_TIME={}", build_time);
-    println!("cargo:rustc-env=BUILD_RUST_VERSION={}", rust_version);
+    println!("cargo:rustc-env=BUILD_GIT_BRANCH={git_branch}");
+    println!("cargo:rustc-env=BUILD_GIT_COMMIT={git_commit}");
+    println!("cargo:rustc-env=BUILD_GIT_DATE={commit_date}");
+    println!("cargo:rustc-env=BUILD_TIME={build_time}");
+    println!("cargo:rustc-env=BUILD_RUST_VERSION={rust_version}");
 }

--- a/tvm_types/src/bls.rs
+++ b/tvm_types/src/bls.rs
@@ -139,7 +139,7 @@ pub fn aggregate_public_keys_based_on_nodes_info(
     let result = aggregate_public_keys(&apk_pks_required_refs)?;
     let duration = now.elapsed();
 
-    println!("Time elapsed by !!!aggregate_public_keys is: {:?}", duration);
+    println!("Time elapsed by !!!aggregate_public_keys is: {duration:?}");
     Ok(result)
 }
 
@@ -263,7 +263,7 @@ impl BlsKeyPair {
         println!("Aggregated BLS public key");
         println!("--------------------------------------------------");
         println!("Public key bytes:");
-        println!("{:?}", bls_pk_bytes);
+        println!("{bls_pk_bytes:?}");
         println!("--------------------------------------------------");
     }
 
@@ -382,7 +382,7 @@ impl NodesInfo {
         println!("Total number of nodes: {}", &self.total_num_of_nodes);
         println!("Indexes -- occurrences: ");
         for (index, number_of_occurrence) in &self.map {
-            println!("{}: \"{}\"", index, number_of_occurrence);
+            println!("{index}: \"{number_of_occurrence}\"");
         }
         println!("--------------------------------------------------");
         println!("--------------------------------------------------");
@@ -615,7 +615,7 @@ impl BlsSignature {
         println!("--------------------------------------------------");
         println!("BLS Signature bytes:");
         println!("--------------------------------------------------");
-        println!("{:?}", sig_bytes);
+        println!("{sig_bytes:?}");
         println!("--------------------------------------------------");
     }
 

--- a/tvm_types/src/boc.rs
+++ b/tvm_types/src/boc.rs
@@ -906,13 +906,8 @@ impl<'a> BocReader<'a> {
         {
             let total_time = now.elapsed().as_millis();
             log::trace!(
-                "TIME read_cells_tree_ex: {}ms (read: {}, creating cells: {}, \
-                    indexed cells cleanup: {}, done cells cleanup: {})",
-                total_time,
-                read_time,
-                constructing_time,
-                drop_time_ic,
-                drop_time_dc
+                "TIME read_cells_tree_ex: {total_time}ms (read: {read_time}, creating cells: {constructing_time}, \
+                    indexed cells cleanup: {drop_time_ic}, done cells cleanup: {drop_time_dc})"
             );
         }
 
@@ -1032,12 +1027,7 @@ impl<'a> BocReader<'a> {
         {
             let total_time = now.elapsed().as_millis();
             log::trace!(
-                "TIME read_inmem: {}ms (index: {}, creating cells: {}, crc: {}, cleanup: {})",
-                total_time,
-                index_time,
-                constructing_time,
-                crc_time,
-                cleanup_time
+                "TIME read_inmem: {total_time}ms (index: {index_time}, creating cells: {constructing_time}, crc: {crc_time}, cleanup: {cleanup_time})"
             );
         }
 

--- a/tvm_types/src/cell/builder.rs
+++ b/tvm_types/src/cell/builder.rs
@@ -380,6 +380,6 @@ impl fmt::UpperHex for BuilderData {
 
 impl fmt::Binary for BuilderData {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.data.iter().try_for_each(|x| write!(f, "{:08b}", x))
+        self.data.iter().try_for_each(|x| write!(f, "{x:08b}"))
     }
 }

--- a/tvm_types/src/cell/mod.rs
+++ b/tvm_types/src/cell/mod.rs
@@ -692,7 +692,7 @@ impl Cell {
             (false, true) => "   ",
             (false, false) => " │ ",
         };
-        write!(f, "{}{}", indent, build)
+        write!(f, "{indent}{build}")
     }
 
     pub fn format_without_refs(
@@ -709,7 +709,7 @@ impl Cell {
 
         if self.cell_type() == CellType::Big {
             let data_len = self.data().len();
-            write!(f, "Big   bytes: {}", data_len)?;
+            write!(f, "Big   bytes: {data_len}")?;
             if data_len > 100 {
                 writeln!(f)?;
                 if !root {
@@ -753,7 +753,7 @@ impl Cell {
                 }
                 write!(f, "hashes:")?;
                 for h in self.hashes().iter() {
-                    write!(f, " {:x}", h)?;
+                    write!(f, " {h:x}")?;
                 }
                 writeln!(f)?;
                 if !root {
@@ -761,7 +761,7 @@ impl Cell {
                 }
                 write!(f, "depths:")?;
                 for d in self.depths().iter() {
-                    write!(f, " {}", d)?;
+                    write!(f, " {d}")?;
                 }
             }
         }
@@ -952,7 +952,7 @@ impl fmt::Binary for Cell {
         } else {
             let data = self.data();
             for b in &data[..data.len() - 1] {
-                write!(f, "{:08b}", b)?;
+                write!(f, "{b:08b}")?;
             }
             for i in (8 - (bitlen % 8)..8).rev() {
                 write!(f, "{:b}", (data[data.len() - 1] >> i) & 1)?;

--- a/tvm_types/src/cell/slice.rs
+++ b/tvm_types/src/cell/slice.rs
@@ -684,7 +684,7 @@ impl SliceData {
                     true
                 }
                 (_, None, _) => {
-                    log::warn!(target: "tvm", "unreachable in erase_prefix {} {}", self, prefix);
+                    log::warn!(target: "tvm", "unreachable in erase_prefix {self} {prefix}");
                     self.shrink_data(0..0);
                     true
                 }
@@ -871,7 +871,7 @@ impl SliceData {
 
 impl fmt::Debug for SliceData {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:x}", self)
+        write!(f, "{self:x}")
     }
 }
 
@@ -887,7 +887,7 @@ impl fmt::Display for SliceData {
         )?;
         match &self.data {
             InternalData::None => writeln!(f, "cell: empty"),
-            InternalData::Cell(cell) => writeln!(f, "cell: {}", cell),
+            InternalData::Cell(cell) => writeln!(f, "cell: {cell}"),
             InternalData::Data(data, length_in_bits, ) => writeln!(f, "cell: {} - {length_in_bits}", hex::encode(data)),
         }
     }

--- a/tvm_types/src/dictionary/hashmap.rs
+++ b/tvm_types/src/dictionary/hashmap.rs
@@ -29,7 +29,7 @@ pub struct HashmapE {
 impl fmt::Display for HashmapE {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.data() {
-            Some(cell) => write!(f, "Hashmap: {}", cell),
+            Some(cell) => write!(f, "Hashmap: {cell}"),
             None => write!(f, "Empty Hashmap"),
         }
     }

--- a/tvm_types/src/dictionary/mod.rs
+++ b/tvm_types/src/dictionary/mod.rs
@@ -1354,9 +1354,8 @@ impl<'a, T: HashmapType + ?Sized> HashmapInserter<'a, T> {
                 error @ (_, _, _) => {
                     log::error!(
                         target: "tvm",
-                        "If we hit this, there's certainly a bug. {:?}. \
-                        Passed: label: {}, key: {} ",
-                        error, label, key
+                        "If we hit this, there's certainly a bug. {error:?}. \
+                        Passed: label: {label}, key: {key} "
                     );
                     fail!(ExceptionCode::FatalError)
                 }

--- a/tvm_types/src/dictionary/pfxhashmap.rs
+++ b/tvm_types/src/dictionary/pfxhashmap.rs
@@ -35,7 +35,7 @@ pub struct PfxHashmapE {
 impl fmt::Display for PfxHashmapE {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.data() {
-            Some(cell) => write!(f, "PfxHashmap: {}", cell),
+            Some(cell) => write!(f, "PfxHashmap: {cell}"),
             None => write!(f, "Empty PfxHashmap"),
         }
     }

--- a/tvm_types/src/tests.rs
+++ b/tvm_types/src/tests.rs
@@ -164,7 +164,7 @@ fn info(use_boc3: bool) -> String {
 
 fn test_boc_file(filename: &Path, stats: &mut Stats) -> Cell {
     let orig_bytes = Arc::new(
-        read(Path::new(filename)).unwrap_or_else(|_| panic!("Error reading file {:?}", filename)),
+        read(Path::new(filename)).unwrap_or_else(|_| panic!("Error reading file {filename:?}")),
     );
 
     let orig_cells = read_boc_ex(orig_bytes.clone(), false);

--- a/tvm_vm/build.rs
+++ b/tvm_vm/build.rs
@@ -16,9 +16,9 @@ fn main() {
     let build_time = get_value("date", &["+%Y-%m-%d %T %z"]);
     let rust_version = get_value("rustc", &["--version"]);
 
-    println!("cargo:rustc-env=BUILD_GIT_BRANCH={}", git_branch);
-    println!("cargo:rustc-env=BUILD_GIT_COMMIT={}", git_commit);
-    println!("cargo:rustc-env=BUILD_GIT_DATE={}", commit_date);
-    println!("cargo:rustc-env=BUILD_TIME={}", build_time);
-    println!("cargo:rustc-env=BUILD_RUST_VERSION={}", rust_version);
+    println!("cargo:rustc-env=BUILD_GIT_BRANCH={git_branch}");
+    println!("cargo:rustc-env=BUILD_GIT_COMMIT={git_commit}");
+    println!("cargo:rustc-env=BUILD_GIT_DATE={commit_date}");
+    println!("cargo:rustc-env=BUILD_TIME={build_time}");
+    println!("cargo:rustc-env=BUILD_RUST_VERSION={rust_version}");
 }

--- a/tvm_vm/src/error.rs
+++ b/tvm_vm/src/error.rs
@@ -94,7 +94,7 @@ pub fn update_error_description(
                 // TODO: it is wrong, need to modify current backtrace
                 err = TvmError::TvmExceptionFull(
                     Exception::from_code(*code, file!(), line!()),
-                    f(&format!("{:?}", err)),
+                    f(&format!("{err:?}")),
                 )
                 .into()
             }

--- a/tvm_vm/src/executor/dump.rs
+++ b/tvm_vm/src/executor/dump.rs
@@ -52,9 +52,9 @@ fn dump_var_impl(item: &StackItem, how: u8, in_tuple: bool) -> String {
         match item {
             StackItem::None => String::new(),
             StackItem::Builder(x) => format!("BC<{:X}>", Arc::as_ref(x)),
-            StackItem::Cell(x) => format!("C<{:X}>", x),
+            StackItem::Cell(x) => format!("C<{x:X}>"),
             StackItem::Continuation(x) => {
-                x.code().cell_opt().map_or(String::new(), |cell| format!("R<{:X}>", cell))
+                x.code().cell_opt().map_or(String::new(), |cell| format!("R<{cell:X}>"))
             }
             StackItem::Integer(x) => format!("{:X}", Arc::as_ref(x)),
             StackItem::Slice(x) => {
@@ -66,9 +66,9 @@ fn dump_var_impl(item: &StackItem, how: u8, in_tuple: bool) -> String {
         match item {
             StackItem::None => String::new(),
             StackItem::Builder(x) => format!("BC<{:b}>", Arc::as_ref(x)),
-            StackItem::Cell(x) => format!("C<{:b}>", x),
+            StackItem::Cell(x) => format!("C<{x:b}>"),
             StackItem::Continuation(x) => {
-                x.code().cell_opt().map_or(String::new(), |cell| format!("R<{:b}>", cell))
+                x.code().cell_opt().map_or(String::new(), |cell| format!("R<{cell:b}>"))
             }
             StackItem::Integer(x) => format!("{:b}", Arc::as_ref(x)),
             StackItem::Slice(x) => x.cell_opt().map_or(String::new(), |cell| {
@@ -94,9 +94,9 @@ fn dump_var_impl(item: &StackItem, how: u8, in_tuple: bool) -> String {
         match item {
             StackItem::None => String::new(),
             StackItem::Builder(x) => format!("BC<{:X}>", Arc::as_ref(x)),
-            StackItem::Cell(x) => format!("C<{:X}>", x),
+            StackItem::Cell(x) => format!("C<{x:X}>"),
             StackItem::Continuation(x) => {
-                x.code().cell_opt().map_or(String::new(), |cell| format!("R<{:X}>", cell))
+                x.code().cell_opt().map_or(String::new(), |cell| format!("R<{cell:X}>"))
             }
             StackItem::Integer(x) => format!("{}", Arc::as_ref(x)),
             StackItem::Slice(x) => x.cell_opt().map_or(String::new(), |cell| {
@@ -113,7 +113,7 @@ fn dump_stack(engine: &mut Engine, depth: usize, print_depth: bool) -> Status {
         engine.dump(&dump);
     }
     if print_depth {
-        engine.dump(&format!("{}\n", depth));
+        engine.dump(&format!("{depth}\n"));
     }
     engine.flush();
     Ok(())

--- a/tvm_vm/src/executor/engine/core.rs
+++ b/tvm_vm/src/executor/engine/core.rs
@@ -428,10 +428,10 @@ impl Engine {
         let mut s = String::with_capacity(wasm_hash.len() * 2);
         log::debug!("{}", std::env::current_dir()?.display());
         for &b in wasm_hash.as_slice() {
-            write!(&mut s, "{:02x}", b)?;
+            write!(&mut s, "{b:02x}")?;
         }
         let filename = format!("{}/{}", self.wasm_binary_root_path, s);
-        log::debug!("Getting file {:?}", filename);
+        log::debug!("Getting file {filename:?}");
         // TODO: Add some hash checking of the file
         Ok(std::fs::read(filename)?)
     }
@@ -565,7 +565,7 @@ impl Engine {
                 StackItem::None => "N".to_string(),
                 StackItem::Integer(data) => match data.bitsize() {
                     Ok(0..=230) => data.to_string(),
-                    Ok(bitsize) => format!("I{}", bitsize),
+                    Ok(bitsize) => format!("I{bitsize}"),
                     Err(err) => err.to_string(),
                 },
                 StackItem::Cell(data) => {
@@ -580,7 +580,7 @@ impl Engine {
                 }
                 StackItem::Tuple(data) => match data.len() {
                     0 => "[]".to_string(),
-                    len => format!("[@{}]", len),
+                    len => format!("[@{len}]"),
                 },
             };
             result += &string;
@@ -1046,7 +1046,7 @@ impl Engine {
                 .filter_map(|i| {
                     self.ctrls.get(*i).map(|item| {
                         if !short {
-                            format!("{}: {}", i, item)
+                            format!("{i}: {item}")
                         } else if *i == 3 {
                             "3: copy of CC".to_string()
                         } else if *i == 7 {
@@ -1069,7 +1069,7 @@ impl Engine {
             self.cc
                 .stack
                 .iter()
-                .map(|item| if !short { format!("{}", item) } else { item.dump_as_fift() })
+                .map(|item| if !short { format!("{item}") } else { item.dump_as_fift() })
                 .collect::<Vec<_>>()
                 .join("\n"),
         )
@@ -1194,7 +1194,7 @@ impl Engine {
         if self.debug_on > 0 {
             let buffer = std::mem::take(&mut self.debug_buffer);
             if self.trace_callback.is_none() {
-                log::info!(target: "tvm", "{}", buffer);
+                log::info!(target: "tvm", "{buffer}");
             } else {
                 self.trace_info(EngineTraceInfoType::Dump, 0, Some(buffer));
             }
@@ -1580,7 +1580,7 @@ impl Engine {
             self.cmd.vars[n].as_continuation_mut()?.nargs = 1;
             switch(self, var!(n))?;
         } else {
-            let log_string = Some(format!("UNHANDLED EXCEPTION: {}", err));
+            let log_string = Some(format!("UNHANDLED EXCEPTION: {err}"));
             self.trace_info(EngineTraceInfoType::Exception, self.gas_used(), log_string);
             return Err(err);
         }

--- a/tvm_vm/src/executor/engine/handlers.rs
+++ b/tvm_vm/src/executor/engine/handlers.rs
@@ -73,7 +73,7 @@ fn execute_setcpx(engine: &mut Engine) -> Status {
 
 fn execute_unknown(engine: &mut Engine) -> Status {
     let code = engine.last_cmd();
-    log::trace!(target: "tvm", "Invalid code: {} ({:#X})\n", code, code);
+    log::trace!(target: "tvm", "Invalid code: {code} ({code:#X})\n");
     err!(ExceptionCode::InvalidOpcode)
 }
 
@@ -994,14 +994,14 @@ impl Handlers {
                     self.directs[code as usize] = Some(Handler::Subset(self.subsets.len()));
                     self.subsets.push(std::mem::replace(subset, Handlers::new()))
                 } else {
-                    panic!("Slot for subset {:02x} is already occupied", code)
+                    panic!("Slot for subset {code:02x} is already occupied")
                 }
             }
             None => {
                 self.directs[code as usize] = Some(Handler::Subset(self.subsets.len()));
                 self.subsets.push(std::mem::replace(subset, Handlers::new()))
             }
-            _ => panic!("Subset {:02x} is already registered", code),
+            _ => panic!("Subset {code:02x} is already registered"),
         }
         self
     }
@@ -1013,10 +1013,10 @@ impl Handlers {
                 if x as usize == execute_unknown as usize {
                     self.directs[code as usize] = Some(Handler::Direct(handler))
                 } else {
-                    panic!("Code {:02x} is already registered", code)
+                    panic!("Code {code:02x} is already registered")
                 }
             }
-            _ => panic!("Slot for code {:02x} is already occupied", code),
+            _ => panic!("Slot for code {code:02x} is already occupied"),
         }
     }
 
@@ -1040,8 +1040,8 @@ fn print_handlers(handlers: &Handlers, f: &mut fmt::Formatter, indent: String) -
                 writeln!(f, "{}{:02x}: 0x{:x}", indent, h, func as *const u8 as usize)?
             }
             Some(Handler::Subset(i)) => {
-                writeln!(f, "{}{:02x}: subset", indent, h)?;
-                print_handlers(&handlers.subsets[i], f, format!("  {}", indent))?;
+                writeln!(f, "{indent}{h:02x}: subset")?;
+                print_handlers(&handlers.subsets[i], f, format!("  {indent}"))?;
             }
             None => {}
         }

--- a/tvm_vm/src/executor/token.rs
+++ b/tvm_vm/src/executor/token.rs
@@ -193,7 +193,7 @@ pub(super) fn execute_run_wasm_concat_multiarg(engine: &mut Engine) -> Status {
                     err!(ExceptionCode::WasmLoadFail, "Failed to unpack wasm instruction {:?}", e)?
                 }
             };
-        log::debug!("Using WASM Hash {:?}", wasm_hash);
+        log::debug!("Using WASM Hash {wasm_hash:?}");
         engine.get_wasm_binary_by_hash(wasm_hash)?
         // todo!("Add hash lookup here from hash {:?}", wasm_hash);
     } else {
@@ -216,12 +216,12 @@ pub(super) fn execute_run_wasm_concat_multiarg(engine: &mut Engine) -> Status {
 
     let mut exports = component_type.exports(&wasm_engine);
     let arg = exports.next();
-    log::debug!("List of exports from WASM: {:?}", arg);
+    log::debug!("List of exports from WASM: {arg:?}");
     if let Some(arg) = arg {
-        log::debug!("{:?}", arg);
+        log::debug!("{arg:?}");
 
         for arg in exports {
-            log::debug!(" {:?}", arg);
+            log::debug!(" {arg:?}");
         }
     }
 
@@ -269,7 +269,7 @@ pub(super) fn execute_run_wasm_concat_multiarg(engine: &mut Engine) -> Status {
         log::debug!("{:?}", export.0);
     }
     let instance_index = wasm_instance.get_export_index(&mut wasm_store, None, &wasm_instance_name);
-    log::debug!("Instance Index {:?}", instance_index);
+    log::debug!("Instance Index {instance_index:?}");
     let func_index = match wasm_instance.get_export_index(
         &mut wasm_store,
         instance_index.as_ref(),
@@ -280,10 +280,10 @@ pub(super) fn execute_run_wasm_concat_multiarg(engine: &mut Engine) -> Status {
             err!(ExceptionCode::WasmLoadFail, "Failed to find WASM exported function or component",)?
         }
     };
-    log::debug!("Func Index {:?}", func_index);
+    log::debug!("Func Index {func_index:?}");
     let wasm_function = wasm_instance
         .get_func(&mut wasm_store, func_index)
-        .expect(&format!("`{}` was not an exported function", wasm_func_name));
+        .expect(&format!("`{wasm_func_name}` was not an exported function"));
     let wasm_function = match wasm_function.typed::<(Vec<u8>,), (Vec<u8>,)>(&wasm_store) {
         Ok(answer) => answer,
         Err(e) => err!(ExceptionCode::WasmLoadFail, "Failed to get WASM answer function {:?}", e)?,
@@ -320,15 +320,15 @@ pub(super) fn execute_run_wasm_concat_multiarg(engine: &mut Engine) -> Status {
             e => err!(ExceptionCode::WasmLoadFail, "Failed to unpack wasm instruction {:?}", e)?,
         };
     wasm_func_args.append(&mut wasm_args_tail);
-    log::debug!("WASM Args loaded {:?}", wasm_func_args);
+    log::debug!("WASM Args loaded {wasm_func_args:?}");
     let result = match wasm_function.call(&mut wasm_store, (wasm_func_args,)) {
         Ok(result) => result,
         Err(e) => {
-            log::debug!("Failed to execute WASM function {:?}", e);
+            log::debug!("Failed to execute WASM function {e:?}");
             err!(ExceptionCode::WasmExecFail, "Failed to execute WASM function {:?}", e)?
         }
     };
-    log::debug!("WASM Execution result: {:?}", result);
+    log::debug!("WASM Execution result: {result:?}");
 
     let gas_used: i64 = RUNWASM_GAS_PRICE.try_into()?;
     // TODO: If we switch to dynamic gas usage, reenable this code
@@ -348,7 +348,7 @@ pub(super) fn execute_run_wasm_concat_multiarg(engine: &mut Engine) -> Status {
     }
 
     // return result
-    log::debug!("EXEC Wasm execution result: {:?}", result);
+    log::debug!("EXEC Wasm execution result: {result:?}");
     let res_vec = result.0;
 
     let cell = TokenValue::write_bytes(res_vec.as_slice(), &ABI_VERSION_2_4)?.into_cell()?;
@@ -420,7 +420,7 @@ pub(super) fn execute_run_wasm(engine: &mut Engine) -> Status {
                     err!(ExceptionCode::WasmLoadFail, "Failed to unpack wasm instruction {:?}", e)?
                 }
             };
-        log::debug!("Using WASM Hash {:?}", wasm_hash);
+        log::debug!("Using WASM Hash {wasm_hash:?}");
         engine.get_wasm_binary_by_hash(wasm_hash)?
         // todo!("Add hash lookup here from hash {:?}", wasm_hash);
     } else {
@@ -443,12 +443,12 @@ pub(super) fn execute_run_wasm(engine: &mut Engine) -> Status {
 
     let mut exports = component_type.exports(&wasm_engine);
     let arg = exports.next();
-    log::debug!("List of exports from WASM: {:?}", arg);
+    log::debug!("List of exports from WASM: {arg:?}");
     if let Some(arg) = arg {
-        log::debug!("{:?}", arg);
+        log::debug!("{arg:?}");
 
         for arg in exports {
-            log::debug!(" {:?}", arg);
+            log::debug!(" {arg:?}");
         }
     }
 
@@ -496,7 +496,7 @@ pub(super) fn execute_run_wasm(engine: &mut Engine) -> Status {
         log::debug!("{:?}", export.0);
     }
     let instance_index = wasm_instance.get_export_index(&mut wasm_store, None, &wasm_instance_name);
-    log::debug!("Instance Index {:?}", instance_index);
+    log::debug!("Instance Index {instance_index:?}");
     let func_index = match wasm_instance.get_export_index(
         &mut wasm_store,
         instance_index.as_ref(),
@@ -507,10 +507,10 @@ pub(super) fn execute_run_wasm(engine: &mut Engine) -> Status {
             err!(ExceptionCode::WasmLoadFail, "Failed to find WASM exported function or component",)?
         }
     };
-    log::debug!("Func Index {:?}", func_index);
+    log::debug!("Func Index {func_index:?}");
     let wasm_function = wasm_instance
         .get_func(&mut wasm_store, func_index)
-        .expect(&format!("`{}` was not an exported function", wasm_func_name));
+        .expect(&format!("`{wasm_func_name}` was not an exported function"));
     let wasm_function = match wasm_function.typed::<(Vec<u8>,), (Vec<u8>,)>(&wasm_store) {
         Ok(answer) => answer,
         Err(e) => err!(ExceptionCode::WasmLoadFail, "Failed to get WASM answer function {:?}", e)?,
@@ -526,15 +526,15 @@ pub(super) fn execute_run_wasm(engine: &mut Engine) -> Status {
             TokenValue::Bytes(items) => items,
             _ => err!(ExceptionCode::WasmLoadFail, "Failed to unpack wasm instruction")?,
         };
-    log::debug!("WASM Args loaded {:?}", wasm_func_args);
+    log::debug!("WASM Args loaded {wasm_func_args:?}");
     let result = match wasm_function.call(&mut wasm_store, (wasm_func_args,)) {
         Ok(result) => result,
         Err(e) => {
-            log::debug!("Failed to execute WASM function {:?}", e);
+            log::debug!("Failed to execute WASM function {e:?}");
             err!(ExceptionCode::WasmExecFail, "Failed to execute WASM function {:?}", e)?
         }
     };
-    log::debug!("WASM Execution result: {:?}", result);
+    log::debug!("WASM Execution result: {result:?}");
 
     let gas_used: i64 = RUNWASM_GAS_PRICE.try_into()?;
     // TODO: If we switch to dynamic gas usage, reenable this code
@@ -554,7 +554,7 @@ pub(super) fn execute_run_wasm(engine: &mut Engine) -> Status {
     }
 
     // return result
-    log::debug!("EXEC Wasm execution result: {:?}", result);
+    log::debug!("EXEC Wasm execution result: {result:?}");
     let res_vec = result.0;
 
     let cell = TokenValue::write_bytes(res_vec.as_slice(), &ABI_VERSION_2_4)?.into_cell()?;

--- a/tvm_vm/src/executor/zk_stuff/curve_utils.rs
+++ b/tvm_vm/src/executor/zk_stuff/curve_utils.rs
@@ -150,11 +150,11 @@ pub(crate) fn g1_affine_from_str_projective(s: &CircomG1) -> Result<G1Affine, Zk
         return Err(ZkCryptoError::InvalidInput);
     }
 
-    println!("a s CircomG1: {:?}", s);
+    println!("a s CircomG1: {s:?}");
 
     let zz =
         G1Projective::new_unchecked((&s[0]).into(), (&s[1]).into(), (&s[2]).into()).into_affine();
-    println!("a zz CircomG1: {:?}", zz);
+    println!("a zz CircomG1: {zz:?}");
 
     let g1: G1Affine =
         G1Projective::new_unchecked((&s[0]).into(), (&s[1]).into(), (&s[2]).into()).into();

--- a/tvm_vm/src/executor/zk_stuff/zk_login.rs
+++ b/tvm_vm/src/executor/zk_stuff/zk_login.rs
@@ -142,7 +142,7 @@ impl ToString for OIDCProvider {
             Self::KarrierOne => "KarrierOne".to_string(),
             Self::Credenza3 => "Credenza3".to_string(),
             Self::AwsTenant((region, tenant_id)) => {
-                format!("AwsTenant-region:{}-tenant_id:{}", region, tenant_id)
+                format!("AwsTenant-region:{region}-tenant_id:{tenant_id}")
             }
         }
     }
@@ -180,10 +180,9 @@ impl OIDCProvider {
                 "https://login.microsoftonline.com/common/discovery/v2.0/keys",
             ),
             OIDCProvider::AwsTenant((region, tenant_id)) => ProviderConfig::new(
-                &format!("https://cognito-idp.{}.amazonaws.com/{}", region, tenant_id),
+                &format!("https://cognito-idp.{region}.amazonaws.com/{tenant_id}"),
                 &format!(
-                    "https://cognito-idp.{}.amazonaws.com/{}/.well-known/jwks.json",
-                    region, tenant_id
+                    "https://cognito-idp.{region}.amazonaws.com/{tenant_id}/.well-known/jwks.json"
                 ),
             ),
             OIDCProvider::KarrierOne => ProviderConfig::new(

--- a/tvm_vm/src/stack/continuation.rs
+++ b/tvm_vm/src/stack/continuation.rs
@@ -540,7 +540,7 @@ impl fmt::Display for ContinuationData {
         } else {
             writeln!(f)?;
             for x in self.stack.storage.iter() {
-                write!(f, "        {}", x)?;
+                write!(f, "        {x}")?;
                 writeln!(f)?;
             }
         }
@@ -551,7 +551,7 @@ impl fmt::Display for ContinuationData {
             writeln!(f)?;
             for i in SaveList::REGS {
                 if let Some(item) = self.savelist.get(i) {
-                    writeln!(f, "        {}: {}", i, item)?
+                    writeln!(f, "        {i}: {item}")?
                 }
             }
         }
@@ -573,6 +573,6 @@ impl fmt::Display for ContinuationType {
             ContinuationType::WhileLoopCondition(_, _) => "while",
             ContinuationType::ExcQuit => "exception-quit",
         };
-        write!(f, "{}", name)
+        write!(f, "{name}")
     }
 }

--- a/tvm_vm/src/stack/integer/tests/test_formatting.rs
+++ b/tvm_vm/src/stack/integer/tests/test_formatting.rs
@@ -19,8 +19,8 @@ fn test_formatting() {
     assert_eq!("abcde12", value.to_str_radix(16));
     assert_eq!("1010101111001101111000010010", value.to_str_radix(2));
 
-    assert_eq!(value.to_str(), format!("{}", value));
-    assert_eq!(value.to_str_radix(16), format!("{:x}", value));
-    assert_eq!(value.to_str_radix(16).to_uppercase(), format!("{:X}", value));
-    assert_eq!(value.to_str_radix(2), format!("{:b}", value));
+    assert_eq!(value.to_str(), format!("{value}"));
+    assert_eq!(value.to_str_radix(16), format!("{value:x}"));
+    assert_eq!(value.to_str_radix(16).to_uppercase(), format!("{value:X}"));
+    assert_eq!(value.to_str_radix(2), format!("{value:b}"));
 }

--- a/tvm_vm/src/stack/mod.rs
+++ b/tvm_vm/src/stack/mod.rs
@@ -1169,9 +1169,7 @@ impl PartialEq for Stack {
 
 impl fmt::Display for Stack {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(
-            &self.storage.iter().fold(String::new(), |acc, item| format!("{acc}{item}\n")),
-        )
+        f.write_str(&self.storage.iter().fold(String::new(), |acc, item| format!("{acc}{item}\n")))
     }
 }
 

--- a/tvm_vm/src/stack/mod.rs
+++ b/tvm_vm/src/stack/mod.rs
@@ -227,10 +227,10 @@ pub(crate) fn items_serialize(
                         let key = SliceData::load_bitstring(builder)?;
                         savelist.set_builder(key, &value)?; // TODO: gas here?
                     } else {
-                        panic!("savelist is None {}", index)
+                        panic!("savelist is None {index}")
                     }
                 } else {
-                    panic!("list is None {}", index)
+                    panic!("list is None {index}")
                 }
                 continue;
             }
@@ -886,13 +886,13 @@ impl fmt::Display for StackItem {
             StackItem::Cell(x)         => write!(f, "Cell x{:x} x{:x}", x.repr_hash(), x),
             StackItem::Continuation(x) => write!(f, "Continuation x{:x}", x.code().repr_hash()),
             StackItem::Integer(x)      => write!(f, "{}", Arc::as_ref(x)),
-            StackItem::Slice(x)        => write!(f, "Slice x{:x}", x),
+            StackItem::Slice(x)        => write!(f, "Slice x{x:x}"),
             StackItem::Tuple(x)        => {
                 if f.alternate() {
                     write!(f, "Tuple ({})", x.len())
                 } else {
                     write!(f, "Tuple ({})", x.len())?;
-                    f.debug_list().entries(x.iter().map(|v| format!("{:#}", v))).finish()
+                    f.debug_list().entries(x.iter().map(|v| format!("{v:#}"))).finish()
                 }
             }
         }
@@ -1170,7 +1170,7 @@ impl PartialEq for Stack {
 impl fmt::Display for Stack {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(
-            &self.storage.iter().fold(String::new(), |acc, item| format!("{}{}\n", acc, item)),
+            &self.storage.iter().fold(String::new(), |acc, item| format!("{acc}{item}\n")),
         )
     }
 }

--- a/tvm_vm/src/stack/savelist.rs
+++ b/tvm_vm/src/stack/savelist.rs
@@ -161,7 +161,7 @@ impl fmt::Display for SaveList {
         writeln!(f, "--- Control registers ------------------")?;
         for i in 0..Self::NUMREGS {
             if let Some(item) = &self.storage[i] {
-                writeln!(f, "{}: {}", i, item)?
+                writeln!(f, "{i}: {item}")?
             }
         }
         writeln!(f, "{:-<40}", "")

--- a/tvm_vm/src/tests/test_dump.rs
+++ b/tvm_vm/src/tests/test_dump.rs
@@ -66,11 +66,11 @@ fn test_dump_commands() {
         None,
         vec![],
     );
-    log::trace!("--- {} as str\n", int);
+    log::trace!("--- {int} as str\n");
     execute_dump_str(engine).unwrap();
-    log::trace!("--- {} as hex\n", int);
+    log::trace!("--- {int} as hex\n");
     execute_dump_hex(engine).unwrap();
-    log::trace!("--- {} as bin\n", int);
+    log::trace!("--- {int} as bin\n");
     execute_dump_bin(engine).unwrap();
     log::trace!("--- stack\n");
     execute_dump_stack(engine).unwrap();

--- a/tvm_vm/src/tests/test_error.rs
+++ b/tvm_vm/src/tests/test_error.rs
@@ -31,9 +31,9 @@ fn test_tvm_exception_code() {
 #[test]
 fn test_update_error() {
     let err = exception!(ExceptionCode::RangeCheckError, "description {}", 42);
-    println!("{:?}", err);
-    let err = update_error_description(err, |d| format!("additional: {}", d));
-    println!("{:?}", err);
+    println!("{err:?}");
+    let err = update_error_description(err, |d| format!("additional: {d}"));
+    println!("{err:?}");
     assert_eq!(tvm_exception_code(&err).unwrap(), ExceptionCode::RangeCheckError);
 
     let Ok(TvmError::TvmExceptionFull(_, ref description)) = err.downcast::<TvmError>() else {
@@ -52,9 +52,9 @@ fn test_update_error() {
 
     let err =
         || -> Result<()> { custom_err!(112, "text with format {} - {}", 123, 456) }().unwrap_err();
-    println!("{:?}", err);
-    let err = update_error_description(err, |d| format!("additional: {}", d));
-    println!("{:?}", err);
+    println!("{err:?}");
+    let err = update_error_description(err, |d| format!("additional: {d}"));
+    println!("{err:?}");
     assert_eq!(tvm_exception_code(&err), None);
     assert_eq!(tvm_exception_or_custom_code(&err), 112);
 }

--- a/tvm_vm/src/tests/test_executor.rs
+++ b/tvm_vm/src/tests/test_executor.rs
@@ -207,7 +207,7 @@ where
         Engine::with_capabilities(0).setup_with_libraries(code, None, Some(stack), None, vec![]);
 
     match engine.execute() {
-        Err(e) => panic!("Execute error: {}", e),
+        Err(e) => panic!("Execute error: {e}"),
         Ok(_) => {
             if mode.premultiply() {
                 value *= multiplier
@@ -265,7 +265,7 @@ fn test_slice(offset: usize, r: usize, x: usize) -> Status {
     builder.append_bits(0x34, 8)?; // remainder in code slice
 
     let mut code = SliceData::load_builder(builder).unwrap();
-    println!("offset: {}, r: {}, x: {}, code: {}", offset, r, x, code);
+    println!("offset: {offset}, r: {r}, x: {x}, code: {code}");
     let mut engine =
         Engine::with_capabilities(0).setup_with_libraries(code.clone(), None, None, None, vec![]);
     engine
@@ -496,7 +496,7 @@ fn test_run_wasm_basic_add() {
     engine.cc.stack.push(StackItem::cell(cell.clone()));
 
     let status = execute_run_wasm(&mut engine).unwrap();
-    println!("Wasm Return Status: {:?}", status);
+    println!("Wasm Return Status: {status:?}");
 
     assert!(
         rejoin_chain_of_cells(engine.cc.stack.get(0).as_cell().unwrap()).unwrap().pop().unwrap()
@@ -571,7 +571,7 @@ fn test_run_wasm_from_hash() {
     engine.cc.stack.push(StackItem::cell(cell.clone()));
 
     let status = execute_run_wasm(&mut engine).unwrap();
-    println!("Wasm Return Status: {:?}", status);
+    println!("Wasm Return Status: {status:?}");
 
     assert!(
         rejoin_chain_of_cells(engine.cc.stack.get(0).as_cell().unwrap()).unwrap().pop().unwrap()
@@ -652,7 +652,7 @@ fn test_tls_wasm_from_hash() {
     engine.cc.stack.push(StackItem::cell(cell.clone()));
 
     let status = execute_run_wasm_concat_multiarg(&mut engine).unwrap();
-    println!("Wasm Return Status: {:?}", status);
+    println!("Wasm Return Status: {status:?}");
 
     assert!(
         rejoin_chain_of_cells(engine.cc.stack.get(0).as_cell().unwrap()).unwrap().pop().unwrap()
@@ -724,7 +724,7 @@ fn test_run_wasm_fuel_error() {
     engine.cc.stack.push(StackItem::cell(cell.clone()));
     let result = execute_run_wasm(&mut engine);
 
-    println!("Wasm Return Status: {:?}", result);
+    println!("Wasm Return Status: {result:?}");
 
     let _res_error = result.expect_err("Test didn't error on fuel use");
 }
@@ -1198,7 +1198,7 @@ fn test_tls_wasm_from_hash_for_4_args() {
     engine.cc.stack.push(StackItem::cell(cell.clone()));
 
     let status = execute_run_wasm_concat_multiarg(&mut engine).unwrap();
-    println!("Wasm Return Status: {:?}", status);
+    println!("Wasm Return Status: {status:?}");
 
     let res = engine.cc.stack.get(0).as_cell().unwrap(); //engine.cc.stack.get(0).as_slice().unwrap().clone();
     let slice = SliceData::load_cell(res.clone()).unwrap();

--- a/tvm_vm/src/tests/test_smart_contract_info.rs
+++ b/tvm_vm/src/tests/test_smart_contract_info.rs
@@ -28,7 +28,7 @@ fn check_additional_fields(capabilities: u64, count: usize) {
         .as_tuple()
         .expect("SMCI list must be a tuple")
         .len();
-    assert_eq!(result, count, "wrong total count for capabilities {:X}", capabilities);
+    assert_eq!(result, count, "wrong total count for capabilities {capabilities:X}");
 }
 
 #[test]

--- a/tvm_vm/src/types.rs
+++ b/tvm_vm/src/types.rs
@@ -53,7 +53,7 @@ impl ExceptionType {
     fn exception_message(&self) -> String {
         match self {
             ExceptionType::System(code) => format!("{}, code {}", code, *code as u8),
-            ExceptionType::Custom(code) => format!("code {}", code),
+            ExceptionType::Custom(code) => format!("code {code}"),
         }
     }
 }


### PR DESCRIPTION
An attempt to automatically check and fix new clippy rules after Rust 1.88 release.
The main idea is to just use auto `clippy --fix` which supposed to not break the code at all.

e.g.

`cargo clippy --fix --allow-dirty --allow-staged -- -A clippy::all -W clippy::uninlined_format_args`