### PR TITLE
Fix version handling in build_download_pattern function

### DIFF
--- a/install_tvm_binaries.sh
+++ b/install_tvm_binaries.sh
@@ -85,6 +85,10 @@ build_download_pattern() {
     local arch="$3"
     local binary_name="$4"
 
+    if [[ "$version" =~ -[0-9]+$ ]]; then
+        version="${version%-*}"
+    fi
+
     if [ "$os" = "linux" ]; then
         echo "${binary_name}-${version}-linux-musl-${arch}.tar.gz"
     else


### PR DESCRIPTION
Improve version parsing in the `build_download_pattern` function to correctly handle version strings with trailing numeric suffixes.