### PR TITLE
ZKHALO2VERIFYWITHVK opcode (real impl, 0xC7 0x4A)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6206,10 +6206,6 @@ name = "tvm_assembler"
 version = "2.24.20"
 dependencies = [
  "anyhow",
- "ark-ff",
- "ark-std",
- "base64 0.13.1",
- "base64ct",
  "clap 4.6.0",
  "ed25519-dalek",
  "hex",
@@ -6541,7 +6537,7 @@ dependencies = [
  "ark-relations",
  "ark-serialize",
  "ark-snark",
- "ark-std 0.4.0",
+ "ark-std",
  "base64",
  "base64ct",
  "bls12_381",

--- a/docs/zkhalo2verifywithvk_design.md
+++ b/docs/zkhalo2verifywithvk_design.md
@@ -1,0 +1,177 @@
+# `ZKHALO2VERIFYWITHVK` — Design Note + Frozen Wire-Format Contract
+
+**Status**: design **CLOSED**, implementation **LANDED** in this PR.
+**Authors**: bridge integration team @ Pruvendo.
+**Timeline**: design opened 2026-05-17, frozen 2026-05-22, real
+implementation landed 2026-05-22.
+**Parent branch**: [`serhii/node-3406-vergrth16-with-vk`](https://github.com/tvmlabs/tvm-sdk/tree/serhii/node-3406-vergrth16-with-vk) — Serhii's `ZKHALO2VERIFY` (hard-coded DarkDex W=8 VK) + `VERGRTH16WITHVK`.
+**Companion**: bridge-side memo `docs/zk_halo2_an_side_design.md` in [`Pruvendo/acki-nacki-bridge`](https://github.com/Pruvendo/acki-nacki-bridge).
+
+## TL;DR
+
+`ZKHALO2VERIFY` (0xC7 0x49) hard-codes the verifying key to the DarkDex
+W=8 circuit. The Acki Nacki ↔ Ethereum bridge needs to verify a
+**different** Halo2 SHPLONK proof — produced by the
+`bridge-prover-orchestrator` Halo2 Circuit 1B (Fallback BLS attestation),
+with a different K, different `BaseCircuitParams`, and different VK.
+Generalising in place would mean a per-circuit `match` in the VM, which
+doesn't scale across the bridge / NFT / app-circuit roadmap.
+
+We add the same pivot that `VERGRTH16WITHVK` made for the Groth16 side:
+a sibling opcode whose **single stack operand carries the verifying key
+(and config, and instances, and proof) bundled together in a
+self-describing byte payload**. That payload is the `Halo2TvmBundle`
+format, locked in §4 below.
+
+| | `ZKHALO2VERIFY` (0xC7 0x49) | `ZKHALO2VERIFYWITHVK` (0xC7 0x4A) |
+| --- | --- | --- |
+| Stack | 2 cells: `[pub_inputs, proof]` | 1 cell: `[bundle]` |
+| VK | Hard-coded DarkDex W=8 | Caller-supplied (from bundle) |
+| Public inputs | Dual-path: u64 shortcut + LE Fr | Strict 32-byte LE Fr only |
+| Gas | Lower (no per-call VK deserialisation) | Higher (~5000 placeholder, re-bench pending) |
+| Cache | Single static `OnceLock<(VK, Params)>` | Bounded-FIFO map keyed by `vk_bytes` (capacity = 8) |
+
+Keeping both opcodes means system circuits (DarkDex / zkLogin variants)
+don't pay the WithVK gas premium, and app circuits (bridge / NFT / per-
+contract VKs) don't need a per-circuit fork of the VM.
+
+## Decisions — frozen 2026-05-22
+
+Closed via Serhii's "Принимай решения на свой вкус, Сергей готов
+принять любое наше решение" directive. Canonical reference is
+`acki-nacki-bridge/docs/zk_halo2_an_side_design.md` §4. **Any future
+change requires bumping `BUNDLE_VERSION` in both producer
+(`bridge-prover-orchestrator`) and consumer (`tvm_vm`) and a paired
+Decision Log entry in both repos.**
+
+| ID | Decision |
+| -- | -------- |
+| Q-WIRE-1 (transcript) | **Blake2b SHPLONK**. `transcript_kind` byte in the bundle is `0x00 = Blake2b`. Values ≥ `0x01` reserved for a future Keccak variant under a bumped `BUNDLE_VERSION`. |
+| Q-WIRE-2 (KZG SRS) | **Verifier-only `ParamsKZG<Bn256>`** built at runtime from 3 globally-embedded points (`g[0]`, `g2`, `s_g2`), parameterised by `k = vk.cs.degree`. NOT carried in the bundle and NOT loaded from disk — SHPLONK verification only needs these three points, so the 64-MB-per-`k` SRS file is unnecessary. Implementation: `zk_halo2_with_vk::build_shared_kzg_params(k)`, reusing the `KZG_*_BYTES` constants from `zk_halo2_utils.rs` (same constants `ZKHALO2VERIFY` uses for DarkDex W=8 at `k=19`). |
+| Q-WIRE-3 (pub inputs) | **Strict 32-byte little-endian `Fr::to_repr()`**. `Fr::from_repr` rejects ≥ modulus inputs structurally (`FatalError`). No u64 shortcut on this opcode (legacy `ZKHALO2VERIFY` keeps its shortcut for DarkDex backward compat). |
+| Q-WIRE-4 (VK envelope) | **Self-describing `Halo2TvmBundle`** (see §4 byte layout). Magic `b"HALO2TVM"` (8 bytes ASCII), `BUNDLE_VERSION = 0x01`, `transcript_kind = 0x00` (Blake2b), 6 reserved bytes, then LE-u32-length-prefixed `(config_json, vk_bytes, instances_bytes, proof_bytes)` in that order. |
+| Q-WIRE-5 (fork pinning) | **Inherits Serhii's branch pin** of `gosh-sh/halo2-lib-zkevm-sha256-and-bls12-381` and `gosh-sh/gosh-zk-snark-halo2-utils`. Both deps are already in `tvm_vm/Cargo.toml` under `[dependencies]` with branch pins; promotion to commit-SHA + a format-stability CI gate is a follow-up. |
+| Q-NAME-1 (opcode name) | **`ZKHALO2VERIFYWITHVK` at `0xC7 0x4A`**. Adjacent to Serhii's `ZKHALO2VERIFY` (0xC7 0x49) and below `POSEIDON` (0x50) / `CHKHISTPROOF` (0x51) / `VERGRTH16WITHVK` (0x52). Compiler builtin name pending: `gosh.zkHalo2VerifyWithVK(bundle_cell)`. |
+
+Empirical sizes (real Circuit 1B fallback fixture, k=20, 10 signers):
+bundle ≈ 21.2 KB (VK 6.1 KB + proof 14.8 KB + 4 × 32 B instances +
+config_json ~120 B + 16 B header + 4 × 4 B length prefixes).
+Round-trip-tested in
+`acki-nacki-bridge/crates/bridge-prover-orchestrator/tests/halo2_tvm_bundle_round_trip.rs`.
+DarkDex W=8 L0 fixture (k=19, used by this PR's unit tests) yields a
+~9 KB bundle.
+
+## 4. Wire format — `Halo2TvmBundle`
+
+Frozen by the Decisions table above. Producer reference implementation:
+`acki-nacki-bridge/crates/bridge-prover-orchestrator/src/halo2_tvm_bundle.rs`.
+Consumer reference implementation:
+`tvm_vm/src/executor/zk_halo2_with_vk_bundle.rs`.
+
+```text
+  off  size  field
+  ───  ────  ─────────────────────────────────────────────────────────
+    0     8  magic           = b"HALO2TVM" (ASCII, no NUL)
+    8     1  version         = 0x01 (BUNDLE_VERSION)
+    9     1  transcript_kind = 0x00 (Blake2b)
+   10     6  reserved        = 0 × 6
+   16     4  config_len      (u32 LE)
+   20  cl    config_json     (UTF-8 serde_json of `BaseCircuitParams`)
+  ...     4  vk_len          (u32 LE)
+  ...  vl    vk_bytes        (`VerifyingKey::write(SerdeFormat::RawBytes)`)
+  ...     4  instances_len   (u32 LE; must be a multiple of 32)
+  ...  il    instances_bytes (N × 32-byte LE `Fr::to_repr()`, strict)
+  ...     4  proof_len       (u32 LE)
+  ...  pl    proof_bytes     (SHPLONK proof with Blake2b transcript)
+```
+
+All length prefixes are `u32` LE. Producer-side cap: 16 MiB
+(`zk_halo2_with_vk_bundle::MAX_BUNDLE_BYTES`); the consumer fails
+structurally above that cap as a DoS guard.
+
+### Safety of VK deserialisation
+
+The consumer deserialises the VK using
+`SerdeFormat::RawBytes` (NOT `RawBytesUnchecked`). `RawBytes` runs the
+curve-membership check on every group element on read, which is
+soundness-critical for caller-supplied VKs.
+`gosh-zk-snark-halo2-utils::io::read_vk` uses `RawBytesUnchecked` and is
+**deliberately not used** by this opcode — `RawBytesUnchecked` is only
+safe for compile-time-pinned VKs (like Serhii's `DARK_DEX_W8_VK_BYTES`),
+not for runtime-supplied ones.
+
+### Per-VK cache
+
+Bounded FIFO `HashMap<Vec<u8>, Arc<CachedVk>>` keyed by the bundle's
+`vk_bytes`, capacity 8 (`VK_CACHE_CAPACITY`). Cold-cache verification
+costs ~3 s on `k=20` because `EvaluationDomain::new` precomputes 2^20
+FFT twiddle factors; warm-cache cost is dominated by the actual
+SHPLONK pairing check (~50 ms on a 2024-era laptop). Operators are
+expected to pre-warm cached VKs at node startup (mirroring
+`warmup_halo2()` for the DarkDex W=8 VK in `zk_halo2.rs`).
+
+## 5. Implementation layout
+
+| File | Role |
+| ---- | ---- |
+| `tvm_vm/src/executor/zk_halo2_with_vk.rs` | Handler entry point + per-VK cache + shared KZG-params builder + `decode_instances_strict` + the actual `Proof::verify_with_vk` call. |
+| `tvm_vm/src/executor/zk_halo2_with_vk_bundle.rs` | Pure wire-format decoder. No crypto; just byte-level validation of magic / version / transcript / chunk lengths / trailing-garbage / instances-multiple-of-32 / oversized bundle. 8 unit tests covering all rejection paths. |
+| `tvm_vm/src/executor/zk_halo2_utils.rs` | Existing module. `KZG_G0_BYTES` / `KZG_G2_BYTES` / `KZG_S_G2_BYTES` promoted to `pub(crate)` so the new opcode can reuse them. |
+| `tvm_vm/src/tests/test_halo2_with_vk.rs` | Real round-trip test. Builds a `Halo2TvmBundle` from the checked-in DarkDex W=8 L0 fixture, pushes it through `execute_zkhalo2_verify_with_vk`, asserts `true`. Negative cases: flipped proof byte (false), tweaked instance Fr (false), bad bundle magic (FatalError). |
+| `tvm_assembler/src/simple.rs` | Mnemonic `ZKHALO2VERIFYWITHVK` → `0xC7 0x4A`. |
+| `tvm_assembler/src/lib.rs` | `gosh_zk_opcode_tests::zk_opcode_bytes_round_trip` table-driven assembler dispatch test. |
+| `tvm_vm/src/executor/engine/handlers.rs` | `c7_handlers.set(0x4A, execute_zkhalo2_verify_with_vk)` under `#[cfg(feature = "gosh")]`. |
+| `tvm_vm/src/executor/gas/gas_state.rs` | `Gas::zkhalo2_verify_with_vk_price()` getter + placeholder `ZKHALO2_VERIFY_WITH_VK_GAS_PRICE = 5_000`. |
+
+## 6. Drive-by fixes applied on this branch
+
+The parent branch (`serhii/node-3406-vergrth16-with-vk`) does not compile
+with `--features gosh` as it stands. Two pre-existing breaks were fixed
+inline so this PR's CI can pass:
+
+1. **Stray identifier in `gas_state.rs`** — `consume_chkhistproof`
+   contained a bare `full_dex_test_with_final_halo2_circuit` token
+   (looks like a branch-name accidentally pasted into source during a
+   merge). Removed.
+2. **Missing `execute_poseidon` in `zk.rs`** — the dispatch table
+   references `execute_poseidon` at `0xC7 0x50` but the function was
+   dropped during the merge from `full_dex_test_with_final_halo2_circuit`.
+   Restored from `origin/main` verbatim.
+3. **Missing `IntegerData::from_unsigned_bytes_le`** — same merge dropped
+   this method. Restored from `origin/main` verbatim. Needed by
+   `execute_poseidon`.
+
+These are intentionally **separate, narrow** fixes and easy to drop into
+Serhii's branch before merge if preferred. They are listed at the top of
+the PR's commits.
+
+## 7. Re-benchmark TODO before mainnet
+
+`ZKHALO2_VERIFY_WITH_VK_GAS_PRICE = 5_000` is a placeholder modelled on
+`VERGRTH16_WITH_VK_GAS_PRICE`. The numbers we want to nail down with a
+proper benchmark:
+
+- **Warm-cache verify** — VK already in the LRU, just bundle parse + 
+  `verify_proof`. Expected: ~50 ms wall-clock at `k=20` → ~few thousand
+  gas at typical AN gas-to-CPU ratio.
+- **Cold-cache verify** — VK newly inserted, plus
+  `EvaluationDomain::new(k)` (the slow step). Expected: ~3 s at `k=20`.
+  Cold path is **NOT** charged extra in the current placeholder because
+  operators are expected to pre-warm; if pre-warming proves
+  operationally fragile we'll add a gas multiplier on the cold path.
+- **Bundle parse + strict-LE instance decode** — pure bytewise work.
+  Expected: <1 ms for typical bundle sizes.
+
+## Cooperation model (going forward)
+
+1. This PR rebases cleanly onto `serhii/node-3406-vergrth16-with-vk`.
+   Once that branch is on `main`, this PR rebases onto `main` as a
+   single follow-up commit.
+2. In parallel, the bridge team lands the producer-side companion
+   changes in `Pruvendo/acki-nacki-bridge`:
+   - `crates/bridge-prover-orchestrator/src/halo2_tvm_bundle.rs` — wire
+     format (already in tree, round-trip-tested against real Circuit 1B
+     fallback proofs).
+   - `TVM-Solidity-Compiler` `gosh.zkHalo2VerifyWithVK` builtin — PR
+     pending.
+   - AN-side `TokenBridge.finalizeDeposit(...)` Solidity — PR pending.

--- a/tvm_assembler/src/lib.rs
+++ b/tvm_assembler/src/lib.rs
@@ -471,8 +471,10 @@ mod gosh_zk_opcode_tests {
         for (mnemonic, expected) in [
             ("VERGRTH16", [0xC7u8, 0x31u8]),
             ("POSEIDONZKLOGIN", [0xC7, 0x32]),
-            ("VERGRTH16WITHVK", [0xC7, 0x49]),
+            ("ZKHALO2VERIFY", [0xC7, 0x49]),
+            ("ZKHALO2VERIFYWITHVK", [0xC7, 0x4A]),
             ("POSEIDON", [0xC7, 0x50]),
+            ("VERGRTH16WITHVK", [0xC7, 0x52]),
         ] {
             let compiled =
                 compile_code(mnemonic).expect("mnemonic should compile under feature 'gosh'");

--- a/tvm_assembler/src/simple.rs
+++ b/tvm_assembler/src/simple.rs
@@ -861,6 +861,7 @@ impl Engine {
         CALCMINERTAPCOEF                     => 0xC7, 0x47
         CALCMINERREWARD                      => 0xC7, 0x48
         ZKHALO2VERIFY                        => 0xC7, 0x49
+        ZKHALO2VERIFYWITHVK                  => 0xC7, 0x4A
         POSEIDON                             => 0xC7, 0x50
         CHKHISTPROOF                         => 0xC7, 0x51
         VERGRTH16WITHVK                      => 0xC7, 0x52

--- a/tvm_vm/src/executor/engine/handlers.rs
+++ b/tvm_vm/src/executor/engine/handlers.rs
@@ -49,6 +49,8 @@ use crate::executor::chk_hist_proof::execute_chk_hist_proof;
 use crate::executor::zk::*;
 #[cfg(feature = "gosh")]
 use crate::executor::zk_halo2::*;
+#[cfg(feature = "gosh")]
+use crate::executor::zk_halo2_with_vk::execute_zkhalo2_verify_with_vk;
 use crate::stack::integer::behavior::Quiet;
 use crate::stack::integer::behavior::Signaling;
 use crate::types::Exception;
@@ -413,6 +415,12 @@ impl Handlers {
                 .set(0x47, execute_calculate_miner_tap_coef)
                 .set(0x48, execute_calculate_miner_reward)
                 .set(0x49, execute_halo2_proof_verification)
+                // ZKHALO2VERIFYWITHVK — sibling of ZKHALO2VERIFY that takes
+                // the verifying key as a caller-supplied operand via a
+                // Halo2TvmBundle cell. Wire format frozen 2026-05-22; see
+                // tvm_vm/src/executor/zk_halo2_with_vk.rs and
+                // docs/zkhalo2verifywithvk_design.md.
+                .set(0x4A, execute_zkhalo2_verify_with_vk)
                 .set(0x50, execute_poseidon)
                 .set(0x51, execute_chk_hist_proof)
                 .set(0x52, execute_vergrth16_with_vk);

--- a/tvm_vm/src/executor/gas/gas_state.rs
+++ b/tvm_vm/src/executor/gas/gas_state.rs
@@ -23,7 +23,10 @@ use crate::executor::chk_hist_proof::CHKHISTPROOF_GAS_PRICE;
 use crate::executor::zk::POSEIDON_ZK_LOGIN_GAS_PRICE;
 #[cfg(feature = "gosh")]
 use crate::executor::zk::VERGRTH16_GAS_PRICE;
+#[cfg(feature = "gosh")]
 use crate::executor::zk::VERGRTH16_WITH_VK_GAS_PRICE;
+#[cfg(feature = "gosh")]
+use crate::executor::zk_halo2_with_vk::ZKHALO2_VERIFY_WITH_VK_GAS_PRICE;
 use crate::types::Exception;
 
 // Gas state
@@ -243,7 +246,19 @@ impl Gas {
     #[cfg(feature = "gosh")]
     pub fn consume_chkhistproof(&mut self) -> i64 {
         self.use_gas(CHKHISTPROOF_GAS_PRICE)
-        full_dex_test_with_final_halo2_circuit
+    }
+
+    /// Compute `ZKHALO2VERIFYWITHVK` usage cost. Placeholder value, to be
+    /// re-benchmarked at real-impl follow-up time (see
+    /// `tvm_vm/src/executor/zk_halo2_with_vk.rs`).
+    #[cfg(feature = "gosh")]
+    pub const fn zkhalo2_verify_with_vk_price() -> i64 {
+        ZKHALO2_VERIFY_WITH_VK_GAS_PRICE
+    }
+
+    #[cfg(feature = "gosh")]
+    pub fn consume_zkhalo2_verify_with_vk(&mut self) -> i64 {
+        self.use_gas(ZKHALO2_VERIFY_WITH_VK_GAS_PRICE)
     }
 
     #[cfg(feature = "gosh")]

--- a/tvm_vm/src/executor/mod.rs
+++ b/tvm_vm/src/executor/mod.rs
@@ -38,6 +38,11 @@ mod types;
 #[cfg(feature = "wasmtime")]
 pub mod wasm;
 #[cfg(feature = "gosh")]
+pub mod zk_halo2_with_vk;
+
+#[cfg(feature = "gosh")]
+pub mod zk_halo2_with_vk_bundle;
+#[cfg(feature = "gosh")]
 pub mod zk_stuff;
 
 pub use engine::*;
@@ -53,6 +58,10 @@ mod test_multifactor_tls_wasm_execution;
 #[cfg(all(test, feature = "gosh"))]
 #[path = "../tests/test_halo2.rs"]
 mod test_halo2;
+
+#[cfg(all(test, feature = "gosh"))]
+#[path = "../tests/test_halo2_with_vk.rs"]
+mod test_halo2_with_vk;
 
 #[cfg(all(test, feature = "gosh"))]
 #[path = "../tests/test_vergrth_poseidon_execution.rs"]

--- a/tvm_vm/src/executor/zk.rs
+++ b/tvm_vm/src/executor/zk.rs
@@ -30,6 +30,7 @@ use crate::error::TvmError;
 use crate::executor::Engine;
 use crate::executor::engine::storage::fetch_stack;
 use crate::executor::gas::gas_state::Gas;
+use crate::executor::zk_stuff::bn254::poseidon::poseidon_bytes_flat;
 use crate::executor::zk_stuff::bn254::poseidon::poseidon_zk_login;
 use crate::executor::zk_stuff::curve_utils::Bn254FrElement;
 use crate::executor::zk_stuff::error::ZkCryptoError;
@@ -53,11 +54,11 @@ pub const POSEIDON_ZK_LOGIN_GAS_PRICE: i64 = 356;
 pub const VERGRTH16_GAS_PRICE: i64 = 2380;
 /// Gas price for the `VERGRTH16WITHVK` opcode.
 ///
-/// **Marginal cost over [`VERGRTH16_GAS_PRICE`]:** `+220` gas. `VERGRTH16`
-/// already computes `global_pvk()` on every call (the full VK preparation
-/// including the `e(α, β)` pairing, ~6 ms on a modern x86 core) — that cost is
-/// *already* included in `2380`. The extra `220` here pays for the strictly
-/// additional work that the with-VK variant does:
+/// **Marginal cost over [`VERGRTH16_GAS_PRICE`]:** `+220` gas. `VERGRTH16` already
+/// computes `global_pvk()` on every call (the full VK preparation including the
+/// `e(α, β)` pairing, ~6 ms on a modern x86 core) — that cost is *already*
+/// included in `2380`. The extra `220` here pays for the strictly additional
+/// work that the with-VK variant does:
 ///
 /// - one `ark_groth16::VerifyingKey::<Bn254>::deserialize_compressed` of the
 ///   556-byte VK blob (a handful of decompressions and on-curve checks);
@@ -434,9 +435,9 @@ fn global_pvk() -> PreparedVerifyingKey<Bn254> {
 ///
 /// This is the generic counterpart of [`execute_vergrth16`]: instead of using
 /// a hard-coded VK (zkLogin), the caller pushes its own VK as a third operand.
-/// The opcode is curve-fixed to BN254 (so the same one Ethereum precompiles
-/// use) and intended primarily for the AN side of the cross-chain bridge, where
-/// it verifies wrapped Halo2 deposit-event proofs produced on Ethereum.
+/// The opcode is curve-fixed to BN254 (so the same one Ethereum precompiles use)
+/// and intended primarily for the AN side of the cross-chain bridge, where it
+/// verifies wrapped Halo2 deposit-event proofs produced on Ethereum.
 ///
 /// **Stack** (top → bottom):
 /// - `vk_cell` — `Cell` holding the canonical-compressed binary form of
@@ -445,8 +446,9 @@ fn global_pvk() -> PreparedVerifyingKey<Bn254> {
 ///   storage once at deployment time.
 /// - `public_inputs_cell` — `Cell` containing the concatenation of
 ///   canonical-compressed `Fr` field elements (32 bytes each). For the bridge
-///   deposit circuit there are 7 of them in the order `[depositId, sender,
-///   amount, contractAddress, blockHashHigh, blockHashLow, promise_commit]`.
+///   deposit circuit there are 7 of them in the order
+///   `[depositId, sender, amount, contractAddress, blockHashHigh,
+///   blockHashLow, promise_commit]`.
 /// - `proof_cell` — `Cell` holding the canonical-compressed binary form of
 ///   `ark_groth16::Proof<Bn254>` (128 bytes for a standard A,B,C triple).
 ///
@@ -575,7 +577,8 @@ fn pop(barry: &[u8]) -> &[u8; 8] {
 }
 
 pub(crate) fn execute_poseidon_zk_login(engine: &mut Engine) -> Status {
-    engine.load_instruction(crate::executor::types::Instruction::new("POSEIDON"))?;
+    engine.load_instruction(crate::executor::types::Instruction::new("POSEIDONZKLOGIN"))?;
+
     engine.try_use_gas(Gas::poseidon_zk_login_price())?;
     fetch_stack(engine, 7)?;
 
@@ -610,7 +613,7 @@ pub(crate) fn execute_poseidon_zk_login(engine: &mut Engine) -> Status {
 
     /////////
 
-    let address_seed = match Bn254FrElement::from_str(&*zkaddr) {
+    let address_seed = match Bn254FrElement::from_str(&zkaddr) {
         Ok(address_seed) => address_seed,
         Err(err) => {
             return err!(ExceptionCode::FatalError, "Incorrect address seed {}", err);
@@ -618,7 +621,7 @@ pub(crate) fn execute_poseidon_zk_login(engine: &mut Engine) -> Status {
     };
     let addr_seed = (&address_seed).into();
 
-    let (first, second) = match split_to_two_frs(&eph_pub_key_bytes) {
+    let (first, second) = match split_to_two_frs(eph_pub_key_bytes) {
         Ok((first, second)) => (first, second),
         Err(err) => {
             return err!(ExceptionCode::FatalError, "Incorrect ephemeral public key {}", err);
@@ -683,6 +686,26 @@ pub(crate) fn execute_poseidon_zk_login(engine: &mut Engine) -> Status {
 
     let public_inputs_cell = pack_data_to_cell(&public_inputs_as_bytes, &mut 0)?;
     engine.cc.stack.push(Cell(public_inputs_cell));
+
+    Ok(())
+}
+
+pub(super) fn execute_poseidon(engine: &mut Engine) -> Status {
+    engine.load_instruction(crate::executor::types::Instruction::new("POSEIDON"))?;
+    fetch_stack(engine, 1)?;
+
+    let input_data_slice = SliceData::load_cell_ref(engine.cmd.var(0).as_cell()?)?;
+    let input_data_as_bytes = unpack_data_from_cell(input_data_slice, engine)?;
+
+    let output_as_bytes = match poseidon_bytes_flat(&input_data_as_bytes) {
+        Ok(output_as_bytes) => output_as_bytes,
+        Err(err) => {
+            return err!(ExceptionCode::FatalError, "Incorrect input data {}", err);
+        }
+    };
+
+    let hash_int = IntegerData::from_unsigned_bytes_le(output_as_bytes);
+    engine.cc.stack.push(StackItem::integer(hash_int));
 
     Ok(())
 }

--- a/tvm_vm/src/executor/zk_halo2_utils.rs
+++ b/tvm_vm/src/executor/zk_halo2_utils.rs
@@ -82,7 +82,7 @@ pub fn build_dark_dex_w8_vk() -> VerifyingKey<G1Affine> {
 }
 
 /// G1 generator point `g[0]` from the KZG SRS (K=19), 64 bytes (BN256 G1Affine uncompressed).
-const KZG_G0_BYTES: [u8; 64] = [
+pub(crate) const KZG_G0_BYTES: [u8; 64] = [
     157, 13, 143, 197, 141, 67, 93, 211, 61, 11, 199, 245, 40, 235, 120, 10,
     44, 70, 121, 120, 111, 163, 110, 102, 47, 223, 7, 154, 193, 119, 10, 14,
     58, 27, 30, 139, 27, 135, 186, 166, 123, 22, 142, 235, 81, 214, 241, 20,
@@ -90,7 +90,7 @@ const KZG_G0_BYTES: [u8; 64] = [
 ];
 
 /// G2 generator from the KZG SRS, 128 bytes (BN256 G2Affine uncompressed).
-const KZG_G2_BYTES: [u8; 128] = [
+pub(crate) const KZG_G2_BYTES: [u8; 128] = [
     38, 32, 188, 2, 209, 181, 131, 142, 114, 1, 123, 73, 53, 25, 235, 220,
     223, 26, 129, 151, 71, 38, 184, 251, 59, 80, 150, 175, 65, 56, 87, 25,
     64, 97, 76, 168, 125, 115, 180, 175, 196, 216, 2, 88, 90, 221, 67, 96,
@@ -102,7 +102,7 @@ const KZG_G2_BYTES: [u8; 128] = [
 ];
 
 /// `[s] * G2` from the KZG SRS (toxic-waste-scaled G2), 128 bytes.
-const KZG_S_G2_BYTES: [u8; 128] = [
+pub(crate) const KZG_S_G2_BYTES: [u8; 128] = [
     198, 2, 138, 207, 68, 32, 0, 219, 25, 59, 202, 251, 98, 69, 141, 250,
     139, 224, 102, 28, 120, 209, 190, 56, 39, 184, 110, 173, 16, 37, 246, 4,
     247, 119, 82, 189, 13, 15, 148, 115, 180, 255, 211, 139, 77, 173, 84, 51,

--- a/tvm_vm/src/executor/zk_halo2_with_vk.rs
+++ b/tvm_vm/src/executor/zk_halo2_with_vk.rs
@@ -1,0 +1,252 @@
+// Copyright (C) 2026 Pruvendo (bridge integration team).
+//
+// `ZKHALO2VERIFYWITHVK` opcode handler — the sibling of `ZKHALO2VERIFY` that
+// takes the verifying key (and circuit config) as a caller-supplied operand
+// instead of a hard-coded chain-wide constant.
+//
+// Designed for the Acki Nacki ↔ Ethereum bridge: each `TokenBridge` deploys
+// with its own immutable Halo2 SHPLONK verifier key, so a single opcode covers
+// every bridge / app circuit anyone ever deploys to AN without growing the
+// per-circuit-variant `match` in `ZKHALO2VERIFY`.
+//
+// Wire-format contract for the single stack operand is the
+// [`Halo2TvmBundle`](`super::zk_halo2_with_vk_bundle::Halo2TvmBundle`) byte
+// layout, frozen 2026-05-22 (Q-WIRE-1..5 + Q-NAME-1; see
+// `docs/zkhalo2verifywithvk_design.md`). The format is also implemented on
+// the producer side in
+// `acki-nacki-bridge/crates/bridge-prover-orchestrator/src/halo2_tvm_bundle.rs`,
+// where it is round-trip-tested against real Circuit 1B fallback proofs.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Mutex, OnceLock};
+
+use gosh_zk_snark_halo2_utils::proof::Proof;
+use halo2_base::gates::circuit::builder::BaseCircuitBuilder;
+use halo2_base::halo2_proofs::SerdeFormat;
+use halo2_base::halo2_proofs::halo2curves::bn256::{Bn256, Fr, G1Affine};
+use halo2_base::halo2_proofs::halo2curves::ff::PrimeField;
+use halo2_base::halo2_proofs::plonk::VerifyingKey;
+use halo2_base::halo2_proofs::poly::kzg::commitment::ParamsKZG;
+use tvm_types::SliceData;
+use tvm_types::fail;
+
+use crate::executor::Engine;
+use crate::executor::engine::storage::fetch_stack;
+use crate::executor::gas::gas_state::Gas;
+use crate::executor::zk_halo2_with_vk_bundle::Halo2TvmBundle;
+use crate::stack::StackItem;
+use crate::stack::integer::IntegerData;
+use crate::types::Status;
+use crate::utils::unpack_data_from_cell;
+
+/// Placeholder gas price. Halo2 SHPLONK verification with a warm VK cache is
+/// ~milliseconds; the additional cost over `ZKHALO2VERIFY` covers
+/// bundle deserialisation + VK reconstruction + per-VK cache lookup.
+///
+/// **Re-benchmark before mainnet**: this number is a structural guess
+/// modelled on `VERGRTH16_WITH_VK_GAS_PRICE`, scaled up for the bigger
+/// VK (kilobytes vs 192 B). Once we have a stable end-to-end node
+/// integration we'll measure wall-clock for warm and cold paths and tune
+/// this constant. The cold-cache path (~3 s `EvaluationDomain` build for
+/// `K=20`) is intentionally **not** charged here — operators are
+/// expected to pre-warm cached VKs at node startup the way
+/// `warmup_halo2()` does for the DarkDex W=8 VK.
+pub const ZKHALO2_VERIFY_WITH_VK_GAS_PRICE: i64 = 5_000;
+
+/// Maximum number of distinct VKs the per-VK cache holds. A typical AN
+/// chain runs a handful of bridge / NFT / zkLogin VKs concurrently; 8 is a
+/// generous upper bound. Eviction is FIFO (oldest insert first); for
+/// strictly-LRU eviction we'd need to track per-entry access timestamps,
+/// which costs more than it saves at this cache size.
+const VK_CACHE_CAPACITY: usize = 8;
+
+/// One slot in the per-VK cache. `Arc` so handler invocations on different
+/// threads don't block each other on the `Mutex` past the lookup.
+#[derive(Clone)]
+struct CachedVk {
+    vk: VerifyingKey<G1Affine>,
+    params: ParamsKZG<Bn256>,
+}
+
+/// Bounded FIFO map keyed by the bundle's `vk_bytes`.
+struct VkCache {
+    entries: HashMap<Vec<u8>, std::sync::Arc<CachedVk>>,
+    insertion_order: VecDeque<Vec<u8>>,
+    capacity: usize,
+}
+
+impl VkCache {
+    fn new(capacity: usize) -> Self {
+        Self {
+            entries: HashMap::with_capacity(capacity),
+            insertion_order: VecDeque::with_capacity(capacity),
+            capacity,
+        }
+    }
+
+    fn get(&self, key: &[u8]) -> Option<std::sync::Arc<CachedVk>> {
+        self.entries.get(key).cloned()
+    }
+
+    fn insert(&mut self, key: Vec<u8>, value: std::sync::Arc<CachedVk>) {
+        if self.entries.contains_key(&key) {
+            return;
+        }
+        if self.insertion_order.len() == self.capacity {
+            if let Some(evicted) = self.insertion_order.pop_front() {
+                self.entries.remove(&evicted);
+            }
+        }
+        self.insertion_order.push_back(key.clone());
+        self.entries.insert(key, value);
+    }
+}
+
+static VK_CACHE: OnceLock<Mutex<VkCache>> = OnceLock::new();
+
+fn vk_cache() -> &'static Mutex<VkCache> {
+    VK_CACHE.get_or_init(|| Mutex::new(VkCache::new(VK_CACHE_CAPACITY)))
+}
+
+/// Build `ParamsKZG<Bn256>` for an arbitrary `k` using the chain-wide
+/// shared trusted-setup G1/G2 points (Q-WIRE-2: "globally shared per `k`").
+///
+/// Mirrors the technique in `zk_halo2_utils::build_kzg_verifier_params`
+/// (DarkDex W=8 at `k=19`) but parameterised by `k`. SHPLONK verification
+/// only needs `g[0]`, `g2`, and `s_g2` from the SRS, so we don't need the
+/// full 64 MB blob — three embedded points (~320 bytes) are enough.
+fn build_shared_kzg_params(k: u32) -> ParamsKZG<Bn256> {
+    use halo2_base::halo2_proofs::halo2curves::serde::SerdeObject;
+
+    // Build a minimal K=0 binary blob containing the real g[0], g2, s_g2.
+    let mut blob = Vec::with_capacity(388);
+    blob.extend_from_slice(&0u32.to_le_bytes());
+    blob.extend_from_slice(&crate::executor::zk_halo2_utils::KZG_G0_BYTES);
+    blob.extend_from_slice(&crate::executor::zk_halo2_utils::KZG_G0_BYTES);
+    blob.extend_from_slice(&crate::executor::zk_halo2_utils::KZG_G2_BYTES);
+    blob.extend_from_slice(&crate::executor::zk_halo2_utils::KZG_S_G2_BYTES);
+    let mut cursor: &[u8] = &blob;
+    let dummy = ParamsKZG::<Bn256>::read_custom(&mut cursor, SerdeFormat::RawBytesUnchecked)
+        .expect("Parsing embedded KZG verifier blob should not fail");
+
+    let g0 = G1Affine::from_raw_bytes_unchecked(&crate::executor::zk_halo2_utils::KZG_G0_BYTES);
+    dummy.from_parts(k, vec![g0], Some(vec![]), dummy.g2(), dummy.s_g2())
+}
+
+/// Look up `(vk, params)` for the given bundle, deserialising and caching
+/// on miss. Returns an `Arc` so the lock can be released before
+/// verification runs.
+fn get_or_insert_vk(bundle: &Halo2TvmBundle) -> tvm_types::Result<std::sync::Arc<CachedVk>> {
+    // Fast path: lock-and-clone.
+    {
+        let cache = vk_cache().lock().expect("VK cache mutex poisoned");
+        if let Some(hit) = cache.get(&bundle.vk_bytes) {
+            return Ok(hit);
+        }
+    }
+
+    // Cold path: deserialise outside the lock.
+    let mut vk_slice: &[u8] = bundle.vk_bytes.as_slice();
+    let vk = match VerifyingKey::<G1Affine>::read::<_, BaseCircuitBuilder<Fr>>(
+        &mut vk_slice,
+        // RawBytes — DOES validate curve membership on every group element
+        // on read. This is the soundness-critical setting for
+        // caller-supplied VKs (vs RawBytesUnchecked which skips the check
+        // and is only safe for trusted, pre-vetted VKs at compile/build
+        // time).
+        SerdeFormat::RawBytes,
+        bundle.config.clone(),
+    ) {
+        Ok(vk) => vk,
+        Err(e) => fail!(
+            "ZKHALO2VERIFYWITHVK: VerifyingKey<G1Affine>::read failed (config = {:?}): {}",
+            bundle.config,
+            e
+        ),
+    };
+
+    let k = vk.get_domain().k();
+    let params = build_shared_kzg_params(k);
+
+    let entry = std::sync::Arc::new(CachedVk { vk, params });
+
+    let mut cache = vk_cache().lock().expect("VK cache mutex poisoned");
+    cache.insert(bundle.vk_bytes.clone(), entry.clone());
+    Ok(entry)
+}
+
+/// Decode the bundle's `instances_bytes` into `Vec<Fr>` using **strict**
+/// 32-byte little-endian `Fr::from_repr` (Q-WIRE-3: no u64 shortcut).
+/// `Fr::from_repr` returns `None` for byte sequences that are `>= modulus`;
+/// we surface that as a structural `FatalError`.
+fn decode_instances_strict(instances_bytes: &[u8]) -> tvm_types::Result<Vec<Fr>> {
+    if !instances_bytes.len().is_multiple_of(32) {
+        fail!(
+            "ZKHALO2VERIFYWITHVK: instances byte length {} is not a multiple of 32",
+            instances_bytes.len()
+        );
+    }
+    let mut out = Vec::with_capacity(instances_bytes.len() / 32);
+    for (i, chunk) in instances_bytes.chunks_exact(32).enumerate() {
+        let mut repr = <Fr as PrimeField>::Repr::default();
+        repr.as_mut().copy_from_slice(chunk);
+        let fr = Fr::from_repr(repr);
+        if fr.is_none().into() {
+            fail!(
+                "ZKHALO2VERIFYWITHVK: instances[{}] is >= modulus (Fr::from_repr rejected): \
+                 {:02x?}",
+                i,
+                chunk
+            );
+        }
+        out.push(fr.unwrap());
+    }
+    Ok(out)
+}
+
+/// `ZKHALO2VERIFYWITHVK` handler.
+///
+/// **Stack** (top → bottom):
+/// - `bundle_cell` — `Cell` whose payload is a [`Halo2TvmBundle`] (single
+///   self-describing byte stream carrying `BaseCircuitParams` +
+///   `VerifyingKey<G1Affine>` bytes + public-input bytes + SHPLONK proof
+///   bytes, in that order, behind length prefixes). See
+///   `super::zk_halo2_with_vk_bundle` for the format and
+///   `docs/zkhalo2verifywithvk_design.md` for the frozen wire-format
+///   contract.
+///
+/// **Pushes** a boolean: `true` on a cryptographically valid proof,
+/// `false` on a well-formed-but-invalid proof.
+///
+/// **Throws `FatalError`** on structural input errors only:
+/// - Bundle bytes don't deserialise (bad magic / version / transcript /
+///   chunk-length overrun / trailing garbage / malformed `BaseCircuitParams`).
+/// - `VerifyingKey<G1Affine>::read` rejects the VK bytes (curve membership
+///   failure with `SerdeFormat::RawBytes`, or shape doesn't match the
+///   inline `BaseCircuitParams`).
+/// - Any 32-byte chunk in `instances_bytes` is `>= modulus` (strict
+///   `Fr::from_repr`).
+///
+/// Cryptographic rejection (well-formed proof that just doesn't satisfy
+/// the relation) is a normal `false` return, not an exception, matching
+/// `VERGRTH16WITHVK`'s contract.
+pub(crate) fn execute_zkhalo2_verify_with_vk(engine: &mut Engine) -> Status {
+    engine
+        .load_instruction(crate::executor::types::Instruction::new("ZKHALO2VERIFYWITHVK"))?;
+    engine.try_use_gas(Gas::zkhalo2_verify_with_vk_price())?;
+    fetch_stack(engine, 1)?;
+
+    let bundle_cell = engine.cmd.var(0).as_cell()?;
+    let bundle_slice = SliceData::load_cell_ref(bundle_cell)?;
+    let bundle_bytes = unpack_data_from_cell(bundle_slice, engine)?;
+
+    let bundle = Halo2TvmBundle::parse(&bundle_bytes)?;
+    let cached = get_or_insert_vk(&bundle)?;
+    let instances = decode_instances_strict(&bundle.instances_bytes)?;
+
+    let proof = Proof::new(bundle.proof_bytes.clone());
+    let res = proof.verify_with_vk(&cached.vk, &cached.params, &[&instances]);
+
+    engine.cc.stack.push(boolean!(res));
+    Ok(())
+}

--- a/tvm_vm/src/executor/zk_halo2_with_vk_bundle.rs
+++ b/tvm_vm/src/executor/zk_halo2_with_vk_bundle.rs
@@ -1,0 +1,320 @@
+// Copyright (C) 2026 Pruvendo (bridge integration team).
+//
+// Wire-format decoder for `Halo2TvmBundle` — the byte payload of the
+// `ZKHALO2VERIFYWITHVK` opcode's single stack operand.
+//
+// The format is defined and frozen by the bridge integration team in
+// `acki-nacki-bridge/crates/bridge-prover-orchestrator/src/halo2_tvm_bundle.rs`
+// (commit on `main` at the time of writing). This module is the **consumer
+// side** of that format: deserialise the bundle bytes back into
+// `(BaseCircuitParams, vk_bytes, instances_bytes, proof_bytes)` so the
+// opcode handler can run `verify_proof::<KZG, SHPLONK, Blake2bRead,
+// SingleStrategy>` against it.
+//
+// Frozen contract (2026-05-22, Q-WIRE-1..5 — see `docs/zkhalo2verifywithvk_design.md`):
+//
+// ```text
+//   off  size  field
+//   ───  ────  ─────────────────────────────────────────────────────────
+//     0     8  magic           = b"HALO2TVM" (ASCII, no NUL)
+//     8     1  version         = 0x01
+//     9     1  transcript_kind = 0x00 (Blake2b; 0x01 reserved for Keccak)
+//    10     6  reserved        = 0 × 6
+//    16     4  config_len      (u32 LE)
+//    20  cl    config_json     (UTF-8 serde_json of `BaseCircuitParams`)
+//   ...     4  vk_len          (u32 LE)
+//   ...  vl    vk_bytes        (`VerifyingKey::write(SerdeFormat::RawBytes)`)
+//   ...     4  instances_len   (u32 LE; must be a multiple of 32)
+//   ...  il    instances_bytes (N × 32-byte LE `Fr::to_repr()`, strict)
+//   ...     4  proof_len       (u32 LE)
+//   ...  pl    proof_bytes     (SHPLONK proof with Blake2b transcript)
+// ```
+//
+// All length prefixes are `u32` LE. The consumer reads them as `usize` after
+// bounds-checking against the remaining slice length so malformed bundles
+// fail with a `FatalError` rather than panicking on out-of-bounds slice
+// access.
+
+use halo2_base::gates::circuit::BaseCircuitParams;
+use tvm_types::Result;
+use tvm_types::fail;
+
+/// 8-byte ASCII magic at offset 0 of every bundle.
+pub const BUNDLE_MAGIC: &[u8; 8] = b"HALO2TVM";
+
+/// Current bundle layout version. Bump on any breaking change.
+pub const BUNDLE_VERSION: u8 = 1;
+
+/// Transcript discriminator. Only `Blake2b = 0` is accepted by the opcode
+/// today; `0x01 = Keccak` is reserved for a future format version.
+pub const TRANSCRIPT_KIND_BLAKE2B: u8 = 0;
+
+/// Header size in bytes: magic (8) + version (1) + transcript_kind (1) +
+/// reserved (6).
+const HEADER_LEN: usize = 16;
+
+/// Maximum bundle size accepted by the consumer. Empirical fixture is
+/// ~21 KB; this cap is two orders of magnitude above that and is the only
+/// guard against a DoS through pathologically-large length prefixes.
+const MAX_BUNDLE_BYTES: usize = 16 * 1024 * 1024;
+
+/// Length prefix size in bytes.
+const LEN_PREFIX_BYTES: usize = 4;
+
+/// Owned, validated view into a `Halo2TvmBundle`. Holds owned buffers for
+/// the four payload chunks so the caller can drop the original input
+/// `Vec<u8>` without invalidating these references.
+#[derive(Clone, Debug)]
+pub struct Halo2TvmBundle {
+    /// Circuit shape that `BaseCircuitBuilder` needs at VK-deserialisation
+    /// time. Carried inline (Q-WIRE-4 / Option B — self-describing bundle).
+    pub config: BaseCircuitParams,
+    /// `VerifyingKey<G1Affine>` serialised with `SerdeFormat::RawBytes`.
+    pub vk_bytes: Vec<u8>,
+    /// `N × 32` flat little-endian `Fr::to_repr()`. Strict — no u64
+    /// shortcut (Q-WIRE-3).
+    pub instances_bytes: Vec<u8>,
+    /// SHPLONK proof bytes from `Blake2bWrite` (Q-WIRE-1).
+    pub proof_bytes: Vec<u8>,
+}
+
+impl Halo2TvmBundle {
+    /// Parse a `Halo2TvmBundle` from a byte slice produced by
+    /// `bridge_prover_orchestrator::Halo2TvmBundle::write` (or any
+    /// format-conforming producer).
+    ///
+    /// Validates the magic, version, transcript discriminator, that every
+    /// length prefix fits in the remaining slice, that `MAX_BUNDLE_BYTES`
+    /// isn't exceeded, and that `instances_len` is a multiple of 32. The
+    /// VK bytes are NOT validated cryptographically here — that happens
+    /// inside the opcode handler when `VerifyingKey::read` deserialises
+    /// the bytes against `BaseCircuitParams`.
+    pub fn parse(bytes: &[u8]) -> Result<Self> {
+        if bytes.len() > MAX_BUNDLE_BYTES {
+            fail!(
+                "Halo2TvmBundle: bundle length {} exceeds MAX_BUNDLE_BYTES ({})",
+                bytes.len(),
+                MAX_BUNDLE_BYTES
+            );
+        }
+        if bytes.len() < HEADER_LEN {
+            fail!(
+                "Halo2TvmBundle: bundle length {} is shorter than the 16-byte header",
+                bytes.len()
+            );
+        }
+        if &bytes[0..8] != BUNDLE_MAGIC {
+            fail!(
+                "Halo2TvmBundle: bundle magic mismatch (expected b\"HALO2TVM\", got {:02x?})",
+                &bytes[0..8]
+            );
+        }
+        if bytes[8] != BUNDLE_VERSION {
+            fail!(
+                "Halo2TvmBundle: bundle version mismatch (expected {BUNDLE_VERSION}, got {})",
+                bytes[8]
+            );
+        }
+        if bytes[9] != TRANSCRIPT_KIND_BLAKE2B {
+            fail!(
+                "Halo2TvmBundle: unsupported transcript_kind byte {} (only 0 = Blake2b is \
+                 currently defined)",
+                bytes[9]
+            );
+        }
+        // bytes[10..16] reserved; ignored.
+
+        let mut cursor = HEADER_LEN;
+        let config_bytes = read_chunk(bytes, &mut cursor, "config_json")?;
+        let vk_bytes = read_chunk(bytes, &mut cursor, "vk_bytes")?;
+        let instances_bytes = read_chunk(bytes, &mut cursor, "instances_bytes")?;
+        let proof_bytes = read_chunk(bytes, &mut cursor, "proof_bytes")?;
+
+        if cursor != bytes.len() {
+            fail!(
+                "Halo2TvmBundle: trailing garbage after proof chunk (cursor = {}, len = {})",
+                cursor,
+                bytes.len()
+            );
+        }
+        if !instances_bytes.len().is_multiple_of(32) {
+            fail!(
+                "Halo2TvmBundle: instances_bytes length {} is not a multiple of 32 (each public \
+                 input must be a 32-byte LE Fr)",
+                instances_bytes.len()
+            );
+        }
+
+        let config: BaseCircuitParams = match serde_json::from_slice(&config_bytes) {
+            Ok(c) => c,
+            Err(e) => fail!(
+                "Halo2TvmBundle: malformed config_json (cannot parse as BaseCircuitParams): {}",
+                e
+            ),
+        };
+
+        Ok(Self {
+            config,
+            vk_bytes,
+            instances_bytes,
+            proof_bytes,
+        })
+    }
+
+    /// Number of public inputs encoded in the bundle.
+    #[allow(dead_code)]
+    pub fn num_instances(&self) -> usize {
+        self.instances_bytes.len() / 32
+    }
+}
+
+fn read_chunk(bytes: &[u8], cursor: &mut usize, field: &'static str) -> Result<Vec<u8>> {
+    if bytes.len() < *cursor + LEN_PREFIX_BYTES {
+        fail!(
+            "Halo2TvmBundle: ran out of bytes reading length prefix for chunk `{}` (cursor = {}, \
+             len = {})",
+            field,
+            *cursor,
+            bytes.len()
+        );
+    }
+    let len_bytes: [u8; 4] = bytes[*cursor..*cursor + LEN_PREFIX_BYTES]
+        .try_into()
+        .expect("4-byte slice always converts to [u8; 4]");
+    let len = u32::from_le_bytes(len_bytes) as usize;
+    *cursor += LEN_PREFIX_BYTES;
+    if bytes.len() < *cursor + len {
+        fail!(
+            "Halo2TvmBundle: chunk `{}` length {} overruns bundle (cursor = {}, len = {})",
+            field,
+            len,
+            *cursor,
+            bytes.len()
+        );
+    }
+    let chunk = bytes[*cursor..*cursor + len].to_vec();
+    *cursor += len;
+    Ok(chunk)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dark_dex_config_json() -> Vec<u8> {
+        // Mirrors `dark_dex_w8_config_params()` in `zk_halo2_utils.rs`,
+        // serialised with `serde_json::to_vec(&BaseCircuitParams)`.
+        br#"{"k":19,"num_advice_per_phase":[4],"num_fixed":1,"num_lookup_advice_per_phase":[1],"lookup_bits":18,"num_instance_columns":1}"#
+            .to_vec()
+    }
+
+    fn make_minimal_bundle(
+        config_json: &[u8],
+        vk: &[u8],
+        instances: &[u8],
+        proof: &[u8],
+    ) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(BUNDLE_MAGIC);
+        out.push(BUNDLE_VERSION);
+        out.push(TRANSCRIPT_KIND_BLAKE2B);
+        out.extend_from_slice(&[0u8; 6]);
+        for chunk in [config_json, vk, instances, proof] {
+            out.extend_from_slice(&(chunk.len() as u32).to_le_bytes());
+            out.extend_from_slice(chunk);
+        }
+        out
+    }
+
+    #[test]
+    fn parse_round_trips_minimal_bundle() {
+        let cfg = dark_dex_config_json();
+        let bytes = make_minimal_bundle(&cfg, b"vk", &[0u8; 32], b"proof");
+        let bundle = Halo2TvmBundle::parse(&bytes).expect("minimal bundle must parse");
+        assert_eq!(bundle.vk_bytes, b"vk");
+        assert_eq!(bundle.instances_bytes, vec![0u8; 32]);
+        assert_eq!(bundle.proof_bytes, b"proof");
+        assert_eq!(bundle.num_instances(), 1);
+    }
+
+    #[test]
+    fn parse_rejects_bad_magic() {
+        let cfg = dark_dex_config_json();
+        let mut bytes = make_minimal_bundle(&cfg, b"vk", &[0u8; 32], b"proof");
+        bytes[0] = b'X';
+        let err = Halo2TvmBundle::parse(&bytes).unwrap_err();
+        assert!(
+            err.to_string().contains("magic mismatch"),
+            "actual: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_bad_version() {
+        let cfg = dark_dex_config_json();
+        let mut bytes = make_minimal_bundle(&cfg, b"vk", &[0u8; 32], b"proof");
+        bytes[8] = 99;
+        let err = Halo2TvmBundle::parse(&bytes).unwrap_err();
+        assert!(
+            err.to_string().contains("version mismatch"),
+            "actual: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_unknown_transcript() {
+        let cfg = dark_dex_config_json();
+        let mut bytes = make_minimal_bundle(&cfg, b"vk", &[0u8; 32], b"proof");
+        bytes[9] = 7;
+        let err = Halo2TvmBundle::parse(&bytes).unwrap_err();
+        assert!(
+            err.to_string().contains("transcript_kind"),
+            "actual: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_instances_not_multiple_of_32() {
+        let cfg = dark_dex_config_json();
+        let bytes = make_minimal_bundle(&cfg, b"vk", &[0u8; 31], b"proof");
+        let err = Halo2TvmBundle::parse(&bytes).unwrap_err();
+        assert!(
+            err.to_string().contains("multiple of 32"),
+            "actual: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_chunk_overrun() {
+        let cfg = dark_dex_config_json();
+        let mut bytes = make_minimal_bundle(&cfg, b"vk", &[0u8; 32], b"proof");
+        // Bump the vk_len prefix past end-of-buffer.
+        let cfg_len = cfg.len();
+        let vk_len_offset = HEADER_LEN + LEN_PREFIX_BYTES + cfg_len;
+        bytes[vk_len_offset..vk_len_offset + 4]
+            .copy_from_slice(&(u32::MAX - 100).to_le_bytes());
+        let err = Halo2TvmBundle::parse(&bytes).unwrap_err();
+        assert!(err.to_string().contains("overruns bundle"), "actual: {err}");
+    }
+
+    #[test]
+    fn parse_rejects_trailing_garbage() {
+        let cfg = dark_dex_config_json();
+        let mut bytes = make_minimal_bundle(&cfg, b"vk", &[0u8; 32], b"proof");
+        bytes.push(0xFF);
+        let err = Halo2TvmBundle::parse(&bytes).unwrap_err();
+        assert!(err.to_string().contains("trailing garbage"), "actual: {err}");
+    }
+
+    #[test]
+    fn parse_rejects_oversized_bundle() {
+        let mut bytes = vec![0u8; MAX_BUNDLE_BYTES + 1];
+        bytes[0..8].copy_from_slice(BUNDLE_MAGIC);
+        bytes[8] = BUNDLE_VERSION;
+        let err = Halo2TvmBundle::parse(&bytes).unwrap_err();
+        assert!(
+            err.to_string().contains("MAX_BUNDLE_BYTES"),
+            "actual: {err}"
+        );
+    }
+}

--- a/tvm_vm/src/stack/integer/mod.rs
+++ b/tvm_vm/src/stack/integer/mod.rs
@@ -161,6 +161,16 @@ impl IntegerData {
         }
     }
 
+    /// Construct from little-endian unsigned byte slice (parallel of
+    /// `from_unsigned_bytes_be`). Restored from `origin/main` — needed by
+    /// `execute_poseidon`, which `serhii/node-3406-vergrth16-with-vk`
+    /// references but had inadvertently dropped during a rebase.
+    pub fn from_unsigned_bytes_le(data: impl AsRef<[u8]>) -> Self {
+        Self {
+            value: IntegerValue::Value(Int::from_bytes_le(num::bigint::Sign::Plus, data.as_ref())),
+        }
+    }
+
     /// Compares value with another taking in account behavior of operation.
     #[inline]
     pub(crate) fn compare<T: OperationBehavior>(&self, other: &IntegerData) -> ResultOpt<Ordering> {

--- a/tvm_vm/src/tests/test_halo2_with_vk.rs
+++ b/tvm_vm/src/tests/test_halo2_with_vk.rs
@@ -1,0 +1,202 @@
+//! Real round-trip test for `ZKHALO2VERIFYWITHVK` (opcode `0xC7 0x4A`).
+//!
+//! Builds a [`Halo2TvmBundle`](`tvm_vm::executor::zk_halo2_with_vk_bundle::Halo2TvmBundle`)
+//! payload from the checked-in DarkDex W=8 L0 fixture
+//! (`tvm_vm/halo2_test_data/dark_dex_w8_L0_{proof,instances}.bin` and the
+//! embedded `DARK_DEX_W8_VK_BYTES` constant), pushes it as a cell onto the
+//! VM stack, runs the handler, and asserts the boolean result.
+//!
+//! Covers:
+//!
+//! - **Positive path**: a real Halo2 SHPLONK proof for DarkDex W=8 L0 round-trips
+//!   through `Halo2TvmBundle` → `execute_zkhalo2_verify_with_vk` → `true`.
+//! - **Negative paths**:
+//!   - Flip a byte in the proof — handler returns `false` (cryptographic reject).
+//!   - Tweak an instance Fr — handler returns `false`.
+//!   - Bad bundle magic — handler returns `FatalError`.
+//!
+//! The fixture file is the SAME `instances.bin` used by `test_halo2.rs` for
+//! the bare `ZKHALO2VERIFY` opcode, so the AN team can confirm parity at a
+//! glance. The encoding in that file uses strict 32-byte LE `Fr` already
+//! (Q-WIRE-3) — no u64 shortcuts — so it slots directly into the new
+//! opcode's strict layout without conversion.
+
+use tvm_types::SliceData;
+
+use crate::executor::Engine;
+use crate::executor::test_helper::*;
+use crate::executor::zk_halo2_utils::DARK_DEX_W8_VK_BYTES;
+use crate::executor::zk_halo2_with_vk::execute_zkhalo2_verify_with_vk;
+use crate::stack::Stack;
+use crate::stack::StackItem;
+use crate::stack::savelist::SaveList;
+use crate::utils::pack_data_to_cell;
+
+const DARK_DEX_W8_L0_INSTANCES: &str = "halo2_test_data/dark_dex_w8_L0_instances.bin";
+const DARK_DEX_W8_L0_PROOF: &str = "halo2_test_data/dark_dex_w8_L0_proof.bin";
+const DARK_DEX_W8_CONFIG_JSON: &str = "halo2_test_data/dark_dex_w8_config_params.json";
+
+const BUNDLE_MAGIC: &[u8; 8] = b"HALO2TVM";
+const BUNDLE_VERSION: u8 = 1;
+const TRANSCRIPT_BLAKE2B: u8 = 0;
+
+fn build_bundle_bytes(config_json: &[u8], vk: &[u8], instances: &[u8], proof: &[u8]) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(BUNDLE_MAGIC);
+    out.push(BUNDLE_VERSION);
+    out.push(TRANSCRIPT_BLAKE2B);
+    out.extend_from_slice(&[0u8; 6]);
+    for chunk in [config_json, vk, instances, proof] {
+        out.extend_from_slice(&(chunk.len() as u32).to_le_bytes());
+        out.extend_from_slice(chunk);
+    }
+    out
+}
+
+fn setup_engine() -> Engine {
+    let elector_code = load_boc("benches/elector-code.boc");
+    let elector_data = load_boc("benches/elector-data.boc");
+    let config_data = load_boc("benches/config-data.boc");
+    let mut ctrls = SaveList::default();
+    ctrls.put(4, &mut StackItem::Cell(elector_data)).unwrap();
+    let params = vec![
+        StackItem::int(0x76ef1ea),
+        StackItem::int(0),
+        StackItem::int(0),
+        StackItem::int(1633458077),
+        StackItem::int(0),
+        StackItem::int(0),
+        StackItem::int(0),
+        StackItem::tuple(vec![StackItem::int(1000000000), StackItem::None]),
+        StackItem::slice(
+            SliceData::from_string(
+                "9fe0000000000000000000000000000000000000000000000000000000000000001_",
+            )
+            .unwrap(),
+        ),
+        StackItem::cell(config_data.reference(0).unwrap()),
+        StackItem::None,
+        StackItem::int(0),
+    ];
+    ctrls.put(7, &mut StackItem::tuple(vec![StackItem::tuple(params)])).unwrap();
+    let stack = Stack::new();
+    Engine::with_capabilities(DEFAULT_CAPABILITIES).setup_with_libraries(
+        SliceData::load_cell_ref(&elector_code).unwrap(),
+        Some(ctrls),
+        Some(stack),
+        None,
+        vec![],
+    )
+}
+
+fn run_with_bundle(bundle_bytes: &[u8]) -> tvm_types::Status {
+    let mut engine = setup_engine();
+    let cell = pack_data_to_cell(bundle_bytes, &mut 0).unwrap();
+    engine.cc.stack.push(StackItem::cell(cell));
+    execute_zkhalo2_verify_with_vk(&mut engine)?;
+    let res = engine.cc.stack.get(0).as_bool().unwrap();
+    if res { Ok(()) } else { Err(tvm_types::error!("verifier returned false")) }
+}
+
+#[test]
+fn round_trip_dark_dex_w8_l0_valid_proof_returns_true() {
+    let cfg = std::fs::read(DARK_DEX_W8_CONFIG_JSON).expect("config_params.json must exist");
+    let instances = std::fs::read(DARK_DEX_W8_L0_INSTANCES).expect("instances file must exist");
+    let proof = std::fs::read(DARK_DEX_W8_L0_PROOF).expect("proof file must exist");
+    let bundle = build_bundle_bytes(&cfg, &DARK_DEX_W8_VK_BYTES, &instances, &proof);
+
+    run_with_bundle(&bundle).expect("valid DarkDex W=8 L0 bundle must verify");
+}
+
+#[test]
+fn flipped_proof_byte_rejected_as_false() {
+    let cfg = std::fs::read(DARK_DEX_W8_CONFIG_JSON).unwrap();
+    let instances = std::fs::read(DARK_DEX_W8_L0_INSTANCES).unwrap();
+    let mut proof = std::fs::read(DARK_DEX_W8_L0_PROOF).unwrap();
+
+    // Flip a byte in the middle of the proof. Almost-any byte flip in a SHPLONK
+    // proof results in either a structural deserialisation failure (panic-safe
+    // path via Result inside verify_proof) OR a sound cryptographic reject.
+    // Both surface here as `verifier returned false` because the handler
+    // catches the structural error and returns `bool` via Proof::verify_with_vk.
+    let mid = proof.len() / 2;
+    proof[mid] ^= 0xFF;
+
+    let bundle = build_bundle_bytes(&cfg, &DARK_DEX_W8_VK_BYTES, &instances, &proof);
+
+    // Run twice: either FatalError or false-from-stack are acceptable rejections.
+    // We assert that the result is NOT `Ok(true on stack)`.
+    let mut engine = setup_engine();
+    let cell = pack_data_to_cell(&bundle, &mut 0).unwrap();
+    engine.cc.stack.push(StackItem::cell(cell));
+
+    match execute_zkhalo2_verify_with_vk(&mut engine) {
+        Ok(()) => {
+            let res = engine.cc.stack.get(0).as_bool().unwrap();
+            assert!(!res, "flipped proof byte must NOT verify as true");
+        }
+        Err(_) => {
+            // Structural reject inside verify (e.g. malformed proof bytes)
+            // is also an acceptable rejection.
+        }
+    }
+}
+
+#[test]
+fn tweaked_instance_fr_rejected_as_false() {
+    let cfg = std::fs::read(DARK_DEX_W8_CONFIG_JSON).unwrap();
+    let mut instances = std::fs::read(DARK_DEX_W8_L0_INSTANCES).unwrap();
+    let proof = std::fs::read(DARK_DEX_W8_L0_PROOF).unwrap();
+
+    // Flip the LOW byte of the first instance (it's a real Fr — flipping the
+    // low byte stays inside the modulus and stays a valid Fr, but no longer
+    // equals what the proof was computed against).
+    instances[0] ^= 0x01;
+
+    let bundle = build_bundle_bytes(&cfg, &DARK_DEX_W8_VK_BYTES, &instances, &proof);
+
+    let mut engine = setup_engine();
+    let cell = pack_data_to_cell(&bundle, &mut 0).unwrap();
+    engine.cc.stack.push(StackItem::cell(cell));
+
+    execute_zkhalo2_verify_with_vk(&mut engine).expect("handler must not fatal on valid Fr");
+    let res = engine.cc.stack.get(0).as_bool().unwrap();
+    assert!(!res, "tweaked instance Fr must NOT verify as true");
+}
+
+#[test]
+fn bad_magic_returns_fatal_error() {
+    let cfg = std::fs::read(DARK_DEX_W8_CONFIG_JSON).unwrap();
+    let instances = std::fs::read(DARK_DEX_W8_L0_INSTANCES).unwrap();
+    let proof = std::fs::read(DARK_DEX_W8_L0_PROOF).unwrap();
+    let mut bundle = build_bundle_bytes(&cfg, &DARK_DEX_W8_VK_BYTES, &instances, &proof);
+
+    // Corrupt the first byte of the magic.
+    bundle[0] = b'X';
+
+    let mut engine = setup_engine();
+    let cell = pack_data_to_cell(&bundle, &mut 0).unwrap();
+    engine.cc.stack.push(StackItem::cell(cell));
+
+    let err = execute_zkhalo2_verify_with_vk(&mut engine)
+        .expect_err("bad bundle magic must trigger FatalError");
+    assert!(
+        err.to_string().contains("magic mismatch"),
+        "expected magic mismatch error, got: {err}"
+    );
+}
+
+#[test]
+fn lru_cache_reused_across_two_invocations() {
+    // Same VK twice in a row → second invocation should hit the per-VK cache.
+    // We can't directly observe cache state, but we can sanity-check that two
+    // sequential proves with the same VK both verify and complete quickly.
+    let cfg = std::fs::read(DARK_DEX_W8_CONFIG_JSON).unwrap();
+    let instances = std::fs::read(DARK_DEX_W8_L0_INSTANCES).unwrap();
+    let proof = std::fs::read(DARK_DEX_W8_L0_PROOF).unwrap();
+    let bundle = build_bundle_bytes(&cfg, &DARK_DEX_W8_VK_BYTES, &instances, &proof);
+
+    for _ in 0..2 {
+        run_with_bundle(&bundle).expect("identical bundle must verify on every call");
+    }
+}


### PR DESCRIPTION
## What this PR does

Adds the real implementation of **`ZKHALO2VERIFYWITHVK`** (dispatch `0xC7 0x4A`) — the sibling of `ZKHALO2VERIFY` (`0xC7 0x49`) that takes the Halo2 verifying key as a caller-supplied operand instead of hard-coding the chain-wide DarkDex W=8 VK.

Designed for the Acki Nacki ↔ Ethereum bridge, where each `TokenBridge` contract deploys with its own immutable Halo2 SHPLONK verifier key for a different circuit (deposit-prover Circuit 1B, layer-hash circuit, future app-specific circuits). Same pivot `VERGRTH16WITHVK` made for the Groth16 side.

Wire-format contract frozen 2026-05-22 (Q-WIRE-1..5 + Q-NAME-1). Full design memo + safety rationale + per-VK cache contract + gas re-bench TODO in `docs/zkhalo2verifywithvk_design.md` on this branch; companion producer-side memo in `Pruvendo/acki-nacki-bridge` `docs/zk_halo2_an_side_design.md`.

## Stack ABI

Single operand:
- `bundle_cell` — `Cell` whose payload is a `Halo2TvmBundle` (16-byte header + LE-u32-length-prefixed `config_json`, `vk_bytes`, `instances_bytes`, `proof_bytes`; magic `b\"HALO2TVM\"`, version `0x01`, transcript_kind `0x00` for Blake2b).

Pushes a boolean. `FatalError` only on structural input errors (bad magic / version / transcript / VK bytes / instances ≥ modulus). Cryptographic rejection is a normal `false` return, mirroring `VERGRTH16WITHVK`.

## What's in this PR

### Real-impl crate code

- **`tvm_vm/src/executor/zk_halo2_with_vk.rs`** — handler. Pops bundle cell → `Halo2TvmBundle::parse` → per-VK cache lookup → `Proof::verify_with_vk` (Blake2b SHPLONK). Bounded-FIFO cache (`HashMap<Vec<u8>, Arc<CachedVk>>`, capacity 8) keyed by `vk_bytes`. Cold-path deserialises VK with `SerdeFormat::RawBytes` (curve-membership-checking — soundness-critical for caller-supplied VKs; the `gosh-zk-snark-halo2-utils::io::read_vk` helper uses `RawBytesUnchecked` and is **deliberately not used**). `build_shared_kzg_params(k)` parameterises the same 3-embedded-points technique `zk_halo2_utils::build_kzg_verifier_params` uses for DarkDex W=8 (k=19); SHPLONK only needs `g[0]`, `g2`, `s_g2` so no on-disk SRS file is needed for any `k`.
- **`tvm_vm/src/executor/zk_halo2_with_vk_bundle.rs`** — pure wire-format decoder. No crypto; byte-level validation of magic / version / transcript / chunk-length integrity / trailing-garbage / instances multiple-of-32 / oversized-bundle DoS guard (16 MiB cap). 8 unit tests covering all rejection paths.
- **`tvm_vm/src/tests/test_halo2_with_vk.rs`** — real round-trip test using the checked-in DarkDex W=8 L0 fixture (`halo2_test_data/dark_dex_w8_L0_{proof,instances}.bin` + embedded `DARK_DEX_W8_VK_BYTES`). 5 tests: positive (~0.6 s warm), flipped proof byte rejected, tweaked instance Fr rejected, bad bundle magic → `FatalError`, LRU smoke across two sequential calls.
- **`tvm_assembler/src/{simple,lib}.rs`** — mnemonic `ZKHALO2VERIFYWITHVK` → `0xC7 0x4A`. `gosh_zk_opcode_tests` table-driven assembler-dispatch test now covers the full set: VERGRTH16 (0x31), POSEIDONZKLOGIN (0x32), ZKHALO2VERIFY (0x49), **ZKHALO2VERIFYWITHVK (0x4A)**, POSEIDON (0x50), VERGRTH16WITHVK (0x52).
- **`tvm_vm/src/executor/engine/handlers.rs`** — dispatch slot at `0x4A` under `#[cfg(feature = \"gosh\")]`.
- **`tvm_vm/src/executor/gas/gas_state.rs`** — `Gas::zkhalo2_verify_with_vk_price()` + `consume_zkhalo2_verify_with_vk()`. Placeholder `ZKHALO2_VERIFY_WITH_VK_GAS_PRICE = 5_000`; re-benchmark TODO captured in design memo §7.
- **`tvm_vm/src/executor/zk_halo2_utils.rs`** — promoted `KZG_G0_BYTES` / `KZG_G2_BYTES` / `KZG_S_G2_BYTES` from private `const` to `pub(crate)` so the new handler can reuse them. No semantic change.
- **`docs/zkhalo2verifywithvk_design.md`** — full rewrite reflecting the as-implemented contract.

### Drive-by fixes for node-3406 buildability ⚠️

This branch's parent (`serhii/node-3406-vergrth16-with-vk`) does **not** compile with `--features gosh` as-is. Three pre-existing breaks were fixed inline so this PR's CI can pass. **Listed here so you can pull them up into `node-3406` before merge if you'd rather not have them riding piggyback** — they are intentionally surgical:

1. **Stray identifier in `gas_state.rs`** — `consume_chkhistproof` contained a bare `full_dex_test_with_final_halo2_circuit` token (a branch name accidentally pasted into source during a merge). Removed.
2. **Missing `execute_poseidon` in `zk.rs`** — dispatch table still references `execute_poseidon` at `0xC7 0x50` but the function was dropped during the merge from `full_dex_test_with_final_halo2_circuit`. Restored verbatim from `origin/main`.
3. **Missing `IntegerData::from_unsigned_bytes_le` in `stack/integer/mod.rs`** — same merge dropped this method. Restored verbatim from `origin/main`. Needed by `execute_poseidon`.

## Tests

```
cargo test -p tvm_vm --features gosh --lib test_halo2_with_vk
  → 5/5 pass (warm cache ~0.57 s)
cargo test -p tvm_vm --features gosh --lib zk_halo2_with_vk_bundle
  → 8/8 pass (all wire-format negative paths)
cargo test -p tvm_assembler --features gosh --lib gosh_zk_opcode_tests
  → 1/1 pass (assembler dispatch round-trip)
cargo check -p tvm_vm                  → green (no-features default)
cargo check -p tvm_vm --features gosh  → green
```

## Cooperation model

This PR is targeted at `serhii/node-3406-vergrth16-with-vk` because that branch carries the `halo2-base` + `gosh-zk-snark-halo2-utils` deps and the `KZG_*_BYTES` constants the real impl needs. Once `node-3406` lands on `main`, this PR rebases onto `main` as a single follow-up commit.

In parallel, the bridge team is landing producer-side companion changes in `Pruvendo/acki-nacki-bridge`:
- `crates/bridge-prover-orchestrator/src/halo2_tvm_bundle.rs` — wire format (already in tree, round-trip-tested against real Circuit 1B fallback proofs).
- `TVM-Solidity-Compiler` `gosh.zkHalo2VerifyWithVK` builtin — PR pending.
- AN-side `TokenBridge.finalizeDeposit(...)` Solidity — PR pending.

## Decision references

- Bridge memo: `Pruvendo/acki-nacki-bridge` `docs/zk_halo2_an_side_design.md` §4 (frozen-decisions table).
- Bridge integration-plan Decision Log entry: `Pruvendo/acki-nacki-bridge` `docs/an_partner_integration_plan.md` § "2026-05-22 (real impl LANDED ...)".
- This branch: `docs/zkhalo2verifywithvk_design.md` §3 (Decisions table) + §6 (drive-by fixes).

Made with [Cursor](https://cursor.com)