### PR TITLE
Feature/node 3500 support of dapp id in sdk bm and bk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+> **Upgrading from 2.x?** See [`docs/MIGRATION-3.0.md`](docs/MIGRATION-3.0.md)
+> for a step-by-step migration guide covering the dapp_id changes below.
+
 ### Changed (breaking)
 - `tvm_client`: `ParamsOfGetAccount.address` renamed to `account_id`; now strict 64-character hex (no `0x`, no workchain). Added required `dapp_id` field.
 - `tvm_client`: `ResultOfGetAccount.dapp_id` is now `String` (not `Option`); added `account_id` field.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed (breaking)
+- `tvm_client`: `ParamsOfGetAccount.address` renamed to `account_id`; now strict 64-character hex (no `0x`, no workchain). Added required `dapp_id` field.
+- `tvm_client`: `ResultOfGetAccount.dapp_id` is now `String` (not `Option`); added `account_id` field.
+- `tvm_client`: `ParamsOfSendMessage.dst_dapp_id: Option<String>` renamed to `dapp_id: String` (empty allowed only for pre-1.0.0 servers).
+- `tvm_client`: `ResultOfSendMessage` now exposes `account_id` and `dapp_id` (always populated; derived from the request when the server doesn't return them).
+- `tvm_client`: `ParamsOfProcessMessage.dst_dapp_id` renamed to `dapp_id: String`.
+
+### Added
+- `tvm_client`: SDK version-gates `/v2/account` and `/v2/messages` wire formats based on GraphQL `info.version`. v>=1.0.0 sends new `dapp_id`/`account_id` fields; v<1.0.0 keeps legacy `address`/`dst_dapp_id`.
+- `tvm_client`: new `ServerLink::server_version()` and `ServerLink::supports_dapp_id()` helpers.
+- `tvm_cli`: `account` command requires `dapp_id` (via `dapp_id::account_id` address form) when connected to v>=1.0.0 servers; legacy single-address form remains accepted for older nodes.
+
 ## [2.24.21] - 2026-04-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,13 @@ All notable changes to this project will be documented in this file.
 - `tvm_client`: `ParamsOfSendMessage.dst_dapp_id: Option<String>` renamed to `dapp_id: String` (empty allowed only for pre-1.0.0 servers).
 - `tvm_client`: `ResultOfSendMessage` now exposes `account_id` and `dapp_id` (always populated; derived from the request when the server doesn't return them).
 - `tvm_client`: `ParamsOfProcessMessage.dst_dapp_id` renamed to `dapp_id: String`.
+- `tvm-cli` now requires the `dapp_id::account_id` address form on all commands and against all nodes; legacy `0:<hex>` and bare-hex address inputs are no longer accepted.
+- `tvm-cli` `deploy`/`deployx` now always require `--dst-dapp-id` (including `--fee` mode); pass all zeros for a self-rooted dapp.
+- `tvm-cli` `genaddr` additionally prints the `dapp_id::account_id` (`dapp_account` in JSON) self-rooted form.
 
 ### Added
 - `tvm_client`: SDK version-gates `/v2/account` and `/v2/messages` wire formats based on GraphQL `info.version`. v>=1.0.0 sends new `dapp_id`/`account_id` fields; v<1.0.0 keeps legacy `address`/`dst_dapp_id`.
 - `tvm_client`: new `ServerLink::server_version()` and `ServerLink::supports_dapp_id()` helpers.
-- `tvm_cli`: `account` command requires `dapp_id` (via `dapp_id::account_id` address form) when connected to v>=1.0.0 servers; legacy single-address form remains accepted for older nodes.
 
 ## [2.24.21] - 2026-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [3.0.0] - ????-??-??
+## [3.0.0] - 2026-06-05
 
 > **Upgrading from 2.x?** See [`docs/MIGRATION-3.0.md`](docs/MIGRATION-3.0.md)
 > for a step-by-step migration guide covering the dapp_id changes below.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [3.0.0] - ????-??-??
 
 > **Upgrading from 2.x?** See [`docs/MIGRATION-3.0.md`](docs/MIGRATION-3.0.md)
 > for a step-by-step migration guide covering the dapp_id changes below.
 
 ### Changed (breaking)
+- Default HD key derivation path changed from `m/44'/396'/0'/0/0` to `m/44'/1331'/0'/0/0`. Crypto functions (`tvm_client`) and key/address generation (`tvm_cli`) that rely on the default path now derive different keys from the same seed phrase. To keep previous keys, pass the old path explicitly.
 - `tvm_client`: `ParamsOfGetAccount.address` renamed to `account_id`; now strict 64-character hex (no `0x`, no workchain). Added required `dapp_id` field.
 - `tvm_client`: `ResultOfGetAccount.dapp_id` is now `String` (not `Option`); added `account_id` field.
 - `tvm_client`: `ParamsOfSendMessage.dst_dapp_id: Option<String>` renamed to `dapp_id: String` (empty allowed only for pre-1.0.0 servers).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5095,9 +5095,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -983,6 +983,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "cap-fs-ext"
 version = "3.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1058,6 +1067,28 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "winx",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3493,7 +3524,10 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
+ "bitflags 2.11.1",
  "libc",
+ "plain",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -3819,6 +3853,15 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -4154,7 +4197,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -4296,6 +4339,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -4791,6 +4840,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -5697,6 +5755,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.26.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c18a6156d1f27a9592ee18c1a846ca8dd5c258b7179fc193ae87c74ebb666f5"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "winapi",
+]
+
+[[package]]
 name = "system-interface"
 version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5751,6 +5823,21 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "testdir"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9ffa013be124f7e8e648876190de818e3a87088ed97ccd414a398b403aec8c8"
+dependencies = [
+ "anyhow",
+ "backtrace",
+ "cargo-platform",
+ "cargo_metadata",
+ "once_cell",
+ "sysinfo",
+ "whoami",
+]
 
 [[package]]
 name = "textwrap"
@@ -6305,6 +6392,7 @@ dependencies = [
  "serde_json",
  "simplelog",
  "string-error",
+ "testdir",
  "thiserror 2.0.18",
  "tokio",
  "tokio-retry",
@@ -6817,6 +6905,12 @@ checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -7350,6 +7444,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api_derive"
-version = "3.0.0-alpha"
+version = "3.0.0"
 dependencies = [
  "api_info",
  "proc-macro2",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "api_info"
-version = "3.0.0-alpha"
+version = "3.0.0"
 dependencies = [
  "serde",
  "serde_derive",
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "api_test"
-version = "3.0.0-alpha"
+version = "3.0.0"
 dependencies = [
  "api_derive",
  "api_info",
@@ -5904,7 +5904,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tl_code_gen"
-version = "3.0.0-alpha"
+version = "3.0.0"
 dependencies = [
  "serde_json",
  "tvm_tl_codegen",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_abi"
-version = "3.0.0-alpha"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6200,7 +6200,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_api"
-version = "3.0.0-alpha"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -6218,7 +6218,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_assembler"
-version = "3.0.0-alpha"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "clap 4.6.0",
@@ -6239,7 +6239,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_block"
-version = "3.0.0-alpha"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -6260,7 +6260,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_block_json"
-version = "3.0.0-alpha"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "hex",
@@ -6281,7 +6281,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_cli"
-version = "3.0.0-alpha"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -6322,7 +6322,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_client"
-version = "3.0.0-alpha"
+version = "3.0.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -6397,7 +6397,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_client_processing"
-version = "3.0.0-alpha"
+version = "3.0.0"
 dependencies = [
  "api_derive",
  "api_info",
@@ -6416,7 +6416,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_common"
-version = "3.0.0-alpha"
+version = "3.0.0"
 dependencies = [
  "log",
  "log4rs",
@@ -6427,7 +6427,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_debugger"
-version = "3.0.0-alpha"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -6445,7 +6445,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_executor"
-version = "3.0.0-alpha"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -6461,7 +6461,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_sdk"
-version = "3.0.0-alpha"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "api_derive",
@@ -6485,7 +6485,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_struct"
-version = "3.0.0-alpha"
+version = "3.0.0"
 dependencies = [
  "thiserror 2.0.18",
  "tvm_block",
@@ -6494,7 +6494,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_tl_codegen"
-version = "3.0.0-alpha"
+version = "3.0.0"
 dependencies = [
  "crc",
  "pom",
@@ -6507,7 +6507,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_types"
-version = "3.0.0-alpha"
+version = "3.0.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -6539,7 +6539,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_vm"
-version = "3.0.0-alpha"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "ark-bls12-381",
@@ -6690,7 +6690,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "update_trusted_blocks"
-version = "3.0.0-alpha"
+version = "3.0.0"
 dependencies = [
  "bincode",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5032,9 +5032,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api_derive"
-version = "2.24.21"
+version = "3.0.0-alpha"
 dependencies = [
  "api_info",
  "proc-macro2",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "api_info"
-version = "2.24.21"
+version = "3.0.0-alpha"
 dependencies = [
  "serde",
  "serde_derive",
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "api_test"
-version = "2.24.21"
+version = "3.0.0-alpha"
 dependencies = [
  "api_derive",
  "api_info",
@@ -5904,7 +5904,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tl_code_gen"
-version = "2.24.21"
+version = "3.0.0-alpha"
 dependencies = [
  "serde_json",
  "tvm_tl_codegen",
@@ -6184,7 +6184,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_abi"
-version = "2.24.21"
+version = "3.0.0-alpha"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6200,7 +6200,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_api"
-version = "2.24.21"
+version = "3.0.0-alpha"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -6218,7 +6218,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_assembler"
-version = "2.24.21"
+version = "3.0.0-alpha"
 dependencies = [
  "anyhow",
  "clap 4.6.0",
@@ -6239,7 +6239,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_block"
-version = "2.24.21"
+version = "3.0.0-alpha"
 dependencies = [
  "anyhow",
  "base64",
@@ -6260,7 +6260,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_block_json"
-version = "2.24.21"
+version = "3.0.0-alpha"
 dependencies = [
  "anyhow",
  "hex",
@@ -6281,7 +6281,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_cli"
-version = "2.24.21"
+version = "3.0.0-alpha"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -6322,7 +6322,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_client"
-version = "2.24.21"
+version = "3.0.0-alpha"
 dependencies = [
  "aes",
  "anyhow",
@@ -6397,7 +6397,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_client_processing"
-version = "2.24.21"
+version = "3.0.0-alpha"
 dependencies = [
  "api_derive",
  "api_info",
@@ -6416,7 +6416,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_common"
-version = "2.24.21"
+version = "3.0.0-alpha"
 dependencies = [
  "log",
  "log4rs",
@@ -6427,7 +6427,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_debugger"
-version = "2.24.21"
+version = "3.0.0-alpha"
 dependencies = [
  "anyhow",
  "base64",
@@ -6445,7 +6445,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_executor"
-version = "2.24.21"
+version = "3.0.0-alpha"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -6461,7 +6461,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_sdk"
-version = "2.24.21"
+version = "3.0.0-alpha"
 dependencies = [
  "anyhow",
  "api_derive",
@@ -6485,7 +6485,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_struct"
-version = "2.24.21"
+version = "3.0.0-alpha"
 dependencies = [
  "thiserror 2.0.18",
  "tvm_block",
@@ -6494,7 +6494,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_tl_codegen"
-version = "2.24.21"
+version = "3.0.0-alpha"
 dependencies = [
  "crc",
  "pom",
@@ -6507,7 +6507,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_types"
-version = "2.24.21"
+version = "3.0.0-alpha"
 dependencies = [
  "aes",
  "anyhow",
@@ -6539,7 +6539,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_vm"
-version = "2.24.21"
+version = "3.0.0-alpha"
 dependencies = [
  "anyhow",
  "ark-bls12-381",
@@ -6690,7 +6690,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "update_trusted_blocks"
-version = "2.24.21"
+version = "3.0.0-alpha"
 dependencies = [
  "bincode",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
   "tvm_vm",
 ]
 [workspace.package]
-version = "2.24.21"
+version = "3.0.0-alpha"
 
 rust-version = "1.76.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
   "tvm_vm",
 ]
 [workspace.package]
-version = "3.0.0-alpha"
+version = "3.0.0"
 
 rust-version = "1.76.0"
 

--- a/docs/MIGRATION-3.0.md
+++ b/docs/MIGRATION-3.0.md
@@ -17,8 +17,8 @@ changed. This guide walks you through the migration.
 | `ParamsOfSendMessage.dst_dapp_id: Option<String>` | `dapp_id: String` |
 | `ParamsOfProcessMessage.dst_dapp_id` | `dapp_id: String` |
 | `ResultOfSendMessage` — no account_id/dapp_id | now exposes both (`String`) |
-| `tvm-cli account 0:abc…` (against v3 node) | `tvm-cli account <dapp>::<acc>` |
-| `tvm-cli deploy/deployx` — no flag needed | requires `--dst-dapp-id <hex>` on v3 nodes |
+| `tvm-cli account 0:abc…` (any node) | `tvm-cli account <dapp>::<acc>` |
+| `tvm-cli deploy/deployx` — no flag needed | requires `--dst-dapp-id <hex>` on all nodes |
 | `deployed_at: "0:abc…"` | `deployed_at: "<acc>::<acc>"` |
 
 ---
@@ -33,11 +33,8 @@ You are affected if **any** of the following is true:
   `ParamsOfProcessMessage`, `ResultOfGetAccount`, or
   `ResultOfSendMessage`.
 - You drive `tvm-cli account`, `deploy`, `deployx`, `call`, `callx`,
-  `send`, or `message` against a node reporting `info.version >=
-  "1.0.0"` over GraphQL.
-
-You are **not** affected if you only talk to legacy (`< 1.0.0`) nodes
-through the older SDK — the new SDK handles them transparently.
+  `send`, or `message` against any node (legacy `< 1.0.0` or v3
+  `>= 1.0.0`) over GraphQL.
 
 ---
 
@@ -185,38 +182,33 @@ is always present.
 
 ### `account`
 
-The legacy form still works against `< 1.0.0` (GraphQL `info.version`) nodes:
+The `dapp_id::account_id` double-colon form is now **required on all nodes**,
+including legacy `< 1.0.0` (GraphQL `info.version`) nodes. Legacy `0:abc...`
+and bare-hex address inputs are no longer accepted as CLI input.
 
 ```bash
-tvm-cli account 0:abc...
-```
-
-Against a `>= 1.0.0` (GraphQL `info.version`) node, `account_id` alone is not
-enough — provide the `dapp_id` via the extended form:
-
-```bash
-# Extended form, double-colon (preferred):
 tvm-cli account <dapp_id>::<account_id>
-
-# Single-colon when the dapp portion is 64-hex:
-tvm-cli account <dapp_id>:<account_id>
 ```
 
-If you forget the `dapp_id` on a v3-compatible node, the CLI errors with:
+Against a legacy node the `dapp_id` is dropped on the wire automatically.
+Against a v3 (`>= 1.0.0`) node it is forwarded as-is. Either way the
+double-colon form must be supplied.
+
+Passing a legacy `0:abc...` or bare-hex address now errors with:
 
 ```
-address `...` is missing dapp_id; v>=1.0.0 servers require the form
-`dapp_id::account_id` or `dapp_id:account_id`
+address must be in the form `dapp_id::account_id`
 ```
 
-The output now always shows both `account_id` and `dapp_id` as plain
-fields (JSON `dapp_id` is `null` when the legacy node didn't return one;
+The output always shows both `account_id` and `dapp_id` as plain fields
+(JSON `dapp_id` is `null` when the legacy node didn't return one;
 text output prints `None`).
 
 ### `deploy` / `deployx`
 
-The CLI flag `--dst-dapp-id` is unchanged in name. It is now **required**
-on `>= 1.0.0` nodes. Examples:
+The CLI flag `--dst-dapp-id` is unchanged in name. It is now **always required**
+on every node — legacy and v3 alike — including when running in `--fee`
+estimation mode. Use all zeros for a self-rooted dapp. Examples:
 
 ```bash
 # Self-rooted deployment (dapp_id == future account_id): pass all zeros
@@ -234,11 +226,10 @@ tvm-cli deployx \
   MyContract.tvc '{...}'
 ```
 
-If you forget `--dst-dapp-id` on a v3-compatible node, the CLI errors with:
+If you omit `--dst-dapp-id`, the CLI errors with:
 
 ```
---dst-dapp-id is required when deploying to a v>=1.0.0 server
-(pass a 64-character hex dapp_id; use all zeros for a self-rooted dapp)
+--dst-dapp-id is required (pass a 64-character hex dapp_id)
 ```
 
 The `deployed_at` field and any saved alias now use the extended
@@ -251,17 +242,18 @@ identical:
 
 ### `call`, `callx`, `send`, `message`
 
-If a destination address is passed in the new `dapp_id::account_id`
-form, the dapp_id is automatically extracted and forwarded to the
-SDK. The legacy `--dst-dapp-id` flag is still accepted for backward
-compatibility (it overrides any dapp_id embedded in the address).
+The destination address must be supplied in the `dapp_id::account_id`
+form; the dapp_id is automatically extracted and forwarded to the SDK.
+The `--dst-dapp-id` flag is still accepted and overrides any dapp_id
+embedded in the address. Legacy `0:<acc>` address inputs are no longer
+accepted.
 
 ```bash
-# New form — dapp_id derived from the address:
+# Required form — dapp_id derived from the address:
 tvm-cli call <dapp>::<acc> --abi ... --method ... '{...}'
 
-# Legacy form with explicit flag (still works):
-tvm-cli call 0:<acc> --abi ... --method ... '{...}' --dst-dapp-id <dapp>
+# Explicit flag overrides the embedded dapp_id:
+tvm-cli call <dapp>::<acc> --abi ... --method ... '{...}' --dst-dapp-id <other-dapp>
 ```
 
 ---
@@ -311,7 +303,7 @@ emit `null` when the string is empty.
 - [ ] Audit CLI shell scripts: use `--dst-dapp-id` (hyphens), and pass
       a real 64-hex value (not the extended `dapp::acc` form) to the
       flag itself.
-- [ ] If you store contract addresses in a database / config, decide
-      whether to migrate stored values to the extended
-      `dapp::acc` form. Both forms are accepted by the SDK; the
-      extended form is preferred going forward.
+- [ ] If you store contract addresses in a database / config, migrate
+      stored values to the extended `dapp::acc` form. The CLI now
+      requires this form on every command; legacy `0:<hex>` stored
+      values must be converted before use.

--- a/docs/MIGRATION-3.0.md
+++ b/docs/MIGRATION-3.0.md
@@ -1,0 +1,317 @@
+# Migrating to tvm_client / tvm-cli 3.0.0 (dapp_id)
+
+This release adds first-class support for the **dAPP ID** concept in
+the SDK and CLI for Acki Nacki (GraphQL `info.version >= "1.0.0"`).
+The on-the-wire format is selected at runtime, so the SDK keeps talking
+to older nodes — but the public Rust types and several CLI inputs have
+changed. This guide walks you through the migration.
+
+---
+
+## TL;DR
+
+| Old | New |
+|---|---|
+| `ParamsOfGetAccount { address: "0:abc…" }` | `ParamsOfGetAccount { account_id: "abc…", dapp_id: "def…" }` |
+| `ResultOfGetAccount.dapp_id: Option<String>` | `String` (always populated) |
+| `ParamsOfSendMessage.dst_dapp_id: Option<String>` | `dapp_id: String` |
+| `ParamsOfProcessMessage.dst_dapp_id` | `dapp_id: String` |
+| `ResultOfSendMessage` — no account_id/dapp_id | now exposes both (`String`) |
+| `tvm-cli account 0:abc…` (against v3 node) | `tvm-cli account <dapp>::<acc>` |
+| `tvm-cli deploy/deployx` — no flag needed | requires `--dst-dapp-id <hex>` on v3 nodes |
+| `deployed_at: "0:abc…"` | `deployed_at: "<acc>::<acc>"` |
+
+---
+
+## Am I affected?
+
+You are affected if **any** of the following is true:
+
+- You upgrade `tvm_client` or `tvm-cli` to 3.0.0+ from a prior version.
+- You consume the SDK through Rust, Node.js, Python, or any binding
+  that maps to `ParamsOfGetAccount`, `ParamsOfSendMessage`,
+  `ParamsOfProcessMessage`, `ResultOfGetAccount`, or
+  `ResultOfSendMessage`.
+- You drive `tvm-cli account`, `deploy`, `deployx`, `call`, `callx`,
+  `send`, or `message` against a node reporting `info.version >=
+  "1.0.0"` over GraphQL.
+
+You are **not** affected if you only talk to legacy (`< 1.0.0`) nodes
+through the older SDK — the new SDK handles them transparently.
+
+---
+
+## Concepts
+
+A `dapp_id` is a 64-character hex string that identifies of a Decentralized
+Contract System on the Acki Nacki blockchain. This ID is equal to the
+address of the root smart contract, which is deployed using an external
+message. All contracts deployed with internal messages automatically receive
+the same Dapp ID. Whether from the same root contract, or from contracts
+deployed by the root contract. On v3 nodes every contract belongs to exactly
+one dapp, and every external message routed through `/v2/messages` and
+`/v2/account` must carry it.
+
+The SDK introduces an **extended address form**:
+
+```
+<dapp_id_hex64>::<account_id_hex64>
+```
+
+For self-rooted contracts (the common case for `tvm-cli deploy`),
+**`dapp_id == account_id`**, so a self-rooted deployment ends up at
+`<hex>::<hex>` (both halves identical). The `::` separator is what
+distinguishes the new form from the legacy `<wc>:<hex>` form.
+
+---
+
+## Rust SDK migration
+
+### `ParamsOfGetAccount` and `ResultOfGetAccount`
+
+```rust
+// Before:
+let params = ParamsOfGetAccount {
+    address: "0:abc...".to_string(),
+};
+let res = get_account(client, params).await?;
+let dapp_id: Option<String> = res.dapp_id;
+let boc: String = res.boc;
+
+// After:
+let params = ParamsOfGetAccount {
+    account_id: "abc...".to_string(),  // strict 64-hex, no 0x, no wc
+    dapp_id:    "def...".to_string(),  // strict 64-hex; required on v>=1.0.0
+};
+let res = get_account(client, params).await?;
+let account_id: String = res.account_id;  // always populated
+let dapp_id:    String = res.dapp_id;     // always populated
+let boc:        String = res.boc;
+```
+
+Notes:
+- `account_id` and `dapp_id` are validated up front. Pass them as
+  64-character hex with no `0x` and no workchain prefix.
+- On `< 1.0.0` (GraphQL `info.version`) servers, `dapp_id` may be
+  `""` (empty); the SDK skips the field on the wire.
+- On `>= 1.0.0` (GraphQL `info.version`) servers, an empty `dapp_id`
+  produces an error code `518 DappIdRequired`.
+
+### `ParamsOfSendMessage` and `ResultOfSendMessage`
+
+```rust
+// Before:
+let params = ParamsOfSendMessage {
+    message: msg_boc,
+    abi: Some(abi),
+    thread_id: None,
+    send_events: false,
+    dst_dapp_id: Some("def...".into()),
+};
+let res = send_message(client, params, |_| async {}).await?;
+// res had no account_id / dapp_id
+
+// After:
+let params = ParamsOfSendMessage {
+    message: msg_boc,
+    abi: Some(abi),
+    thread_id: None,
+    send_events: false,
+    dapp_id: "def...".to_string(),  // String, not Option<String>
+};
+let res = send_message(client, params, |_| async {}).await?;
+let account_id: String = res.account_id;  // always populated
+let dapp_id:    String = res.dapp_id;     // always populated
+```
+
+For v3-compatible nodes `account_id` and `dapp_id` come from the response;
+for legacy servers they are derived locally (destination address hex / mirrored
+from request). Either way, your downstream code does not need to branch on
+server version.
+
+### `ParamsOfProcessMessage`
+
+```rust
+// Before:
+let params = ParamsOfProcessMessage {
+    message_encode_params,
+    send_events: false,
+    dst_dapp_id: None,
+};
+
+// After:
+let params = ParamsOfProcessMessage {
+    message_encode_params,
+    send_events: false,
+    dapp_id: "def...".to_string(),  // empty string allowed only on v<1.0.0
+};
+```
+
+### New helper API
+
+```rust
+let server_link = context.get_server_link()?;
+server_link.state().get_query_endpoint().await?;       // force resolution
+if context.supports_dapp_id().await? {
+    // server is v>=1.0.0
+}
+```
+
+`supports_dapp_id()` is the recommended way to gate version-conditional
+code in your own application logic.
+
+---
+
+## JS / Python / language-binding migration
+
+Any binding that maps directly to the Rust JSON interface sees the
+same renames at the JSON level:
+
+```diff
+- { "address": "0:abc..." }
++ { "account_id": "abc...", "dapp_id": "def..." }
+
+- { "dst_dapp_id": null }
++ { "dapp_id": "def..." }
+```
+
+If your binding parses `ResultOfGetAccount.dapp_id` as a nullable
+field, change it to a plain string. New non-null `account_id` field
+is always present.
+
+---
+
+## tvm-cli migration
+
+### `account`
+
+The legacy form still works against `< 1.0.0` (GraphQL `info.version`) nodes:
+
+```bash
+tvm-cli account 0:abc...
+```
+
+Against a `>= 1.0.0` (GraphQL `info.version`) node, `account_id` alone is not
+enough — provide the `dapp_id` via the extended form:
+
+```bash
+# Extended form, double-colon (preferred):
+tvm-cli account <dapp_id>::<account_id>
+
+# Single-colon when the dapp portion is 64-hex:
+tvm-cli account <dapp_id>:<account_id>
+```
+
+If you forget the `dapp_id` on a v3-compatible node, the CLI errors with:
+
+```
+address `...` is missing dapp_id; v>=1.0.0 servers require the form
+`dapp_id::account_id` or `dapp_id:account_id`
+```
+
+The output now always shows both `account_id` and `dapp_id` as plain
+fields (JSON `dapp_id` is `null` when the legacy node didn't return one;
+text output prints `None`).
+
+### `deploy` / `deployx`
+
+The CLI flag `--dst-dapp-id` is unchanged in name. It is now **required**
+on `>= 1.0.0` nodes. Examples:
+
+```bash
+# Self-rooted deployment (dapp_id == future account_id): pass all zeros
+tvm-cli deployx \
+  --abi MyContract.abi.json \
+  --keys keys.json \
+  --dst-dapp-id 0000000000000000000000000000000000000000000000000000000000000000 \
+  MyContract.tvc '{...}'
+
+# Deployment into an existing dapp: pass that dapp_id
+tvm-cli deployx \
+  --abi MyContract.abi.json \
+  --keys keys.json \
+  --dst-dapp-id <64-hex-of-existing-dapp> \
+  MyContract.tvc '{...}'
+```
+
+If you forget `--dst-dapp-id` on a v3-compatible node, the CLI errors with:
+
+```
+--dst-dapp-id is required when deploying to a v>=1.0.0 server
+(pass a 64-character hex dapp_id; use all zeros for a self-rooted dapp)
+```
+
+The `deployed_at` field and any saved alias now use the extended
+`dapp_id::account_id` form. For a self-rooted contract both halves are
+identical:
+
+```json
+{ "deployed_at": "abc123...::abc123..." }
+```
+
+### `call`, `callx`, `send`, `message`
+
+If a destination address is passed in the new `dapp_id::account_id`
+form, the dapp_id is automatically extracted and forwarded to the
+SDK. The legacy `--dst-dapp-id` flag is still accepted for backward
+compatibility (it overrides any dapp_id embedded in the address).
+
+```bash
+# New form — dapp_id derived from the address:
+tvm-cli call <dapp>::<acc> --abi ... --method ... '{...}'
+
+# Legacy form with explicit flag (still works):
+tvm-cli call 0:<acc> --abi ... --method ... '{...}' --dst-dapp-id <dapp>
+```
+
+---
+
+## Common pitfalls
+
+### "argument 'X' of type 'Y' not found"
+
+Your CLI flag almost certainly uses underscores instead of hyphens.
+The flag is `--dst-dapp-id`, not `--dst_dapp_id`. With the wrong name,
+clap treats the flag as part of the positional `PARAMS` list and the
+function-argument parser then can't find the next constructor argument.
+
+### "Invalid address [Invalid argument: 0]"
+
+You passed an extended `dapp::acc` address to a code path that goes
+straight to TVM message encoding (e.g. an older version of `runx`).
+Upgrade to a build that includes the fix in `tvm_cli/src/message.rs`;
+it normalizes the address before encoding.
+
+### `518 DappIdRequired`
+
+You sent a message to a `>= 1.0.0` server with an empty `dapp_id`.
+Provide it explicitly (Rust API: set `dapp_id`; CLI: pass
+`--dst-dapp-id` or use the extended address form).
+
+### `ResultOfGetAccount.dapp_id` no longer compiles
+
+The type changed from `Option<String>` to `String`. Remove any
+`.as_deref()`, `.unwrap_or("None")`, or `.is_some()` calls; use the
+field directly. If you need a nullable representation downstream,
+emit `null` when the string is empty.
+
+---
+
+## Quick checklist
+
+- [ ] Replace every `ParamsOfGetAccount { address }` with
+      `{ account_id, dapp_id }`. Strip the `0:` prefix from the input.
+- [ ] Replace every `dst_dapp_id: Option<String>` with
+      `dapp_id: String` in `ParamsOfSendMessage` and
+      `ParamsOfProcessMessage`.
+- [ ] Update consumers of `ResultOfGetAccount.dapp_id` to treat it as
+      `String`.
+- [ ] Update consumers of `ResultOfSendMessage` to read the new
+      `account_id` and `dapp_id` fields if you need them.
+- [ ] Audit CLI shell scripts: use `--dst-dapp-id` (hyphens), and pass
+      a real 64-hex value (not the extended `dapp::acc` form) to the
+      flag itself.
+- [ ] If you store contract addresses in a database / config, decide
+      whether to migrate stored values to the extended
+      `dapp::acc` form. Both forms are accepted by the SDK; the
+      extended form is preferred going forward.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,13 @@
 # Dapp ID Full Guide: creation, fees, centralized replenishment
 
+{% hint style="info" %}
+**Upgrading from `tvm_client` / `tvm-cli` 2.x?** See the
+[3.0.0 migration guide](MIGRATION-3.0.md) for breaking changes in the
+SDK types and CLI inputs (renamed `address` → `account_id`,
+`dst_dapp_id` → `dapp_id`, the extended `dapp_id::account_id` address
+form, and required `--dst-dapp-id` on deploy commands against v3 nodes).
+{% endhint %}
+
 ## **What will you learn from this guide?** <a href="#prerequisites" id="prerequisites"></a>
 
 * How to create your [Dapp ID](https://docs.ackinacki.com/glossary#dapp-id)

--- a/docs/acki-nacki-sdk/types-and-methods/README.md
+++ b/docs/acki-nacki-sdk/types-and-methods/README.md
@@ -1,14 +1,15 @@
-# Core Library Reference
+# Types and Methods
 
-This section contains documents describing TVM SDK Types and Methods supported by various [modules](modules.md).
+This section contains documents describing TON SDK Types and Methods supported by various [modules](modules.md).
 
-* [Module abi](mod_abi.md)
-* [Module boc](mod_boc.md)
-* [Module client](mod_client.md)
-* [Module crypto](mod_crypto.md)
-* [Module debot](mod_debot.md)
-* [Module net](mod_net.md)
-* [Module processing](mod_processing.md)
-* [Module proofs](mod_proofs.md)
-* [Module tvm](mod_tvm.md)
-* [Module utils](mod_utils.md)
+* [Module abi](mod\_abi.md)
+* [Module account](mod\_account.md)
+* [Module boc](mod\_boc.md)
+* [Module client](mod\_client.md)
+* [Module crypto](mod\_crypto.md)
+* [Module debot](mod\_debot.md)
+* [Module net](mod\_net.md)
+* [Module processing](mod\_processing.md)
+* [Module proofs](mod\_proofs.md)
+* [Module tvm](mod\_tvm.md)
+* [Module utils](mod\_utils.md)

--- a/docs/acki-nacki-sdk/types-and-methods/mod_abi.md
+++ b/docs/acki-nacki-sdk/types-and-methods/mod_abi.md
@@ -1,154 +1,151 @@
 # Module abi
 
-## Module abi
-
 Provides message encoding and decoding according to the ABI specification.
 
-### Functions
-
-[encode\_message\_body](mod_abi.md#encode_message_body) – Encodes message body according to ABI function call.
-
-[attach\_signature\_to\_message\_body](mod_abi.md#attach_signature_to_message_body)
-
-[encode\_message](mod_abi.md#encode_message) – Encodes an ABI-compatible message
-
-[encode\_internal\_message](mod_abi.md#encode_internal_message) – Encodes an internal ABI-compatible message
-
-[attach\_signature](mod_abi.md#attach_signature) – Combines `hex`-encoded `signature` with `base64`-encoded `unsigned_message`. Returns signed message encoded in `base64`.
-
-[decode\_message](mod_abi.md#decode_message) – Decodes message body using provided message BOC and ABI.
-
-[decode\_message\_body](mod_abi.md#decode_message_body) – Decodes message body using provided body BOC and ABI.
-
-[encode\_account](mod_abi.md#encode_account) – Creates account state BOC
-
-[decode\_account\_data](mod_abi.md#decode_account_data) – Decodes account data using provided data BOC and ABI.
-
-[update\_initial\_data](mod_abi.md#update_initial_data) – Updates initial account data with initial values for the contract's static variables and owner's public key. This operation is applicable only for initial account data (before deploy). If the contract is already deployed, its data doesn't contain this data section any more.
-
-[encode\_initial\_data](mod_abi.md#encode_initial_data) – Encodes initial account data with initial values for the contract's static variables and owner's public key into a data BOC that can be passed to `encode_tvc` function afterwards.
-
-[decode\_initial\_data](mod_abi.md#decode_initial_data) – Decodes initial values of a contract's static variables and owner's public key from account initial data This operation is applicable only for initial account data (before deploy). If the contract is already deployed, its data doesn't contain this data section any more.
-
-[decode\_boc](mod_abi.md#decode_boc) – Decodes BOC into JSON as a set of provided parameters.
-
-[encode\_boc](mod_abi.md#encode_boc) – Encodes given parameters in JSON into a BOC using param types from ABI.
-
-[calc\_function\_id](mod_abi.md#calc_function_id) – Calculates contract function ID by contract ABI
-
-[get\_signature\_data](mod_abi.md#get_signature_data) – Extracts signature from message body and calculates hash to verify the signature
-
-### Types
-
-[AbiErrorCode](mod_abi.md#abierrorcode)
-
-[AbiContractVariant](mod_abi.md#abicontractvariant)
-
-[AbiJsonVariant](mod_abi.md#abijsonvariant)
-
-[AbiHandleVariant](mod_abi.md#abihandlevariant)
-
-[AbiSerializedVariant](mod_abi.md#abiserializedvariant)
-
-[Abi](mod_abi.md#abi)
-
-[AbiHandle](mod_abi.md#abihandle)
-
-[FunctionHeader](mod_abi.md#functionheader) – The ABI function header.
-
-[CallSet](mod_abi.md#callset)
-
-[DeploySet](mod_abi.md#deployset)
-
-[SignerNoneVariant](mod_abi.md#signernonevariant) – No keys are provided.
-
-[SignerExternalVariant](mod_abi.md#signerexternalvariant) – Only public key is provided in unprefixed hex string format to generate unsigned message and `data_to_sign` which can be signed later.
-
-[SignerKeysVariant](mod_abi.md#signerkeysvariant) – Key pair is provided for signing
-
-[SignerSigningBoxVariant](mod_abi.md#signersigningboxvariant) – Signing Box interface is provided for signing, allows Dapps to sign messages using external APIs, such as HSM, cold wallet, etc.
-
-[Signer](mod_abi.md#signer)
-
-[MessageBodyType](mod_abi.md#messagebodytype)
-
-[AbiParam](mod_abi.md#abiparam)
-
-[AbiEvent](mod_abi.md#abievent)
-
-[AbiData](mod_abi.md#abidata)
-
-[AbiFunction](mod_abi.md#abifunction)
-
-[AbiContract](mod_abi.md#abicontract)
-
-[DataLayout](mod_abi.md#datalayout)
-
-[ParamsOfEncodeMessageBody](mod_abi.md#paramsofencodemessagebody)
-
-[ResultOfEncodeMessageBody](mod_abi.md#resultofencodemessagebody)
-
-[ParamsOfAttachSignatureToMessageBody](mod_abi.md#paramsofattachsignaturetomessagebody)
-
-[ResultOfAttachSignatureToMessageBody](mod_abi.md#resultofattachsignaturetomessagebody)
-
-[ParamsOfEncodeMessage](mod_abi.md#paramsofencodemessage)
-
-[ResultOfEncodeMessage](mod_abi.md#resultofencodemessage)
-
-[ParamsOfEncodeInternalMessage](mod_abi.md#paramsofencodeinternalmessage)
-
-[ResultOfEncodeInternalMessage](mod_abi.md#resultofencodeinternalmessage)
-
-[ParamsOfAttachSignature](mod_abi.md#paramsofattachsignature)
-
-[ResultOfAttachSignature](mod_abi.md#resultofattachsignature)
-
-[ParamsOfDecodeMessage](mod_abi.md#paramsofdecodemessage)
-
-[DecodedMessageBody](mod_abi.md#decodedmessagebody)
-
-[ParamsOfDecodeMessageBody](mod_abi.md#paramsofdecodemessagebody)
-
-[ParamsOfEncodeAccount](mod_abi.md#paramsofencodeaccount)
-
-[ResultOfEncodeAccount](mod_abi.md#resultofencodeaccount)
-
-[ParamsOfDecodeAccountData](mod_abi.md#paramsofdecodeaccountdata)
-
-[ResultOfDecodeAccountData](mod_abi.md#resultofdecodeaccountdata)
-
-[ParamsOfUpdateInitialData](mod_abi.md#paramsofupdateinitialdata)
-
-[ResultOfUpdateInitialData](mod_abi.md#resultofupdateinitialdata)
-
-[ParamsOfEncodeInitialData](mod_abi.md#paramsofencodeinitialdata)
-
-[ResultOfEncodeInitialData](mod_abi.md#resultofencodeinitialdata)
-
-[ParamsOfDecodeInitialData](mod_abi.md#paramsofdecodeinitialdata)
-
-[ResultOfDecodeInitialData](mod_abi.md#resultofdecodeinitialdata)
-
-[ParamsOfDecodeBoc](mod_abi.md#paramsofdecodeboc)
-
-[ResultOfDecodeBoc](mod_abi.md#resultofdecodeboc)
-
-[ParamsOfAbiEncodeBoc](mod_abi.md#paramsofabiencodeboc)
-
-[ResultOfAbiEncodeBoc](mod_abi.md#resultofabiencodeboc)
-
-[ParamsOfCalcFunctionId](mod_abi.md#paramsofcalcfunctionid)
-
-[ResultOfCalcFunctionId](mod_abi.md#resultofcalcfunctionid)
-
-[ParamsOfGetSignatureData](mod_abi.md#paramsofgetsignaturedata)
-
-[ResultOfGetSignatureData](mod_abi.md#resultofgetsignaturedata)
 
 ## Functions
+[encode_message_body](mod\_abi.md#encode_message_body) – Encodes message body according to ABI function call.
 
-### encode\_message\_body
+[attach_signature_to_message_body](mod\_abi.md#attach_signature_to_message_body) – Attach signature
+
+[encode_message](mod\_abi.md#encode_message) – Encodes an ABI-compatible message
+
+[encode_internal_message](mod\_abi.md#encode_internal_message) – Encodes an internal ABI-compatible message
+
+[attach_signature](mod\_abi.md#attach_signature) – Combines `hex`-encoded `signature` with `base64`-encoded `unsigned_message`. Returns signed message encoded in `base64`.
+
+[decode_message](mod\_abi.md#decode_message) – Decodes message body using provided message BOC and ABI.
+
+[decode_message_body](mod\_abi.md#decode_message_body) – Decodes message body using provided body BOC and ABI.
+
+[encode_account](mod\_abi.md#encode_account) – Creates account state BOC
+
+[decode_account_data](mod\_abi.md#decode_account_data) – Decodes account data using provided data BOC and ABI.
+
+[update_initial_data](mod\_abi.md#update_initial_data) – Updates initial account data with initial values for the contract's static variables and owner's public key.
+
+[encode_initial_data](mod\_abi.md#encode_initial_data) – Encodes initial account data with initial values for the contract's static variables and owner's public key into a data BOC that can be passed to `encode_tvc` function afterwards.
+
+[decode_initial_data](mod\_abi.md#decode_initial_data) – Decodes initial values of a contract's static variables and owner's public key from account initial data This operation is applicable only for initial account data (before deploy).
+
+[decode_boc](mod\_abi.md#decode_boc) – Decodes BOC into JSON as a set of provided parameters.
+
+[encode_boc](mod\_abi.md#encode_boc) – Encodes given parameters in JSON into a BOC using param types from ABI.
+
+[calc_function_id](mod\_abi.md#calc_function_id) – Calculates contract function ID by contract ABI
+
+[get_signature_data](mod\_abi.md#get_signature_data) – Extracts signature from message body and calculates hash to verify the signature
+
+## Types
+[AbiErrorCode](mod\_abi.md#abierrorcode)
+
+[AbiContractVariant](mod\_abi.md#abicontractvariant)
+
+[AbiJsonVariant](mod\_abi.md#abijsonvariant)
+
+[AbiHandleVariant](mod\_abi.md#abihandlevariant)
+
+[AbiSerializedVariant](mod\_abi.md#abiserializedvariant)
+
+[Abi](mod\_abi.md#abi)
+
+[AbiHandle](mod\_abi.md#abihandle)
+
+[FunctionHeader](mod\_abi.md#functionheader) – The ABI function header.
+
+[CallSet](mod\_abi.md#callset)
+
+[DeploySet](mod\_abi.md#deployset)
+
+[SignerNoneVariant](mod\_abi.md#signernonevariant) – No keys are provided.
+
+[SignerExternalVariant](mod\_abi.md#signerexternalvariant) – Only public key is provided in unprefixed hex string format to generate unsigned message and `data_to_sign` which can be signed later.
+
+[SignerKeysVariant](mod\_abi.md#signerkeysvariant) – Key pair is provided for signing
+
+[SignerSigningBoxVariant](mod\_abi.md#signersigningboxvariant) – Signing Box interface is provided for signing, allows Dapps to sign messages using external APIs, such as HSM, cold wallet, etc.
+
+[Signer](mod\_abi.md#signer)
+
+[MessageBodyType](mod\_abi.md#messagebodytype)
+
+[AbiParam](mod\_abi.md#abiparam)
+
+[AbiEvent](mod\_abi.md#abievent)
+
+[AbiData](mod\_abi.md#abidata)
+
+[AbiFunction](mod\_abi.md#abifunction)
+
+[AbiContract](mod\_abi.md#abicontract)
+
+[DataLayout](mod\_abi.md#datalayout)
+
+[ParamsOfEncodeMessageBody](mod\_abi.md#paramsofencodemessagebody)
+
+[ResultOfEncodeMessageBody](mod\_abi.md#resultofencodemessagebody)
+
+[ParamsOfAttachSignatureToMessageBody](mod\_abi.md#paramsofattachsignaturetomessagebody)
+
+[ResultOfAttachSignatureToMessageBody](mod\_abi.md#resultofattachsignaturetomessagebody)
+
+[ParamsOfEncodeMessage](mod\_abi.md#paramsofencodemessage)
+
+[ResultOfEncodeMessage](mod\_abi.md#resultofencodemessage)
+
+[ParamsOfEncodeInternalMessage](mod\_abi.md#paramsofencodeinternalmessage)
+
+[ResultOfEncodeInternalMessage](mod\_abi.md#resultofencodeinternalmessage)
+
+[ParamsOfAttachSignature](mod\_abi.md#paramsofattachsignature)
+
+[ResultOfAttachSignature](mod\_abi.md#resultofattachsignature)
+
+[ParamsOfDecodeMessage](mod\_abi.md#paramsofdecodemessage)
+
+[DecodedMessageBody](mod\_abi.md#decodedmessagebody)
+
+[ParamsOfDecodeMessageBody](mod\_abi.md#paramsofdecodemessagebody)
+
+[ParamsOfEncodeAccount](mod\_abi.md#paramsofencodeaccount)
+
+[ResultOfEncodeAccount](mod\_abi.md#resultofencodeaccount)
+
+[ParamsOfDecodeAccountData](mod\_abi.md#paramsofdecodeaccountdata)
+
+[ResultOfDecodeAccountData](mod\_abi.md#resultofdecodeaccountdata)
+
+[ParamsOfUpdateInitialData](mod\_abi.md#paramsofupdateinitialdata)
+
+[ResultOfUpdateInitialData](mod\_abi.md#resultofupdateinitialdata)
+
+[ParamsOfEncodeInitialData](mod\_abi.md#paramsofencodeinitialdata)
+
+[ResultOfEncodeInitialData](mod\_abi.md#resultofencodeinitialdata)
+
+[ParamsOfDecodeInitialData](mod\_abi.md#paramsofdecodeinitialdata)
+
+[ResultOfDecodeInitialData](mod\_abi.md#resultofdecodeinitialdata)
+
+[ParamsOfDecodeBoc](mod\_abi.md#paramsofdecodeboc)
+
+[ResultOfDecodeBoc](mod\_abi.md#resultofdecodeboc)
+
+[ParamsOfAbiEncodeBoc](mod\_abi.md#paramsofabiencodeboc)
+
+[ResultOfAbiEncodeBoc](mod\_abi.md#resultofabiencodeboc)
+
+[ParamsOfCalcFunctionId](mod\_abi.md#paramsofcalcfunctionid)
+
+[ResultOfCalcFunctionId](mod\_abi.md#resultofcalcfunctionid)
+
+[ParamsOfGetSignatureData](mod\_abi.md#paramsofgetsignaturedata)
+
+[ResultOfGetSignatureData](mod\_abi.md#resultofgetsignaturedata)
+
+
+# Functions
+## encode_message_body
 
 Encodes message body according to ABI function call.
 
@@ -176,43 +173,30 @@ function encode_message_body_sync(
     params: ParamsOfEncodeMessageBody,
 ): ResultOfEncodeMessageBody;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `abi`: _[Abi](mod\_abi.md#abi)_ – Contract ABI.
+- `call_set`: _[CallSet](mod\_abi.md#callset)_ – Function call parameters.
+<br>Must be specified in non deploy message.<br><br>In case of deploy message contains parameters of constructor.
+- `is_internal`: _boolean_ – True if internal message body must be encoded.
+- `signer`: _[Signer](mod\_abi.md#signer)_ – Signing parameters.
+- `processing_try_index`?: _number_ – Processing try index.
+<br>Used in message processing with retries.<br><br>Encoder uses the provided try index to calculate message<br>expiration time.<br><br>Expiration timeouts will grow with every retry.<br><br>Default value is 0.
+- `address`?: _string_ – Destination address of the message
+<br>Since ABI version 2.3 destination address of external inbound message is<br>used in message body signature calculation. Should be provided when<br>signed external inbound message body is created. Otherwise can be<br>omitted.
+- `signature_id`?: _number_ – Signature ID to be used in data to sign preparing when CapSignatureWithId capability is enabled
 
-#### Parameters
 
-* `abi`: [_Abi_](mod_abi.md#abi) – Contract ABI.
-* `call_set`: [_CallSet_](mod_abi.md#callset) – Function call parameters.\
-  Must be specified in non deploy message.\
-  \
-  In case of deploy message contains parameters of constructor.
-* `is_internal`: _boolean_ – True if internal message body must be encoded.
-* `signer`: [_Signer_](mod_abi.md#signer) – Signing parameters.
-* `processing_try_index`?: _number_ – Processing try index.\
-  Used in message processing with retries.\
-  \
-  Encoder uses the provided try index to calculate message\
-  expiration time.\
-  \
-  Expiration timeouts will grow with every retry.\
-  \
-  Default value is 0.
-* `address`?: _string_ – Destination address of the message\
-  Since ABI version 2.3 destination address of external inbound message is used in message\
-  body signature calculation. Should be provided when signed external inbound message body is\
-  created. Otherwise can be omitted.
-* `signature_id`?: _number_ – Signature ID to be used in data to sign preparing when CapSignatureWithId capability is enabled
+### Result
 
-#### Result
+- `body`: _string_ – Message body BOC encoded with `base64`.
+- `data_to_sign`?: _string_ – Optional data to sign.
+<br>Encoded with `base64`. <br>Presents when `message` is unsigned. Can be used for external<br>message signing. Is this case you need to sing this data and<br>produce signed message using `abi.attach_signature`.
 
-* `body`: _string_ – Message body BOC encoded with `base64`.
-* `data_to_sign`?: _string_ – Optional data to sign.\
-  Encoded with `base64`.\
-  Presents when `message` is unsigned. Can be used for external\
-  message signing. Is this case you need to sing this data and\
-  produce signed message using `abi.attach_signature`.
 
-### attach\_signature\_to\_message\_body
+## attach_signature_to_message_body
+
+Attach signature
 
 ```ts
 type ParamsOfAttachSignatureToMessageBody = {
@@ -234,49 +218,55 @@ function attach_signature_to_message_body_sync(
     params: ParamsOfAttachSignatureToMessageBody,
 ): ResultOfAttachSignatureToMessageBody;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `abi`: _[Abi](mod\_abi.md#abi)_ – Contract ABI
+- `public_key`: _string_ – Public key.
+<br>Must be encoded with `hex`.
+- `message`: _string_ – Unsigned message body BOC.
+<br>Must be encoded with `base64`.
+- `signature`: _string_ – Signature.
+<br>Must be encoded with `hex`.
 
-#### Parameters
 
-* `abi`: [_Abi_](mod_abi.md#abi) – Contract ABI
-* `public_key`: _string_ – Public key.\
-  Must be encoded with `hex`.
-* `message`: _string_ – Unsigned message body BOC.\
-  Must be encoded with `base64`.
-* `signature`: _string_ – Signature.\
-  Must be encoded with `hex`.
+### Result
 
-#### Result
+- `body`: _string_
 
-* `body`: _string_
 
-### encode\_message
+## encode_message
 
 Encodes an ABI-compatible message
 
-Allows to encode deploy and function call messages, both signed and unsigned.
+Allows to encode deploy and function call messages,
+both signed and unsigned.
 
 Use cases include messages of any possible type:
-
-* deploy with initial function call (i.e. `constructor` or any other function that is used for some kind of initialization);
-* deploy without initial function call;
-* signed/unsigned + data for signing.
+- deploy with initial function call (i.e. `constructor` or any other
+  function that is used for some kind
+of initialization);
+- deploy without initial function call;
+- signed/unsigned + data for signing.
 
 `Signer` defines how the message should or shouldn't be signed:
 
-`Signer::None` creates an unsigned message. This may be needed in case of some public methods, that do not require authorization by pubkey.
+`Signer::None` creates an unsigned message. This may be needed in case of
+some public methods, that do not require authorization by pubkey.
 
-`Signer::External` takes public key and returns `data_to_sign` for later signing. Use `attach_signature` method with the result signature to get the signed message.
+`Signer::External` takes public key and returns `data_to_sign` for later
+signing. Use `attach_signature` method with the result signature to get the
+signed message.
 
 `Signer::Keys` creates a signed message with provided key pair.
 
-\[SOON] `Signer::SigningBox` Allows using a special interface to implement signing without private key disclosure to SDK. For instance, in case of using a cold wallet or HSM, when application calls some API to sign data.
+[SOON] `Signer::SigningBox` Allows using a special interface to implement
+signing without private key disclosure to SDK. For instance, in case of
+using a cold wallet or HSM, when application calls some API to sign data.
 
-There is an optional public key can be provided in deploy set in order to substitute one in TVM file.
+There is an optional public key can be provided in deploy set in order to
+substitute one in TVM file.
 
 Public key resolving priority:
-
 1. Public key from deploy set.
 2. Public key, specified in TVM file.
 3. Public key, provided by signer.
@@ -307,62 +297,47 @@ function encode_message_sync(
     params: ParamsOfEncodeMessage,
 ): ResultOfEncodeMessage;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `abi`: _[Abi](mod\_abi.md#abi)_ – Contract ABI.
+- `address`?: _string_ – Target address the message will be sent to.
+<br>Must be specified in case of non-deploy message.
+- `deploy_set`?: _[DeploySet](mod\_abi.md#deployset)_ – Deploy parameters.
+<br>Must be specified in case of deploy message.
+- `call_set`?: _[CallSet](mod\_abi.md#callset)_ – Function call parameters.
+<br>Must be specified in case of non-deploy message.<br><br>In case of deploy message it is optional and contains parameters<br>of the functions that will to be called upon deploy transaction.
+- `signer`: _[Signer](mod\_abi.md#signer)_ – Signing parameters.
+- `processing_try_index`?: _number_ – Processing try index.
+<br>Used in message processing with retries (if contract's ABI includes<br>"expire" header).<br><br>Encoder uses the provided try index to calculate message<br>expiration time. The 1st message expiration time is specified in<br>Client config.<br><br>Expiration timeouts will grow with every retry.<br>Retry grow factor is set in Client config:<br><.....add config parameter with default value here><br><br>Default value is 0.
+- `signature_id`?: _number_ – Signature ID to be used in data to sign preparing when CapSignatureWithId capability is enabled
 
-#### Parameters
 
-* `abi`: [_Abi_](mod_abi.md#abi) – Contract ABI.
-* `address`?: _string_ – Target address the message will be sent to.\
-  Must be specified in case of non-deploy message.
-* `deploy_set`?: [_DeploySet_](mod_abi.md#deployset) – Deploy parameters.\
-  Must be specified in case of deploy message.
-* `call_set`?: [_CallSet_](mod_abi.md#callset) – Function call parameters.\
-  Must be specified in case of non-deploy message.\
-  \
-  In case of deploy message it is optional and contains parameters\
-  of the functions that will to be called upon deploy transaction.
-* `signer`: [_Signer_](mod_abi.md#signer) – Signing parameters.
-* `processing_try_index`?: _number_ – Processing try index.\
-  Used in message processing with retries (if contract's ABI includes "expire" header).\
-  \
-  Encoder uses the provided try index to calculate message\
-  expiration time. The 1st message expiration time is specified in\
-  Client config.\
-  \
-  Expiration timeouts will grow with every retry.\
-  Retry grow factor is set in Client config:\
-  <.....add config parameter with default value here>\
-  \
-  Default value is 0.
-* `signature_id`?: _number_ – Signature ID to be used in data to sign preparing when CapSignatureWithId capability is enabled
+### Result
 
-#### Result
+- `message`: _string_ – Message BOC encoded with `base64`.
+- `data_to_sign`?: _string_ – Optional data to be signed encoded in `base64`.
+<br>Returned in case of `Signer::External`. Can be used for external<br>message signing. Is this case you need to use this data to create<br>signature and then produce signed message using<br>`abi.attach_signature`.
+- `address`: _string_ – Destination address.
+- `message_id`: _string_ – Message id.
 
-* `message`: _string_ – Message BOC encoded with `base64`.
-* `data_to_sign`?: _string_ – Optional data to be signed encoded in `base64`.\
-  Returned in case of `Signer::External`. Can be used for external\
-  message signing. Is this case you need to use this data to create signature and\
-  then produce signed message using `abi.attach_signature`.
-* `address`: _string_ – Destination address.
-* `message_id`: _string_ – Message id.
 
-### encode\_internal\_message
+## encode_internal_message
 
 Encodes an internal ABI-compatible message
 
 Allows to encode deploy and function call messages.
 
 Use cases include messages of any possible type:
+- deploy with initial function call (i.e. `constructor` or any other
+  function that is used for some kind
+of initialization);
+- deploy without initial function call;
+- simple function call
 
-* deploy with initial function call (i.e. `constructor` or any other function that is used for some kind of initialization);
-* deploy without initial function call;
-* simple function call
-
-There is an optional public key can be provided in deploy set in order to substitute one in TVM file.
+There is an optional public key can be provided in deploy set in order to
+substitute one in TVM file.
 
 Public key resolving priority:
-
 1. Public key from deploy set.
 2. Public key, specified in TVM file.
 
@@ -392,36 +367,32 @@ function encode_internal_message_sync(
     params: ParamsOfEncodeInternalMessage,
 ): ResultOfEncodeInternalMessage;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `abi`?: _[Abi](mod\_abi.md#abi)_ – Contract ABI.
+<br>Can be None if both deploy_set and call_set are None.
+- `address`?: _string_ – Target address the message will be sent to.
+<br>Must be specified in case of non-deploy message.
+- `src_address`?: _string_ – Source address of the message.
+- `deploy_set`?: _[DeploySet](mod\_abi.md#deployset)_ – Deploy parameters.
+<br>Must be specified in case of deploy message.
+- `call_set`?: _[CallSet](mod\_abi.md#callset)_ – Function call parameters.
+<br>Must be specified in case of non-deploy message.<br><br>In case of deploy message it is optional and contains parameters<br>of the functions that will to be called upon deploy transaction.
+- `value`: _string_ – Value in nanotokens to be sent with message.
+- `bounce`?: _boolean_ – Flag of bounceable message.
+<br>Default is true.
+- `enable_ihr`?: _boolean_ – Enable Instant Hypercube Routing for the message.
+<br>Default is false.
 
-#### Parameters
 
-* `abi`?: [_Abi_](mod_abi.md#abi) – Contract ABI.\
-  Can be None if both deploy\_set and call\_set are None.
-* `address`?: _string_ – Target address the message will be sent to.\
-  Must be specified in case of non-deploy message.
-* `src_address`?: _string_ – Source address of the message.
-* `deploy_set`?: [_DeploySet_](mod_abi.md#deployset) – Deploy parameters.\
-  Must be specified in case of deploy message.
-* `call_set`?: [_CallSet_](mod_abi.md#callset) – Function call parameters.\
-  Must be specified in case of non-deploy message.\
-  \
-  In case of deploy message it is optional and contains parameters\
-  of the functions that will to be called upon deploy transaction.
-* `value`: _string_ – Value in nanotokens to be sent with message.
-* `bounce`?: _boolean_ – Flag of bounceable message.\
-  Default is true.
-* `enable_ihr`?: _boolean_ – Enable Instant Hypercube Routing for the message.\
-  Default is false.
+### Result
 
-#### Result
+- `message`: _string_ – Message BOC encoded with `base64`.
+- `address`: _string_ – Destination address.
+- `message_id`: _string_ – Message id.
 
-* `message`: _string_ – Message BOC encoded with `base64`.
-* `address`: _string_ – Destination address.
-* `message_id`: _string_ – Message id.
 
-### attach\_signature
+## attach_signature
 
 Combines `hex`-encoded `signature` with `base64`-encoded `unsigned_message`. Returns signed message encoded in `base64`.
 
@@ -446,22 +417,21 @@ function attach_signature_sync(
     params: ParamsOfAttachSignature,
 ): ResultOfAttachSignature;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `abi`: _[Abi](mod\_abi.md#abi)_ – Contract ABI
+- `public_key`: _string_ – Public key encoded in `hex`.
+- `message`: _string_ – Unsigned message BOC encoded in `base64`.
+- `signature`: _string_ – Signature encoded in `hex`.
 
-#### Parameters
 
-* `abi`: [_Abi_](mod_abi.md#abi) – Contract ABI
-* `public_key`: _string_ – Public key encoded in `hex`.
-* `message`: _string_ – Unsigned message BOC encoded in `base64`.
-* `signature`: _string_ – Signature encoded in `hex`.
+### Result
 
-#### Result
+- `message`: _string_ – Signed message BOC
+- `message_id`: _string_ – Message ID
 
-* `message`: _string_ – Signed message BOC
-* `message_id`: _string_ – Message ID
 
-### decode\_message
+## decode_message
 
 Decodes message body using provided message BOC and ABI.
 
@@ -489,25 +459,25 @@ function decode_message_sync(
     params: ParamsOfDecodeMessage,
 ): DecodedMessageBody;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `abi`: _[Abi](mod\_abi.md#abi)_ – contract ABI
+- `message`: _string_ – Message BOC
+- `allow_partial`?: _boolean_ – Flag allowing partial BOC decoding when ABI doesn't describe the full body BOC.
+<br>Controls decoder behaviour when after decoding all described in ABI params there are some data left in BOC:<br>`true` - return decoded values<br>`false` - return error of incomplete BOC deserialization (default)
+- `function_name`?: _string_ – Function name or function id if is known in advance
+- `data_layout`?: _[DataLayout](mod\_abi.md#datalayout)_
 
-#### Parameters
 
-* `abi`: [_Abi_](mod_abi.md#abi) – contract ABI
-* `message`: _string_ – Message BOC
-* `allow_partial`?: _boolean_ – Flag allowing partial BOC decoding when ABI doesn't describe the full body BOC. Controls decoder behaviour when after decoding all described in ABI params there are some data left in BOC: `true` - return decoded values `false` - return error of incomplete BOC deserialization (default)
-* `function_name`?: _string_ – Function name or function id if is known in advance
-* `data_layout`?: [_DataLayout_](mod_abi.md#datalayout)
+### Result
 
-#### Result
+- `body_type`: _[MessageBodyType](mod\_abi.md#messagebodytype)_ – Type of the message body content.
+- `name`: _string_ – Function or event name.
+- `value`?: _any_ – Parameters or result value.
+- `header`?: _[FunctionHeader](mod\_abi.md#functionheader)_ – Function header.
 
-* `body_type`: [_MessageBodyType_](mod_abi.md#messagebodytype) – Type of the message body content.
-* `name`: _string_ – Function or event name.
-* `value`?: _any_ – Parameters or result value.
-* `header`?: [_FunctionHeader_](mod_abi.md#functionheader) – Function header.
 
-### decode\_message\_body
+## decode_message_body
 
 Decodes message body using provided body BOC and ABI.
 
@@ -536,26 +506,26 @@ function decode_message_body_sync(
     params: ParamsOfDecodeMessageBody,
 ): DecodedMessageBody;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `abi`: _[Abi](mod\_abi.md#abi)_ – Contract ABI used to decode.
+- `body`: _string_ – Message body BOC encoded in `base64`.
+- `is_internal`: _boolean_ – True if the body belongs to the internal message.
+- `allow_partial`?: _boolean_ – Flag allowing partial BOC decoding when ABI doesn't describe the full body BOC.
+<br>Controls decoder behaviour when after decoding all described in ABI params there are some data left in BOC:<br>`true` - return decoded values<br>`false` - return error of incomplete BOC deserialization (default)
+- `function_name`?: _string_ – Function name or function id if is known in advance
+- `data_layout`?: _[DataLayout](mod\_abi.md#datalayout)_
 
-#### Parameters
 
-* `abi`: [_Abi_](mod_abi.md#abi) – Contract ABI used to decode.
-* `body`: _string_ – Message body BOC encoded in `base64`.
-* `is_internal`: _boolean_ – True if the body belongs to the internal message.
-* `allow_partial`?: _boolean_ – Flag allowing partial BOC decoding when ABI doesn't describe the full body BOC. Controls decoder behaviour when after decoding all described in ABI params there are some data left in BOC: `true` - return decoded values `false` - return error of incomplete BOC deserialization (default)
-* `function_name`?: _string_ – Function name or function id if is known in advance
-* `data_layout`?: [_DataLayout_](mod_abi.md#datalayout)
+### Result
 
-#### Result
+- `body_type`: _[MessageBodyType](mod\_abi.md#messagebodytype)_ – Type of the message body content.
+- `name`: _string_ – Function or event name.
+- `value`?: _any_ – Parameters or result value.
+- `header`?: _[FunctionHeader](mod\_abi.md#functionheader)_ – Function header.
 
-* `body_type`: [_MessageBodyType_](mod_abi.md#messagebodytype) – Type of the message body content.
-* `name`: _string_ – Function or event name.
-* `value`?: _any_ – Parameters or result value.
-* `header`?: [_FunctionHeader_](mod_abi.md#functionheader) – Function header.
 
-### encode\_account
+## encode_account
 
 Creates account state BOC
 
@@ -581,24 +551,23 @@ function encode_account_sync(
     params: ParamsOfEncodeAccount,
 ): ResultOfEncodeAccount;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `state_init`: _string_ – Account state init.
+- `balance`?: _bigint_ – Initial balance.
+- `last_trans_lt`?: _bigint_ – Initial value for the `last_trans_lt`.
+- `last_paid`?: _number_ – Initial value for the `last_paid`.
+- `boc_cache`?: _[BocCacheType](mod\_boc.md#boccachetype)_ – Cache type to put the result.
+<br>The BOC itself returned if no cache type provided
 
-#### Parameters
 
-* `state_init`: _string_ – Account state init.
-* `balance`?: _bigint_ – Initial balance.
-* `last_trans_lt`?: _bigint_ – Initial value for the `last_trans_lt`.
-* `last_paid`?: _number_ – Initial value for the `last_paid`.
-* `boc_cache`?: [_BocCacheType_](mod_boc.md#boccachetype) – Cache type to put the result.\
-  The BOC itself returned if no cache type provided
+### Result
 
-#### Result
+- `account`: _string_ – Account BOC encoded in `base64`.
+- `id`: _string_ – Account ID  encoded in `hex`.
 
-* `account`: _string_ – Account BOC encoded in `base64`.
-* `id`: _string_ – Account ID encoded in `hex`.
 
-### decode\_account\_data
+## decode_account_data
 
 Decodes account data using provided data BOC and ABI.
 
@@ -623,22 +592,25 @@ function decode_account_data_sync(
     params: ParamsOfDecodeAccountData,
 ): ResultOfDecodeAccountData;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `abi`: _[Abi](mod\_abi.md#abi)_ – Contract ABI
+- `data`: _string_ – Data BOC or BOC handle
+- `allow_partial`?: _boolean_ – Flag allowing partial BOC decoding when ABI doesn't describe the full body BOC.
+<br>Controls decoder behaviour when after decoding all described in ABI params there are some data left in BOC:<br>`true` - return decoded values<br>`false` - return error of incomplete BOC deserialization (default)
 
-#### Parameters
 
-* `abi`: [_Abi_](mod_abi.md#abi) – Contract ABI
-* `data`: _string_ – Data BOC or BOC handle
-* `allow_partial`?: _boolean_ – Flag allowing partial BOC decoding when ABI doesn't describe the full body BOC. Controls decoder behaviour when after decoding all described in ABI params there are some data left in BOC: `true` - return decoded values `false` - return error of incomplete BOC deserialization (default)
+### Result
 
-#### Result
+- `data`: _any_ – Decoded data as a JSON structure.
 
-* `data`: _any_ – Decoded data as a JSON structure.
 
-### update\_initial\_data
+## update_initial_data
 
-Updates initial account data with initial values for the contract's static variables and owner's public key. This operation is applicable only for initial account data (before deploy). If the contract is already deployed, its data doesn't contain this data section any more.
+Updates initial account data with initial values for the contract's static variables and owner's public key.
+
+This operation is applicable only for initial account data (before deploy). If the contract is already deployed,
+its data doesn't contain this data section any more.
 
 Doesn't support ABI version >= 2.4. Use `encode_initial_data` instead
 
@@ -663,23 +635,22 @@ function update_initial_data_sync(
     params: ParamsOfUpdateInitialData,
 ): ResultOfUpdateInitialData;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `abi`: _[Abi](mod\_abi.md#abi)_ – Contract ABI
+- `data`: _string_ – Data BOC or BOC handle
+- `initial_data`?: _any_ – List of initial values for contract's static variables.
+<br>`abi` parameter should be provided to set initial data
+- `initial_pubkey`?: _string_ – Initial account owner's public key to set into account data
+- `boc_cache`?: _[BocCacheType](mod\_boc.md#boccachetype)_ – Cache type to put the result. The BOC itself returned if no cache type provided.
 
-#### Parameters
 
-* `abi`: [_Abi_](mod_abi.md#abi) – Contract ABI
-* `data`: _string_ – Data BOC or BOC handle
-* `initial_data`?: _any_ – List of initial values for contract's static variables.\
-  `abi` parameter should be provided to set initial data
-* `initial_pubkey`?: _string_ – Initial account owner's public key to set into account data
-* `boc_cache`?: [_BocCacheType_](mod_boc.md#boccachetype) – Cache type to put the result. The BOC itself returned if no cache type provided.
+### Result
 
-#### Result
+- `data`: _string_ – Updated data BOC or BOC handle
 
-* `data`: _string_ – Updated data BOC or BOC handle
 
-### encode\_initial\_data
+## encode_initial_data
 
 Encodes initial account data with initial values for the contract's static variables and owner's public key into a data BOC that can be passed to `encode_tvc` function afterwards.
 
@@ -705,24 +676,25 @@ function encode_initial_data_sync(
     params: ParamsOfEncodeInitialData,
 ): ResultOfEncodeInitialData;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `abi`: _[Abi](mod\_abi.md#abi)_ – Contract ABI
+- `initial_data`?: _any_ – List of initial values for contract's static variables.
+<br>`abi` parameter should be provided to set initial data
+- `initial_pubkey`?: _string_ – Initial account owner's public key to set into account data
+- `boc_cache`?: _[BocCacheType](mod\_boc.md#boccachetype)_ – Cache type to put the result. The BOC itself returned if no cache type provided.
 
-#### Parameters
 
-* `abi`: [_Abi_](mod_abi.md#abi) – Contract ABI
-* `initial_data`?: _any_ – List of initial values for contract's static variables.\
-  `abi` parameter should be provided to set initial data
-* `initial_pubkey`?: _string_ – Initial account owner's public key to set into account data
-* `boc_cache`?: [_BocCacheType_](mod_boc.md#boccachetype) – Cache type to put the result. The BOC itself returned if no cache type provided.
+### Result
 
-#### Result
+- `data`: _string_ – Updated data BOC or BOC handle
 
-* `data`: _string_ – Updated data BOC or BOC handle
 
-### decode\_initial\_data
+## decode_initial_data
 
-Decodes initial values of a contract's static variables and owner's public key from account initial data This operation is applicable only for initial account data (before deploy). If the contract is already deployed, its data doesn't contain this data section any more.
+Decodes initial values of a contract's static variables and owner's public key from account initial data This operation is applicable only for initial account data (before deploy).
+
+If the contract is already deployed, its data doesn't contain this data section any more.
 
 Doesn't support ABI version >= 2.4. Use `decode_account_data` instead
 
@@ -746,31 +718,43 @@ function decode_initial_data_sync(
     params: ParamsOfDecodeInitialData,
 ): ResultOfDecodeInitialData;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `abi`: _[Abi](mod\_abi.md#abi)_ – Contract ABI.
+<br>Initial data is decoded if this parameter is provided
+- `data`: _string_ – Data BOC or BOC handle
+- `allow_partial`?: _boolean_ – Flag allowing partial BOC decoding when ABI doesn't describe the full body BOC.
+<br>Controls decoder behaviour when after decoding all described in ABI params there are some data left in BOC:<br>`true` - return decoded values<br>`false` - return error of incomplete BOC deserialization (default)
 
-#### Parameters
 
-* `abi`: [_Abi_](mod_abi.md#abi) – Contract ABI.\
-  Initial data is decoded if this parameter is provided
-* `data`: _string_ – Data BOC or BOC handle
-* `allow_partial`?: _boolean_ – Flag allowing partial BOC decoding when ABI doesn't describe the full body BOC. Controls decoder behaviour when after decoding all described in ABI params there are some data left in BOC: `true` - return decoded values `false` - return error of incomplete BOC deserialization (default)
+### Result
 
-#### Result
+- `initial_data`: _any_ – List of initial values of contract's public variables.
+<br>Initial data is decoded if `abi` input parameter is provided
+- `initial_pubkey`: _string_ – Initial account owner's public key
 
-* `initial_data`: _any_ – List of initial values of contract's public variables.\
-  Initial data is decoded if `abi` input parameter is provided
-* `initial_pubkey`: _string_ – Initial account owner's public key
 
-### decode\_boc
+## decode_boc
 
 Decodes BOC into JSON as a set of provided parameters.
 
-Solidity functions use ABI types for [builder encoding](https://github.com/tonlabs/TON-Solidity-Compiler/blob/master/API.md#tvmbuilderstore). The simplest way to decode such a BOC is to use ABI decoding. ABI has it own rules for fields layout in cells so manually encoded BOC can not be described in terms of ABI rules.
+Solidity functions use ABI types for [builder encoding](https://github.com/tonlabs/TON-Solidity-Compiler/blob/master/API.md#tvmbuilderstore).
+The simplest way to decode such a BOC is to use ABI decoding.
+ABI has it own rules for fields layout in cells so manually encoded
+BOC can not be described in terms of ABI rules.
 
-To solve this problem we introduce a new ABI type `Ref(<ParamType>)` which allows to store `ParamType` ABI parameter in cell reference and, thus, decode manually encoded BOCs. This type is available only in `decode_boc` function and will not be available in ABI messages encoding until it is included into some ABI revision.
+To solve this problem we introduce a new ABI type `Ref(<ParamType>)`
+which allows to store `ParamType` ABI parameter in cell reference and, thus,
+decode manually encoded BOCs. This type is available only in `decode_boc`
+function and will not be available in ABI messages encoding until it is
+included into some ABI revision.
 
-Such BOC descriptions covers most users needs. If someone wants to decode some BOC which can not be described by these rules (i.e. BOC with TLB containing constructors of flags defining some parsing conditions) then they can decode the fields up to fork condition, check the parsed data manually, expand the parsing schema and then decode the whole BOC with the full schema.
+Such BOC descriptions covers most users needs. If someone wants to decode
+some BOC which can not be described by these rules (i.e. BOC with TLB
+containing constructors of flags defining some parsing conditions) then they
+can decode the fields up to fork condition, check the parsed data manually,
+expand the parsing schema and then decode the whole BOC with the full
+schema.
 
 ```ts
 type ParamsOfDecodeBoc = {
@@ -791,20 +775,19 @@ function decode_boc_sync(
     params: ParamsOfDecodeBoc,
 ): ResultOfDecodeBoc;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `params`: _[AbiParam](mod\_abi.md#abiparam)[]_ – Parameters to decode from BOC
+- `boc`: _string_ – Data BOC or BOC handle
+- `allow_partial`: _boolean_
 
-#### Parameters
 
-* `params`: [_AbiParam_](mod_abi.md#abiparam)_\[]_ – Parameters to decode from BOC
-* `boc`: _string_ – Data BOC or BOC handle
-* `allow_partial`: _boolean_
+### Result
 
-#### Result
+- `data`: _any_ – Decoded data as a JSON structure.
 
-* `data`: _any_ – Decoded data as a JSON structure.
 
-### encode\_boc
+## encode_boc
 
 Encodes given parameters in JSON into a BOC using param types from ABI.
 
@@ -827,21 +810,20 @@ function encode_boc_sync(
     params: ParamsOfAbiEncodeBoc,
 ): ResultOfAbiEncodeBoc;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `params`: _[AbiParam](mod\_abi.md#abiparam)[]_ – Parameters to encode into BOC
+- `data`: _any_ – Parameters and values as a JSON structure
+- `boc_cache`?: _[BocCacheType](mod\_boc.md#boccachetype)_ – Cache type to put the result.
+<br>The BOC itself returned if no cache type provided
 
-#### Parameters
 
-* `params`: [_AbiParam_](mod_abi.md#abiparam)_\[]_ – Parameters to encode into BOC
-* `data`: _any_ – Parameters and values as a JSON structure
-* `boc_cache`?: [_BocCacheType_](mod_boc.md#boccachetype) – Cache type to put the result.\
-  The BOC itself returned if no cache type provided
+### Result
 
-#### Result
+- `boc`: _string_ – BOC encoded as base64
 
-* `boc`: _string_ – BOC encoded as base64
 
-### calc\_function\_id
+## calc_function_id
 
 Calculates contract function ID by contract ABI
 
@@ -864,20 +846,20 @@ function calc_function_id_sync(
     params: ParamsOfCalcFunctionId,
 ): ResultOfCalcFunctionId;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `abi`: _[Abi](mod\_abi.md#abi)_ – Contract ABI.
+- `function_name`: _string_ – Contract function name
+- `output`?: _boolean_ – If set to `true` output function ID will be returned which is used in contract response.
+<br>Default is `false`
 
-#### Parameters
 
-* `abi`: [_Abi_](mod_abi.md#abi) – Contract ABI.
-* `function_name`: _string_ – Contract function name
-* `output`?: _boolean_ – If set to `true` output function ID will be returned which is used in contract response. Default is `false`
+### Result
 
-#### Result
+- `function_id`: _number_ – Contract function ID
 
-* `function_id`: _number_ – Contract function ID
 
-### get\_signature\_data
+## get_signature_data
 
 Extracts signature from message body and calculates hash to verify the signature
 
@@ -901,24 +883,21 @@ function get_signature_data_sync(
     params: ParamsOfGetSignatureData,
 ): ResultOfGetSignatureData;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `abi`: _[Abi](mod\_abi.md#abi)_ – Contract ABI used to decode.
+- `message`: _string_ – Message BOC encoded in `base64`.
+- `signature_id`?: _number_ – Signature ID to be used in unsigned data preparing when CapSignatureWithId capability is enabled
 
-#### Parameters
 
-* `abi`: [_Abi_](mod_abi.md#abi) – Contract ABI used to decode.
-* `message`: _string_ – Message BOC encoded in `base64`.
-* `signature_id`?: _number_ – Signature ID to be used in unsigned data preparing when CapSignatureWithId capability is enabled
+### Result
 
-#### Result
+- `signature`: _string_ – Signature from the message in `hex`.
+- `unsigned`: _string_ – Data to verify the signature in `base64`.
 
-* `signature`: _string_ – Signature from the message in `hex`.
-* `unsigned`: _string_ – Data to verify the signature in `base64`.
 
-## Types
-
-### AbiErrorCode
-
+# Types
+## AbiErrorCode
 ```ts
 enum AbiErrorCode {
     RequiredAddressMissingForEncodeMessage = 301,
@@ -939,68 +918,63 @@ enum AbiErrorCode {
     PubKeyNotSupported = 316
 }
 ```
-
 One of the following value:
 
-* `RequiredAddressMissingForEncodeMessage = 301`
-* `RequiredCallSetMissingForEncodeMessage = 302`
-* `InvalidJson = 303`
-* `InvalidMessage = 304`
-* `EncodeDeployMessageFailed = 305`
-* `EncodeRunMessageFailed = 306`
-* `AttachSignatureFailed = 307`
-* `InvalidTvcImage = 308`
-* `RequiredPublicKeyMissingForFunctionHeader = 309`
-* `InvalidSigner = 310`
-* `InvalidAbi = 311`
-* `InvalidFunctionId = 312`
-* `InvalidData = 313`
-* `EncodeInitialDataFailed = 314`
-* `InvalidFunctionName = 315`
-* `PubKeyNotSupported = 316`
+- `RequiredAddressMissingForEncodeMessage = 301`
+- `RequiredCallSetMissingForEncodeMessage = 302`
+- `InvalidJson = 303`
+- `InvalidMessage = 304`
+- `EncodeDeployMessageFailed = 305`
+- `EncodeRunMessageFailed = 306`
+- `AttachSignatureFailed = 307`
+- `InvalidTvcImage = 308`
+- `RequiredPublicKeyMissingForFunctionHeader = 309`
+- `InvalidSigner = 310`
+- `InvalidAbi = 311`
+- `InvalidFunctionId = 312`
+- `InvalidData = 313`
+- `EncodeInitialDataFailed = 314`
+- `InvalidFunctionName = 315`
+- `PubKeyNotSupported = 316`
 
-### AbiContractVariant
 
+## AbiContractVariant
 ```ts
 type AbiContractVariant = {
     value: AbiContract
 }
 ```
+- `value`: _[AbiContract](mod\_abi.md#abicontract)_
 
-* `value`: [_AbiContract_](mod_abi.md#abicontract)
 
-### AbiJsonVariant
-
+## AbiJsonVariant
 ```ts
 type AbiJsonVariant = {
     value: string
 }
 ```
+- `value`: _string_
 
-* `value`: _string_
 
-### AbiHandleVariant
-
+## AbiHandleVariant
 ```ts
 type AbiHandleVariant = {
     value: AbiHandle
 }
 ```
+- `value`: _[AbiHandle](mod\_abi.md#abihandle)_
 
-* `value`: [_AbiHandle_](mod_abi.md#abihandle)
 
-### AbiSerializedVariant
-
+## AbiSerializedVariant
 ```ts
 type AbiSerializedVariant = {
     value: AbiContract
 }
 ```
+- `value`: _[AbiContract](mod\_abi.md#abicontract)_
 
-* `value`: [_AbiContract_](mod_abi.md#abicontract)
 
-### Abi
-
+## Abi
 ```ts
 type Abi = ({
     type: 'Contract'
@@ -1012,24 +986,24 @@ type Abi = ({
     type: 'Serialized'
 } & AbiSerializedVariant)
 ```
-
-Depends on value of the `type` field.
+Depends on value of the  `type` field.
 
 When _type_ is _'Contract'_
 
-* `value`: [_AbiContract_](mod_abi.md#abicontract)
+- `value`: _[AbiContract](mod\_abi.md#abicontract)_
 
 When _type_ is _'Json'_
 
-* `value`: _string_
+- `value`: _string_
 
 When _type_ is _'Handle'_
 
-* `value`: [_AbiHandle_](mod_abi.md#abihandle)
+- `value`: _[AbiHandle](mod\_abi.md#abihandle)_
 
 When _type_ is _'Serialized'_
 
-* `value`: [_AbiContract_](mod_abi.md#abicontract)
+- `value`: _[AbiContract](mod\_abi.md#abicontract)_
+
 
 Variant constructors:
 
@@ -1040,19 +1014,21 @@ function abiHandle(value: AbiHandle): Abi;
 function abiSerialized(value: AbiContract): Abi;
 ```
 
-### AbiHandle
-
+## AbiHandle
 ```ts
 type AbiHandle = number
 ```
 
-### FunctionHeader
 
+## FunctionHeader
 The ABI function header.
 
-Includes several hidden function parameters that contract uses for security, message delivery monitoring and replay protection reasons.
+Includes several hidden function parameters that contract
+uses for security, message delivery monitoring and replay protection
+reasons.
 
-The actual set of header fields depends on the contract's ABI. If a contract's ABI does not include some headers, then they are not filled.
+The actual set of header fields depends on the contract's ABI.
+If a contract's ABI does not include some headers, then they are not filled.
 
 ```ts
 type FunctionHeader = {
@@ -1061,17 +1037,15 @@ type FunctionHeader = {
     pubkey?: string
 }
 ```
+- `expire`?: _number_ – Message expiration timestamp (UNIX time) in seconds.
+<br>If not specified - calculated automatically from<br>message_expiration_timeout(), try_index and<br>message_expiration_timeout_grow_factor() (if ABI includes `expire`<br>header).
+- `time`?: _bigint_ – Message creation time in milliseconds.
+<br>If not specified, `now` is used (if ABI includes `time` header).
+- `pubkey`?: _string_ – Public key is used by the contract to check the signature.
+<br>Encoded in `hex`. If not specified, method fails with exception (if ABI<br>includes `pubkey` header)..
 
-* `expire`?: _number_ – Message expiration timestamp (UNIX time) in seconds.\
-  If not specified - calculated automatically from message\_expiration\_timeout(),\
-  try\_index and message\_expiration\_timeout\_grow\_factor() (if ABI includes `expire` header).
-* `time`?: _bigint_ – Message creation time in milliseconds.\
-  If not specified, `now` is used (if ABI includes `time` header).
-* `pubkey`?: _string_ – Public key is used by the contract to check the signature.\
-  Encoded in `hex`. If not specified, method fails with exception (if ABI includes `pubkey` header)..
 
-### CallSet
-
+## CallSet
 ```ts
 type CallSet = {
     function_name: string,
@@ -1079,16 +1053,13 @@ type CallSet = {
     input?: any
 }
 ```
+- `function_name`: _string_ – Function name that is being called. Or function id encoded as string in hex (starting with 0x).
+- `header`?: _[FunctionHeader](mod\_abi.md#functionheader)_ – Function header.
+<br>If an application omits some header parameters required by the<br>contract's ABI, the library will set the default values for<br>them.
+- `input`?: _any_ – Function input parameters according to ABI.
 
-* `function_name`: _string_ – Function name that is being called. Or function id encoded as string in hex (starting with 0x).
-* `header`?: [_FunctionHeader_](mod_abi.md#functionheader) – Function header.\
-  If an application omits some header parameters required by the\
-  contract's ABI, the library will set the default values for\
-  them.
-* `input`?: _any_ – Function input parameters according to ABI.
 
-### DeploySet
-
+## DeploySet
 ```ts
 type DeploySet = {
     tvc?: string,
@@ -1099,24 +1070,17 @@ type DeploySet = {
     initial_pubkey?: string
 }
 ```
+- `tvc`?: _string_ – Content of TVC file encoded in `base64`. For compatibility reason this field can contain an encoded  `StateInit`.
+- `code`?: _string_ – Contract code BOC encoded with base64.
+- `state_init`?: _string_ – State init BOC encoded with base64.
+- `workchain_id`?: _number_ – Target workchain for destination address.
+<br>Default is `0`.
+- `initial_data`?: _any_ – List of initial values for contract's public variables.
+- `initial_pubkey`?: _string_ – Optional public key that can be provided in deploy set in order to substitute one in TVM file or provided by Signer.
+<br>Public key resolving priority:<br>1. Public key from deploy set.<br>2. Public key, specified in TVM file.<br>3. Public key, provided by Signer.<br><br>Applicable only for contracts with ABI version < 2.4. Contract initial<br>public key should be explicitly provided inside `initial_data` since<br>ABI 2.4
 
-* `tvc`?: _string_ – Content of TVC file encoded in `base64`. For compatibility reason this field can contain an encoded `StateInit`.
-* `code`?: _string_ – Contract code BOC encoded with base64.
-* `state_init`?: _string_ – State init BOC encoded with base64.
-* `workchain_id`?: _number_ – Target workchain for destination address.\
-  Default is `0`.
-* `initial_data`?: _any_ – List of initial values for contract's public variables.
-* `initial_pubkey`?: _string_ – Optional public key that can be provided in deploy set in order to substitute one in TVM file or provided by Signer.\
-  Public key resolving priority:\
-  1\. Public key from deploy set.\
-  2\. Public key, specified in TVM file.\
-  3\. Public key, provided by Signer.\
-  \
-  Applicable only for contracts with ABI version < 2.4. Contract initial public key should be\
-  explicitly provided inside `initial_data` since ABI 2.4
 
-### SignerNoneVariant
-
+## SignerNoneVariant
 No keys are provided.
 
 Creates an unsigned message.
@@ -1127,8 +1091,8 @@ type SignerNoneVariant = {
 }
 ```
 
-### SignerExternalVariant
 
+## SignerExternalVariant
 Only public key is provided in unprefixed hex string format to generate unsigned message and `data_to_sign` which can be signed later.
 
 ```ts
@@ -1136,11 +1100,10 @@ type SignerExternalVariant = {
     public_key: string
 }
 ```
+- `public_key`: _string_
 
-* `public_key`: _string_
 
-### SignerKeysVariant
-
+## SignerKeysVariant
 Key pair is provided for signing
 
 ```ts
@@ -1148,11 +1111,10 @@ type SignerKeysVariant = {
     keys: KeyPair
 }
 ```
+- `keys`: _[KeyPair](mod\_crypto.md#keypair)_
 
-* `keys`: [_KeyPair_](/broken/pages/b7U0dxs59ESc6rtN09mV#keypair)
 
-### SignerSigningBoxVariant
-
+## SignerSigningBoxVariant
 Signing Box interface is provided for signing, allows Dapps to sign messages using external APIs, such as HSM, cold wallet, etc.
 
 ```ts
@@ -1160,11 +1122,10 @@ type SignerSigningBoxVariant = {
     handle: SigningBoxHandle
 }
 ```
+- `handle`: _[SigningBoxHandle](mod\_crypto.md#signingboxhandle)_
 
-* `handle`: [_SigningBoxHandle_](/broken/pages/b7U0dxs59ESc6rtN09mV#signingboxhandle)
 
-### Signer
-
+## Signer
 ```ts
 type Signer = ({
     type: 'None'
@@ -1176,8 +1137,7 @@ type Signer = ({
     type: 'SigningBox'
 } & SignerSigningBoxVariant)
 ```
-
-Depends on value of the `type` field.
+Depends on value of the  `type` field.
 
 When _type_ is _'None'_
 
@@ -1185,23 +1145,25 @@ No keys are provided.
 
 Creates an unsigned message.
 
+
 When _type_ is _'External'_
 
 Only public key is provided in unprefixed hex string format to generate unsigned message and `data_to_sign` which can be signed later.
 
-* `public_key`: _string_
+- `public_key`: _string_
 
 When _type_ is _'Keys'_
 
 Key pair is provided for signing
 
-* `keys`: [_KeyPair_](/broken/pages/b7U0dxs59ESc6rtN09mV#keypair)
+- `keys`: _[KeyPair](mod\_crypto.md#keypair)_
 
 When _type_ is _'SigningBox'_
 
 Signing Box interface is provided for signing, allows Dapps to sign messages using external APIs, such as HSM, cold wallet, etc.
 
-* `handle`: [_SigningBoxHandle_](/broken/pages/b7U0dxs59ESc6rtN09mV#signingboxhandle)
+- `handle`: _[SigningBoxHandle](mod\_crypto.md#signingboxhandle)_
+
 
 Variant constructors:
 
@@ -1212,8 +1174,7 @@ function signerKeys(keys: KeyPair): Signer;
 function signerSigningBox(handle: SigningBoxHandle): Signer;
 ```
 
-### MessageBodyType
-
+## MessageBodyType
 ```ts
 enum MessageBodyType {
     Input = "Input",
@@ -1222,18 +1183,16 @@ enum MessageBodyType {
     Event = "Event"
 }
 ```
-
 One of the following value:
 
-* `Input = "Input"` – Message contains the input of the ABI function.
-* `Output = "Output"` – Message contains the output of the ABI function.
-* `InternalOutput = "InternalOutput"` – Message contains the input of the imported ABI function.\
-  Occurs when contract sends an internal message to other\
-  contract.
-* `Event = "Event"` – Message contains the input of the ABI event.
+- `Input = "Input"` – Message contains the input of the ABI function.
+- `Output = "Output"` – Message contains the output of the ABI function.
+- `InternalOutput = "InternalOutput"` – Message contains the input of the imported ABI function.
+<br>Occurs when contract sends an internal message to other<br>contract.
+- `Event = "Event"` – Message contains the input of the ABI event.
 
-### AbiParam
 
+## AbiParam
 ```ts
 type AbiParam = {
     name: string,
@@ -1242,14 +1201,13 @@ type AbiParam = {
     init?: boolean
 }
 ```
+- `name`: _string_
+- `type`: _string_
+- `components`?: _[AbiParam](mod\_abi.md#abiparam)[]_
+- `init`?: _boolean_
 
-* `name`: _string_
-* `type`: _string_
-* `components`?: [_AbiParam_](mod_abi.md#abiparam)_\[]_
-* `init`?: _boolean_
 
-### AbiEvent
-
+## AbiEvent
 ```ts
 type AbiEvent = {
     name: string,
@@ -1257,13 +1215,12 @@ type AbiEvent = {
     id?: string | null
 }
 ```
+- `name`: _string_
+- `inputs`: _[AbiParam](mod\_abi.md#abiparam)[]_
+- `id`?: _string?_
 
-* `name`: _string_
-* `inputs`: [_AbiParam_](mod_abi.md#abiparam)_\[]_
-* `id`?: _string?_
 
-### AbiData
-
+## AbiData
 ```ts
 type AbiData = {
     key: number,
@@ -1272,14 +1229,13 @@ type AbiData = {
     components?: AbiParam[]
 }
 ```
+- `key`: _number_
+- `name`: _string_
+- `type`: _string_
+- `components`?: _[AbiParam](mod\_abi.md#abiparam)[]_
 
-* `key`: _number_
-* `name`: _string_
-* `type`: _string_
-* `components`?: [_AbiParam_](mod_abi.md#abiparam)_\[]_
 
-### AbiFunction
-
+## AbiFunction
 ```ts
 type AbiFunction = {
     name: string,
@@ -1288,14 +1244,13 @@ type AbiFunction = {
     id?: string | null
 }
 ```
+- `name`: _string_
+- `inputs`: _[AbiParam](mod\_abi.md#abiparam)[]_
+- `outputs`: _[AbiParam](mod\_abi.md#abiparam)[]_
+- `id`?: _string?_
 
-* `name`: _string_
-* `inputs`: [_AbiParam_](mod_abi.md#abiparam)_\[]_
-* `outputs`: [_AbiParam_](mod_abi.md#abiparam)_\[]_
-* `id`?: _string?_
 
-### AbiContract
-
+## AbiContract
 ```ts
 type AbiContract = {
     'ABI version'?: number,
@@ -1308,32 +1263,30 @@ type AbiContract = {
     fields?: AbiParam[]
 }
 ```
+- `ABI version`?: _number_
+- `abi_version`?: _number_
+- `version`?: _string?_
+- `header`?: _string[]_
+- `functions`?: _[AbiFunction](mod\_abi.md#abifunction)[]_
+- `events`?: _[AbiEvent](mod\_abi.md#abievent)[]_
+- `data`?: _[AbiData](mod\_abi.md#abidata)[]_
+- `fields`?: _[AbiParam](mod\_abi.md#abiparam)[]_
 
-* `ABI version`?: _number_
-* `abi_version`?: _number_
-* `version`?: _string?_
-* `header`?: _string\[]_
-* `functions`?: [_AbiFunction_](mod_abi.md#abifunction)_\[]_
-* `events`?: [_AbiEvent_](mod_abi.md#abievent)_\[]_
-* `data`?: [_AbiData_](mod_abi.md#abidata)_\[]_
-* `fields`?: [_AbiParam_](mod_abi.md#abiparam)_\[]_
 
-### DataLayout
-
+## DataLayout
 ```ts
 enum DataLayout {
     Input = "Input",
     Output = "Output"
 }
 ```
-
 One of the following value:
 
-* `Input = "Input"` – Decode message body as function input parameters.
-* `Output = "Output"` – Decode message body as function output.
+- `Input = "Input"` – Decode message body as function input parameters.
+- `Output = "Output"` – Decode message body as function output.
 
-### ParamsOfEncodeMessageBody
 
+## ParamsOfEncodeMessageBody
 ```ts
 type ParamsOfEncodeMessageBody = {
     abi: Abi,
@@ -1345,47 +1298,31 @@ type ParamsOfEncodeMessageBody = {
     signature_id?: number
 }
 ```
+- `abi`: _[Abi](mod\_abi.md#abi)_ – Contract ABI.
+- `call_set`: _[CallSet](mod\_abi.md#callset)_ – Function call parameters.
+<br>Must be specified in non deploy message.<br><br>In case of deploy message contains parameters of constructor.
+- `is_internal`: _boolean_ – True if internal message body must be encoded.
+- `signer`: _[Signer](mod\_abi.md#signer)_ – Signing parameters.
+- `processing_try_index`?: _number_ – Processing try index.
+<br>Used in message processing with retries.<br><br>Encoder uses the provided try index to calculate message<br>expiration time.<br><br>Expiration timeouts will grow with every retry.<br><br>Default value is 0.
+- `address`?: _string_ – Destination address of the message
+<br>Since ABI version 2.3 destination address of external inbound message is<br>used in message body signature calculation. Should be provided when<br>signed external inbound message body is created. Otherwise can be<br>omitted.
+- `signature_id`?: _number_ – Signature ID to be used in data to sign preparing when CapSignatureWithId capability is enabled
 
-* `abi`: [_Abi_](mod_abi.md#abi) – Contract ABI.
-* `call_set`: [_CallSet_](mod_abi.md#callset) – Function call parameters.\
-  Must be specified in non deploy message.\
-  \
-  In case of deploy message contains parameters of constructor.
-* `is_internal`: _boolean_ – True if internal message body must be encoded.
-* `signer`: [_Signer_](mod_abi.md#signer) – Signing parameters.
-* `processing_try_index`?: _number_ – Processing try index.\
-  Used in message processing with retries.\
-  \
-  Encoder uses the provided try index to calculate message\
-  expiration time.\
-  \
-  Expiration timeouts will grow with every retry.\
-  \
-  Default value is 0.
-* `address`?: _string_ – Destination address of the message\
-  Since ABI version 2.3 destination address of external inbound message is used in message\
-  body signature calculation. Should be provided when signed external inbound message body is\
-  created. Otherwise can be omitted.
-* `signature_id`?: _number_ – Signature ID to be used in data to sign preparing when CapSignatureWithId capability is enabled
 
-### ResultOfEncodeMessageBody
-
+## ResultOfEncodeMessageBody
 ```ts
 type ResultOfEncodeMessageBody = {
     body: string,
     data_to_sign?: string
 }
 ```
+- `body`: _string_ – Message body BOC encoded with `base64`.
+- `data_to_sign`?: _string_ – Optional data to sign.
+<br>Encoded with `base64`. <br>Presents when `message` is unsigned. Can be used for external<br>message signing. Is this case you need to sing this data and<br>produce signed message using `abi.attach_signature`.
 
-* `body`: _string_ – Message body BOC encoded with `base64`.
-* `data_to_sign`?: _string_ – Optional data to sign.\
-  Encoded with `base64`.\
-  Presents when `message` is unsigned. Can be used for external\
-  message signing. Is this case you need to sing this data and\
-  produce signed message using `abi.attach_signature`.
 
-### ParamsOfAttachSignatureToMessageBody
-
+## ParamsOfAttachSignatureToMessageBody
 ```ts
 type ParamsOfAttachSignatureToMessageBody = {
     abi: Abi,
@@ -1394,27 +1331,25 @@ type ParamsOfAttachSignatureToMessageBody = {
     signature: string
 }
 ```
+- `abi`: _[Abi](mod\_abi.md#abi)_ – Contract ABI
+- `public_key`: _string_ – Public key.
+<br>Must be encoded with `hex`.
+- `message`: _string_ – Unsigned message body BOC.
+<br>Must be encoded with `base64`.
+- `signature`: _string_ – Signature.
+<br>Must be encoded with `hex`.
 
-* `abi`: [_Abi_](mod_abi.md#abi) – Contract ABI
-* `public_key`: _string_ – Public key.\
-  Must be encoded with `hex`.
-* `message`: _string_ – Unsigned message body BOC.\
-  Must be encoded with `base64`.
-* `signature`: _string_ – Signature.\
-  Must be encoded with `hex`.
 
-### ResultOfAttachSignatureToMessageBody
-
+## ResultOfAttachSignatureToMessageBody
 ```ts
 type ResultOfAttachSignatureToMessageBody = {
     body: string
 }
 ```
+- `body`: _string_
 
-* `body`: _string_
 
-### ParamsOfEncodeMessage
-
+## ParamsOfEncodeMessage
 ```ts
 type ParamsOfEncodeMessage = {
     abi: Abi,
@@ -1426,34 +1361,20 @@ type ParamsOfEncodeMessage = {
     signature_id?: number
 }
 ```
+- `abi`: _[Abi](mod\_abi.md#abi)_ – Contract ABI.
+- `address`?: _string_ – Target address the message will be sent to.
+<br>Must be specified in case of non-deploy message.
+- `deploy_set`?: _[DeploySet](mod\_abi.md#deployset)_ – Deploy parameters.
+<br>Must be specified in case of deploy message.
+- `call_set`?: _[CallSet](mod\_abi.md#callset)_ – Function call parameters.
+<br>Must be specified in case of non-deploy message.<br><br>In case of deploy message it is optional and contains parameters<br>of the functions that will to be called upon deploy transaction.
+- `signer`: _[Signer](mod\_abi.md#signer)_ – Signing parameters.
+- `processing_try_index`?: _number_ – Processing try index.
+<br>Used in message processing with retries (if contract's ABI includes<br>"expire" header).<br><br>Encoder uses the provided try index to calculate message<br>expiration time. The 1st message expiration time is specified in<br>Client config.<br><br>Expiration timeouts will grow with every retry.<br>Retry grow factor is set in Client config:<br><.....add config parameter with default value here><br><br>Default value is 0.
+- `signature_id`?: _number_ – Signature ID to be used in data to sign preparing when CapSignatureWithId capability is enabled
 
-* `abi`: [_Abi_](mod_abi.md#abi) – Contract ABI.
-* `address`?: _string_ – Target address the message will be sent to.\
-  Must be specified in case of non-deploy message.
-* `deploy_set`?: [_DeploySet_](mod_abi.md#deployset) – Deploy parameters.\
-  Must be specified in case of deploy message.
-* `call_set`?: [_CallSet_](mod_abi.md#callset) – Function call parameters.\
-  Must be specified in case of non-deploy message.\
-  \
-  In case of deploy message it is optional and contains parameters\
-  of the functions that will to be called upon deploy transaction.
-* `signer`: [_Signer_](mod_abi.md#signer) – Signing parameters.
-* `processing_try_index`?: _number_ – Processing try index.\
-  Used in message processing with retries (if contract's ABI includes "expire" header).\
-  \
-  Encoder uses the provided try index to calculate message\
-  expiration time. The 1st message expiration time is specified in\
-  Client config.\
-  \
-  Expiration timeouts will grow with every retry.\
-  Retry grow factor is set in Client config:\
-  <.....add config parameter with default value here>\
-  \
-  Default value is 0.
-* `signature_id`?: _number_ – Signature ID to be used in data to sign preparing when CapSignatureWithId capability is enabled
 
-### ResultOfEncodeMessage
-
+## ResultOfEncodeMessage
 ```ts
 type ResultOfEncodeMessage = {
     message: string,
@@ -1462,17 +1383,14 @@ type ResultOfEncodeMessage = {
     message_id: string
 }
 ```
+- `message`: _string_ – Message BOC encoded with `base64`.
+- `data_to_sign`?: _string_ – Optional data to be signed encoded in `base64`.
+<br>Returned in case of `Signer::External`. Can be used for external<br>message signing. Is this case you need to use this data to create<br>signature and then produce signed message using<br>`abi.attach_signature`.
+- `address`: _string_ – Destination address.
+- `message_id`: _string_ – Message id.
 
-* `message`: _string_ – Message BOC encoded with `base64`.
-* `data_to_sign`?: _string_ – Optional data to be signed encoded in `base64`.\
-  Returned in case of `Signer::External`. Can be used for external\
-  message signing. Is this case you need to use this data to create signature and\
-  then produce signed message using `abi.attach_signature`.
-* `address`: _string_ – Destination address.
-* `message_id`: _string_ – Message id.
 
-### ParamsOfEncodeInternalMessage
-
+## ParamsOfEncodeInternalMessage
 ```ts
 type ParamsOfEncodeInternalMessage = {
     abi?: Abi,
@@ -1485,27 +1403,23 @@ type ParamsOfEncodeInternalMessage = {
     enable_ihr?: boolean
 }
 ```
+- `abi`?: _[Abi](mod\_abi.md#abi)_ – Contract ABI.
+<br>Can be None if both deploy_set and call_set are None.
+- `address`?: _string_ – Target address the message will be sent to.
+<br>Must be specified in case of non-deploy message.
+- `src_address`?: _string_ – Source address of the message.
+- `deploy_set`?: _[DeploySet](mod\_abi.md#deployset)_ – Deploy parameters.
+<br>Must be specified in case of deploy message.
+- `call_set`?: _[CallSet](mod\_abi.md#callset)_ – Function call parameters.
+<br>Must be specified in case of non-deploy message.<br><br>In case of deploy message it is optional and contains parameters<br>of the functions that will to be called upon deploy transaction.
+- `value`: _string_ – Value in nanotokens to be sent with message.
+- `bounce`?: _boolean_ – Flag of bounceable message.
+<br>Default is true.
+- `enable_ihr`?: _boolean_ – Enable Instant Hypercube Routing for the message.
+<br>Default is false.
 
-* `abi`?: [_Abi_](mod_abi.md#abi) – Contract ABI.\
-  Can be None if both deploy\_set and call\_set are None.
-* `address`?: _string_ – Target address the message will be sent to.\
-  Must be specified in case of non-deploy message.
-* `src_address`?: _string_ – Source address of the message.
-* `deploy_set`?: [_DeploySet_](mod_abi.md#deployset) – Deploy parameters.\
-  Must be specified in case of deploy message.
-* `call_set`?: [_CallSet_](mod_abi.md#callset) – Function call parameters.\
-  Must be specified in case of non-deploy message.\
-  \
-  In case of deploy message it is optional and contains parameters\
-  of the functions that will to be called upon deploy transaction.
-* `value`: _string_ – Value in nanotokens to be sent with message.
-* `bounce`?: _boolean_ – Flag of bounceable message.\
-  Default is true.
-* `enable_ihr`?: _boolean_ – Enable Instant Hypercube Routing for the message.\
-  Default is false.
 
-### ResultOfEncodeInternalMessage
-
+## ResultOfEncodeInternalMessage
 ```ts
 type ResultOfEncodeInternalMessage = {
     message: string,
@@ -1513,13 +1427,12 @@ type ResultOfEncodeInternalMessage = {
     message_id: string
 }
 ```
+- `message`: _string_ – Message BOC encoded with `base64`.
+- `address`: _string_ – Destination address.
+- `message_id`: _string_ – Message id.
 
-* `message`: _string_ – Message BOC encoded with `base64`.
-* `address`: _string_ – Destination address.
-* `message_id`: _string_ – Message id.
 
-### ParamsOfAttachSignature
-
+## ParamsOfAttachSignature
 ```ts
 type ParamsOfAttachSignature = {
     abi: Abi,
@@ -1528,26 +1441,24 @@ type ParamsOfAttachSignature = {
     signature: string
 }
 ```
+- `abi`: _[Abi](mod\_abi.md#abi)_ – Contract ABI
+- `public_key`: _string_ – Public key encoded in `hex`.
+- `message`: _string_ – Unsigned message BOC encoded in `base64`.
+- `signature`: _string_ – Signature encoded in `hex`.
 
-* `abi`: [_Abi_](mod_abi.md#abi) – Contract ABI
-* `public_key`: _string_ – Public key encoded in `hex`.
-* `message`: _string_ – Unsigned message BOC encoded in `base64`.
-* `signature`: _string_ – Signature encoded in `hex`.
 
-### ResultOfAttachSignature
-
+## ResultOfAttachSignature
 ```ts
 type ResultOfAttachSignature = {
     message: string,
     message_id: string
 }
 ```
+- `message`: _string_ – Signed message BOC
+- `message_id`: _string_ – Message ID
 
-* `message`: _string_ – Signed message BOC
-* `message_id`: _string_ – Message ID
 
-### ParamsOfDecodeMessage
-
+## ParamsOfDecodeMessage
 ```ts
 type ParamsOfDecodeMessage = {
     abi: Abi,
@@ -1557,15 +1468,15 @@ type ParamsOfDecodeMessage = {
     data_layout?: DataLayout
 }
 ```
+- `abi`: _[Abi](mod\_abi.md#abi)_ – contract ABI
+- `message`: _string_ – Message BOC
+- `allow_partial`?: _boolean_ – Flag allowing partial BOC decoding when ABI doesn't describe the full body BOC.
+<br>Controls decoder behaviour when after decoding all described in ABI params there are some data left in BOC:<br>`true` - return decoded values<br>`false` - return error of incomplete BOC deserialization (default)
+- `function_name`?: _string_ – Function name or function id if is known in advance
+- `data_layout`?: _[DataLayout](mod\_abi.md#datalayout)_
 
-* `abi`: [_Abi_](mod_abi.md#abi) – contract ABI
-* `message`: _string_ – Message BOC
-* `allow_partial`?: _boolean_ – Flag allowing partial BOC decoding when ABI doesn't describe the full body BOC. Controls decoder behaviour when after decoding all described in ABI params there are some data left in BOC: `true` - return decoded values `false` - return error of incomplete BOC deserialization (default)
-* `function_name`?: _string_ – Function name or function id if is known in advance
-* `data_layout`?: [_DataLayout_](mod_abi.md#datalayout)
 
-### DecodedMessageBody
-
+## DecodedMessageBody
 ```ts
 type DecodedMessageBody = {
     body_type: MessageBodyType,
@@ -1574,14 +1485,13 @@ type DecodedMessageBody = {
     header?: FunctionHeader
 }
 ```
+- `body_type`: _[MessageBodyType](mod\_abi.md#messagebodytype)_ – Type of the message body content.
+- `name`: _string_ – Function or event name.
+- `value`?: _any_ – Parameters or result value.
+- `header`?: _[FunctionHeader](mod\_abi.md#functionheader)_ – Function header.
 
-* `body_type`: [_MessageBodyType_](mod_abi.md#messagebodytype) – Type of the message body content.
-* `name`: _string_ – Function or event name.
-* `value`?: _any_ – Parameters or result value.
-* `header`?: [_FunctionHeader_](mod_abi.md#functionheader) – Function header.
 
-### ParamsOfDecodeMessageBody
-
+## ParamsOfDecodeMessageBody
 ```ts
 type ParamsOfDecodeMessageBody = {
     abi: Abi,
@@ -1592,16 +1502,16 @@ type ParamsOfDecodeMessageBody = {
     data_layout?: DataLayout
 }
 ```
+- `abi`: _[Abi](mod\_abi.md#abi)_ – Contract ABI used to decode.
+- `body`: _string_ – Message body BOC encoded in `base64`.
+- `is_internal`: _boolean_ – True if the body belongs to the internal message.
+- `allow_partial`?: _boolean_ – Flag allowing partial BOC decoding when ABI doesn't describe the full body BOC.
+<br>Controls decoder behaviour when after decoding all described in ABI params there are some data left in BOC:<br>`true` - return decoded values<br>`false` - return error of incomplete BOC deserialization (default)
+- `function_name`?: _string_ – Function name or function id if is known in advance
+- `data_layout`?: _[DataLayout](mod\_abi.md#datalayout)_
 
-* `abi`: [_Abi_](mod_abi.md#abi) – Contract ABI used to decode.
-* `body`: _string_ – Message body BOC encoded in `base64`.
-* `is_internal`: _boolean_ – True if the body belongs to the internal message.
-* `allow_partial`?: _boolean_ – Flag allowing partial BOC decoding when ABI doesn't describe the full body BOC. Controls decoder behaviour when after decoding all described in ABI params there are some data left in BOC: `true` - return decoded values `false` - return error of incomplete BOC deserialization (default)
-* `function_name`?: _string_ – Function name or function id if is known in advance
-* `data_layout`?: [_DataLayout_](mod_abi.md#datalayout)
 
-### ParamsOfEncodeAccount
-
+## ParamsOfEncodeAccount
 ```ts
 type ParamsOfEncodeAccount = {
     state_init: string,
@@ -1611,28 +1521,26 @@ type ParamsOfEncodeAccount = {
     boc_cache?: BocCacheType
 }
 ```
+- `state_init`: _string_ – Account state init.
+- `balance`?: _bigint_ – Initial balance.
+- `last_trans_lt`?: _bigint_ – Initial value for the `last_trans_lt`.
+- `last_paid`?: _number_ – Initial value for the `last_paid`.
+- `boc_cache`?: _[BocCacheType](mod\_boc.md#boccachetype)_ – Cache type to put the result.
+<br>The BOC itself returned if no cache type provided
 
-* `state_init`: _string_ – Account state init.
-* `balance`?: _bigint_ – Initial balance.
-* `last_trans_lt`?: _bigint_ – Initial value for the `last_trans_lt`.
-* `last_paid`?: _number_ – Initial value for the `last_paid`.
-* `boc_cache`?: [_BocCacheType_](mod_boc.md#boccachetype) – Cache type to put the result.\
-  The BOC itself returned if no cache type provided
 
-### ResultOfEncodeAccount
-
+## ResultOfEncodeAccount
 ```ts
 type ResultOfEncodeAccount = {
     account: string,
     id: string
 }
 ```
+- `account`: _string_ – Account BOC encoded in `base64`.
+- `id`: _string_ – Account ID  encoded in `hex`.
 
-* `account`: _string_ – Account BOC encoded in `base64`.
-* `id`: _string_ – Account ID encoded in `hex`.
 
-### ParamsOfDecodeAccountData
-
+## ParamsOfDecodeAccountData
 ```ts
 type ParamsOfDecodeAccountData = {
     abi: Abi,
@@ -1640,23 +1548,22 @@ type ParamsOfDecodeAccountData = {
     allow_partial?: boolean
 }
 ```
+- `abi`: _[Abi](mod\_abi.md#abi)_ – Contract ABI
+- `data`: _string_ – Data BOC or BOC handle
+- `allow_partial`?: _boolean_ – Flag allowing partial BOC decoding when ABI doesn't describe the full body BOC.
+<br>Controls decoder behaviour when after decoding all described in ABI params there are some data left in BOC:<br>`true` - return decoded values<br>`false` - return error of incomplete BOC deserialization (default)
 
-* `abi`: [_Abi_](mod_abi.md#abi) – Contract ABI
-* `data`: _string_ – Data BOC or BOC handle
-* `allow_partial`?: _boolean_ – Flag allowing partial BOC decoding when ABI doesn't describe the full body BOC. Controls decoder behaviour when after decoding all described in ABI params there are some data left in BOC: `true` - return decoded values `false` - return error of incomplete BOC deserialization (default)
 
-### ResultOfDecodeAccountData
-
+## ResultOfDecodeAccountData
 ```ts
 type ResultOfDecodeAccountData = {
     data: any
 }
 ```
+- `data`: _any_ – Decoded data as a JSON structure.
 
-* `data`: _any_ – Decoded data as a JSON structure.
 
-### ParamsOfUpdateInitialData
-
+## ParamsOfUpdateInitialData
 ```ts
 type ParamsOfUpdateInitialData = {
     abi: Abi,
@@ -1666,26 +1573,24 @@ type ParamsOfUpdateInitialData = {
     boc_cache?: BocCacheType
 }
 ```
+- `abi`: _[Abi](mod\_abi.md#abi)_ – Contract ABI
+- `data`: _string_ – Data BOC or BOC handle
+- `initial_data`?: _any_ – List of initial values for contract's static variables.
+<br>`abi` parameter should be provided to set initial data
+- `initial_pubkey`?: _string_ – Initial account owner's public key to set into account data
+- `boc_cache`?: _[BocCacheType](mod\_boc.md#boccachetype)_ – Cache type to put the result. The BOC itself returned if no cache type provided.
 
-* `abi`: [_Abi_](mod_abi.md#abi) – Contract ABI
-* `data`: _string_ – Data BOC or BOC handle
-* `initial_data`?: _any_ – List of initial values for contract's static variables.\
-  `abi` parameter should be provided to set initial data
-* `initial_pubkey`?: _string_ – Initial account owner's public key to set into account data
-* `boc_cache`?: [_BocCacheType_](mod_boc.md#boccachetype) – Cache type to put the result. The BOC itself returned if no cache type provided.
 
-### ResultOfUpdateInitialData
-
+## ResultOfUpdateInitialData
 ```ts
 type ResultOfUpdateInitialData = {
     data: string
 }
 ```
+- `data`: _string_ – Updated data BOC or BOC handle
 
-* `data`: _string_ – Updated data BOC or BOC handle
 
-### ParamsOfEncodeInitialData
-
+## ParamsOfEncodeInitialData
 ```ts
 type ParamsOfEncodeInitialData = {
     abi: Abi,
@@ -1694,25 +1599,23 @@ type ParamsOfEncodeInitialData = {
     boc_cache?: BocCacheType
 }
 ```
+- `abi`: _[Abi](mod\_abi.md#abi)_ – Contract ABI
+- `initial_data`?: _any_ – List of initial values for contract's static variables.
+<br>`abi` parameter should be provided to set initial data
+- `initial_pubkey`?: _string_ – Initial account owner's public key to set into account data
+- `boc_cache`?: _[BocCacheType](mod\_boc.md#boccachetype)_ – Cache type to put the result. The BOC itself returned if no cache type provided.
 
-* `abi`: [_Abi_](mod_abi.md#abi) – Contract ABI
-* `initial_data`?: _any_ – List of initial values for contract's static variables.\
-  `abi` parameter should be provided to set initial data
-* `initial_pubkey`?: _string_ – Initial account owner's public key to set into account data
-* `boc_cache`?: [_BocCacheType_](mod_boc.md#boccachetype) – Cache type to put the result. The BOC itself returned if no cache type provided.
 
-### ResultOfEncodeInitialData
-
+## ResultOfEncodeInitialData
 ```ts
 type ResultOfEncodeInitialData = {
     data: string
 }
 ```
+- `data`: _string_ – Updated data BOC or BOC handle
 
-* `data`: _string_ – Updated data BOC or BOC handle
 
-### ParamsOfDecodeInitialData
-
+## ParamsOfDecodeInitialData
 ```ts
 type ParamsOfDecodeInitialData = {
     abi: Abi,
@@ -1720,27 +1623,26 @@ type ParamsOfDecodeInitialData = {
     allow_partial?: boolean
 }
 ```
+- `abi`: _[Abi](mod\_abi.md#abi)_ – Contract ABI.
+<br>Initial data is decoded if this parameter is provided
+- `data`: _string_ – Data BOC or BOC handle
+- `allow_partial`?: _boolean_ – Flag allowing partial BOC decoding when ABI doesn't describe the full body BOC.
+<br>Controls decoder behaviour when after decoding all described in ABI params there are some data left in BOC:<br>`true` - return decoded values<br>`false` - return error of incomplete BOC deserialization (default)
 
-* `abi`: [_Abi_](mod_abi.md#abi) – Contract ABI.\
-  Initial data is decoded if this parameter is provided
-* `data`: _string_ – Data BOC or BOC handle
-* `allow_partial`?: _boolean_ – Flag allowing partial BOC decoding when ABI doesn't describe the full body BOC. Controls decoder behaviour when after decoding all described in ABI params there are some data left in BOC: `true` - return decoded values `false` - return error of incomplete BOC deserialization (default)
 
-### ResultOfDecodeInitialData
-
+## ResultOfDecodeInitialData
 ```ts
 type ResultOfDecodeInitialData = {
     initial_data: any,
     initial_pubkey: string
 }
 ```
+- `initial_data`: _any_ – List of initial values of contract's public variables.
+<br>Initial data is decoded if `abi` input parameter is provided
+- `initial_pubkey`: _string_ – Initial account owner's public key
 
-* `initial_data`: _any_ – List of initial values of contract's public variables.\
-  Initial data is decoded if `abi` input parameter is provided
-* `initial_pubkey`: _string_ – Initial account owner's public key
 
-### ParamsOfDecodeBoc
-
+## ParamsOfDecodeBoc
 ```ts
 type ParamsOfDecodeBoc = {
     params: AbiParam[],
@@ -1748,23 +1650,21 @@ type ParamsOfDecodeBoc = {
     allow_partial: boolean
 }
 ```
+- `params`: _[AbiParam](mod\_abi.md#abiparam)[]_ – Parameters to decode from BOC
+- `boc`: _string_ – Data BOC or BOC handle
+- `allow_partial`: _boolean_
 
-* `params`: [_AbiParam_](mod_abi.md#abiparam)_\[]_ – Parameters to decode from BOC
-* `boc`: _string_ – Data BOC or BOC handle
-* `allow_partial`: _boolean_
 
-### ResultOfDecodeBoc
-
+## ResultOfDecodeBoc
 ```ts
 type ResultOfDecodeBoc = {
     data: any
 }
 ```
+- `data`: _any_ – Decoded data as a JSON structure.
 
-* `data`: _any_ – Decoded data as a JSON structure.
 
-### ParamsOfAbiEncodeBoc
-
+## ParamsOfAbiEncodeBoc
 ```ts
 type ParamsOfAbiEncodeBoc = {
     params: AbiParam[],
@@ -1772,24 +1672,22 @@ type ParamsOfAbiEncodeBoc = {
     boc_cache?: BocCacheType
 }
 ```
+- `params`: _[AbiParam](mod\_abi.md#abiparam)[]_ – Parameters to encode into BOC
+- `data`: _any_ – Parameters and values as a JSON structure
+- `boc_cache`?: _[BocCacheType](mod\_boc.md#boccachetype)_ – Cache type to put the result.
+<br>The BOC itself returned if no cache type provided
 
-* `params`: [_AbiParam_](mod_abi.md#abiparam)_\[]_ – Parameters to encode into BOC
-* `data`: _any_ – Parameters and values as a JSON structure
-* `boc_cache`?: [_BocCacheType_](mod_boc.md#boccachetype) – Cache type to put the result.\
-  The BOC itself returned if no cache type provided
 
-### ResultOfAbiEncodeBoc
-
+## ResultOfAbiEncodeBoc
 ```ts
 type ResultOfAbiEncodeBoc = {
     boc: string
 }
 ```
+- `boc`: _string_ – BOC encoded as base64
 
-* `boc`: _string_ – BOC encoded as base64
 
-### ParamsOfCalcFunctionId
-
+## ParamsOfCalcFunctionId
 ```ts
 type ParamsOfCalcFunctionId = {
     abi: Abi,
@@ -1797,23 +1695,22 @@ type ParamsOfCalcFunctionId = {
     output?: boolean
 }
 ```
+- `abi`: _[Abi](mod\_abi.md#abi)_ – Contract ABI.
+- `function_name`: _string_ – Contract function name
+- `output`?: _boolean_ – If set to `true` output function ID will be returned which is used in contract response.
+<br>Default is `false`
 
-* `abi`: [_Abi_](mod_abi.md#abi) – Contract ABI.
-* `function_name`: _string_ – Contract function name
-* `output`?: _boolean_ – If set to `true` output function ID will be returned which is used in contract response. Default is `false`
 
-### ResultOfCalcFunctionId
-
+## ResultOfCalcFunctionId
 ```ts
 type ResultOfCalcFunctionId = {
     function_id: number
 }
 ```
+- `function_id`: _number_ – Contract function ID
 
-* `function_id`: _number_ – Contract function ID
 
-### ParamsOfGetSignatureData
-
+## ParamsOfGetSignatureData
 ```ts
 type ParamsOfGetSignatureData = {
     abi: Abi,
@@ -1821,19 +1718,19 @@ type ParamsOfGetSignatureData = {
     signature_id?: number
 }
 ```
+- `abi`: _[Abi](mod\_abi.md#abi)_ – Contract ABI used to decode.
+- `message`: _string_ – Message BOC encoded in `base64`.
+- `signature_id`?: _number_ – Signature ID to be used in unsigned data preparing when CapSignatureWithId capability is enabled
 
-* `abi`: [_Abi_](mod_abi.md#abi) – Contract ABI used to decode.
-* `message`: _string_ – Message BOC encoded in `base64`.
-* `signature_id`?: _number_ – Signature ID to be used in unsigned data preparing when CapSignatureWithId capability is enabled
 
-### ResultOfGetSignatureData
-
+## ResultOfGetSignatureData
 ```ts
 type ResultOfGetSignatureData = {
     signature: string,
     unsigned: string
 }
 ```
+- `signature`: _string_ – Signature from the message in `hex`.
+- `unsigned`: _string_ – Data to verify the signature in `base64`.
 
-* `signature`: _string_ – Signature from the message in `hex`.
-* `unsigned`: _string_ – Data to verify the signature in `base64`.
+

--- a/docs/acki-nacki-sdk/types-and-methods/mod_account.md
+++ b/docs/acki-nacki-sdk/types-and-methods/mod_account.md
@@ -1,0 +1,162 @@
+# Module account
+
+Provides information about account.
+
+
+## Functions
+[get_account](mod\_account.md#get_account)
+
+## Types
+[AccountErrorCode](mod\_account.md#accounterrorcode)
+
+[ParamsOfGetAccount](mod\_account.md#paramsofgetaccount)
+
+[ResultOfGetAccount](mod\_account.md#resultofgetaccount)
+
+
+# Functions
+## get_account
+
+```ts
+type ParamsOfGetAccount = {
+    account_id: string,
+    dapp_id: string
+}
+
+type ResultOfGetAccount = {
+    boc: string,
+    dapp_id: string,
+    state_timestamp?: bigint,
+    account_id: string
+}
+
+function get_account(
+    params: ParamsOfGetAccount,
+): Promise<ResultOfGetAccount>;
+
+function get_account_sync(
+    params: ParamsOfGetAccount,
+): ResultOfGetAccount;
+```
+NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `account_id`: _string_ – Account ID as a 64-character hex string (no 0x, no workchain).
+- `dapp_id`: _string_ – Dapp ID as a 64-character hex string (no 0x). Required when the server supports the v3 API (info.version >= "1.0.0").
+
+
+### Result
+
+- `boc`: _string_
+- `dapp_id`: _string_
+- `state_timestamp`?: _bigint_
+- `account_id`: _string_
+
+
+# Types
+## AccountErrorCode
+```ts
+enum AccountErrorCode {
+    NotImplemented = 1,
+    InvalidHex = 2,
+    InvalidBase64 = 3,
+    InvalidAddress = 4,
+    CallbackParamsCantBeConvertedToJson = 5,
+    WebsocketConnectError = 6,
+    WebsocketReceiveError = 7,
+    WebsocketSendError = 8,
+    HttpClientCreateError = 9,
+    HttpRequestCreateError = 10,
+    HttpRequestSendError = 11,
+    HttpRequestParseError = 12,
+    CallbackNotRegistered = 13,
+    NetModuleNotInit = 14,
+    InvalidConfig = 15,
+    CannotCreateRuntime = 16,
+    InvalidContextHandle = 17,
+    CannotSerializeResult = 18,
+    CannotSerializeError = 19,
+    CannotConvertJsValueToJson = 20,
+    CannotReceiveSpawnedResult = 21,
+    SetTimerError = 22,
+    InvalidParams = 23,
+    ContractsAddressConversionFailed = 24,
+    UnknownFunction = 25,
+    AppRequestError = 26,
+    NoSuchRequest = 27,
+    CanNotSendRequestResult = 28,
+    CanNotReceiveRequestResult = 29,
+    CanNotParseRequestResult = 30,
+    UnexpectedCallbackResponse = 31,
+    CanNotParseNumber = 32,
+    InternalError = 33,
+    InvalidHandle = 34,
+    LocalStorageError = 35,
+    InvalidData = 36
+}
+```
+One of the following value:
+
+- `NotImplemented = 1`
+- `InvalidHex = 2`
+- `InvalidBase64 = 3`
+- `InvalidAddress = 4`
+- `CallbackParamsCantBeConvertedToJson = 5`
+- `WebsocketConnectError = 6`
+- `WebsocketReceiveError = 7`
+- `WebsocketSendError = 8`
+- `HttpClientCreateError = 9`
+- `HttpRequestCreateError = 10`
+- `HttpRequestSendError = 11`
+- `HttpRequestParseError = 12`
+- `CallbackNotRegistered = 13`
+- `NetModuleNotInit = 14`
+- `InvalidConfig = 15`
+- `CannotCreateRuntime = 16`
+- `InvalidContextHandle = 17`
+- `CannotSerializeResult = 18`
+- `CannotSerializeError = 19`
+- `CannotConvertJsValueToJson = 20`
+- `CannotReceiveSpawnedResult = 21`
+- `SetTimerError = 22`
+- `InvalidParams = 23`
+- `ContractsAddressConversionFailed = 24`
+- `UnknownFunction = 25`
+- `AppRequestError = 26`
+- `NoSuchRequest = 27`
+- `CanNotSendRequestResult = 28`
+- `CanNotReceiveRequestResult = 29`
+- `CanNotParseRequestResult = 30`
+- `UnexpectedCallbackResponse = 31`
+- `CanNotParseNumber = 32`
+- `InternalError = 33`
+- `InvalidHandle = 34`
+- `LocalStorageError = 35`
+- `InvalidData = 36`
+
+
+## ParamsOfGetAccount
+```ts
+type ParamsOfGetAccount = {
+    account_id: string,
+    dapp_id: string
+}
+```
+- `account_id`: _string_ – Account ID as a 64-character hex string (no 0x, no workchain).
+- `dapp_id`: _string_ – Dapp ID as a 64-character hex string (no 0x). Required when the server supports the v3 API (info.version >= "1.0.0").
+
+
+## ResultOfGetAccount
+```ts
+type ResultOfGetAccount = {
+    boc: string,
+    dapp_id: string,
+    state_timestamp?: bigint,
+    account_id: string
+}
+```
+- `boc`: _string_
+- `dapp_id`: _string_
+- `state_timestamp`?: _bigint_
+- `account_id`: _string_
+
+

--- a/docs/acki-nacki-sdk/types-and-methods/mod_boc.md
+++ b/docs/acki-nacki-sdk/types-and-methods/mod_boc.md
@@ -1,148 +1,145 @@
 # Module boc
 
-## Module boc
-
 BOC manipulation module.
 
-### Functions
-
-[decode\_tvc](mod_boc.md#decode_tvc) – Decodes tvc according to the tvc spec. Read more about tvc structure [here](https://github.com/tvmlabs/tvm-sdk/blob/00fd198e4f8f404d5f495c6a65d84b54fe76881b/tvm_struct/src/scheme/mod.rs#L31)
-
-[parse\_message](mod_boc.md#parse_message) – Parses message boc into a JSON
-
-[parse\_transaction](mod_boc.md#parse_transaction) – Parses transaction boc into a JSON
-
-[parse\_account](mod_boc.md#parse_account) – Parses account boc into a JSON
-
-[parse\_block](mod_boc.md#parse_block) – Parses block boc into a JSON
-
-[parse\_shardstate](mod_boc.md#parse_shardstate) – Parses shardstate boc into a JSON
-
-[get\_blockchain\_config](mod_boc.md#get_blockchain_config) – Extract blockchain configuration from key block and also from zerostate.
-
-[get\_boc\_hash](mod_boc.md#get_boc_hash) – Calculates BOC root hash
-
-[get\_boc\_depth](mod_boc.md#get_boc_depth) – Calculates BOC depth
-
-[get\_code\_from\_tvc](mod_boc.md#get_code_from_tvc) – Extracts code from TVC contract image
-
-[cache\_get](mod_boc.md#cache_get) – Get BOC from cache
-
-[cache\_set](mod_boc.md#cache_set) – Save BOC into cache or increase pin counter for existing pinned BOC
-
-[cache\_unpin](mod_boc.md#cache_unpin) – Unpin BOCs with specified pin defined in the `cache_set`. Decrease pin reference counter for BOCs with specified pin defined in the `cache_set`. BOCs which have only 1 pin and its reference counter become 0 will be removed from cache
-
-[encode\_boc](mod_boc.md#encode_boc) – Encodes bag of cells (BOC) with builder operations. This method provides the same functionality as Solidity TvmBuilder. Resulting BOC of this method can be passed into Solidity and C++ contracts as TvmCell type.
-
-[get\_code\_salt](mod_boc.md#get_code_salt) – Returns the contract code's salt if it is present.
-
-[set\_code\_salt](mod_boc.md#set_code_salt) – Sets new salt to contract code.
-
-[decode\_state\_init](mod_boc.md#decode_state_init) – Decodes contract's initial state into code, data, libraries and special options.
-
-[encode\_state\_init](mod_boc.md#encode_state_init) – Encodes initial contract state from code, data, libraries ans special options (see input params)
-
-[encode\_external\_in\_message](mod_boc.md#encode_external_in_message) – Encodes a message
-
-[get\_compiler\_version](mod_boc.md#get_compiler_version) – Returns the compiler version used to compile the code.
-
-### Types
-
-[BocCacheTypePinnedVariant](mod_boc.md#boccachetypepinnedvariant) – Pin the BOC with `pin` name.
-
-[BocCacheTypeUnpinnedVariant](mod_boc.md#boccachetypeunpinnedvariant) – BOC is placed into a common BOC pool with limited size regulated by LRU (least recently used) cache lifecycle.
-
-[BocCacheType](mod_boc.md#boccachetype)
-
-[BuilderOpIntegerVariant](mod_boc.md#builderopintegervariant) – Append integer to cell data.
-
-[BuilderOpBitStringVariant](mod_boc.md#builderopbitstringvariant) – Append bit string to cell data.
-
-[BuilderOpCellVariant](mod_boc.md#builderopcellvariant) – Append ref to nested cells.
-
-[BuilderOpCellBocVariant](mod_boc.md#builderopcellbocvariant) – Append ref to nested cell.
-
-[BuilderOpAddressVariant](mod_boc.md#builderopaddressvariant) – Address.
-
-[BuilderOp](mod_boc.md#builderop) – Cell builder operation.
-
-[TvcV1Variant](mod_boc.md#tvcv1variant)
-
-[Tvc](mod_boc.md#tvc)
-
-[TvcV1](mod_boc.md#tvcv1)
-
-[BocErrorCode](mod_boc.md#bocerrorcode)
-
-[ParamsOfDecodeTvc](mod_boc.md#paramsofdecodetvc)
-
-[ResultOfDecodeTvc](mod_boc.md#resultofdecodetvc)
-
-[ParamsOfParse](mod_boc.md#paramsofparse)
-
-[ResultOfParse](mod_boc.md#resultofparse)
-
-[ParamsOfParseShardstate](mod_boc.md#paramsofparseshardstate)
-
-[ParamsOfGetBlockchainConfig](mod_boc.md#paramsofgetblockchainconfig)
-
-[ResultOfGetBlockchainConfig](mod_boc.md#resultofgetblockchainconfig)
-
-[ParamsOfGetBocHash](mod_boc.md#paramsofgetbochash)
-
-[ResultOfGetBocHash](mod_boc.md#resultofgetbochash)
-
-[ParamsOfGetBocDepth](mod_boc.md#paramsofgetbocdepth)
-
-[ResultOfGetBocDepth](mod_boc.md#resultofgetbocdepth)
-
-[ParamsOfGetCodeFromTvc](mod_boc.md#paramsofgetcodefromtvc)
-
-[ResultOfGetCodeFromTvc](mod_boc.md#resultofgetcodefromtvc)
-
-[ParamsOfBocCacheGet](mod_boc.md#paramsofboccacheget)
-
-[ResultOfBocCacheGet](mod_boc.md#resultofboccacheget)
-
-[ParamsOfBocCacheSet](mod_boc.md#paramsofboccacheget)
-
-ResultOfBocCacheSet
-
-ParamsOfBocCacheUnpin
-
-ParamsOfEncodeBoc
-
-ResultOfEncodeBoc
-
-ParamsOfGetCodeSalt
-
-ResultOfGetCodeSalt
-
-ParamsOfSetCodeSalt
-
-ResultOfSetCodeSalt
-
-ParamsOfDecodeStateInit
-
-ResultOfDecodeStateInit
-
-ParamsOfEncodeStateInit
-
-ResultOfEncodeStateInit
-
-ParamsOfEncodeExternalInMessage
-
-ResultOfEncodeExternalInMessage
-
-ParamsOfGetCompilerVersion
-
-ResultOfGetCompilerVersion
 
 ## Functions
+[decode_tvc](mod\_boc.md#decode_tvc) – Decodes tvc according to the tvc spec. Read more about tvc structure here https://github.com/tonlabs/ever-struct/blob/main/src/scheme/mod.rs#L30
 
-### decode\_tvc
+[parse_message](mod\_boc.md#parse_message) – Parses message boc into a JSON
 
-Decodes tvc according to the tvc spec. Read more about tvc structure [here](https://github.com/tvmlabs/tvm-sdk/blob/00fd198e4f8f404d5f495c6a65d84b54fe76881b/tvm_struct/src/scheme/mod.rs#L31)
+[parse_transaction](mod\_boc.md#parse_transaction) – Parses transaction boc into a JSON
+
+[parse_account](mod\_boc.md#parse_account) – Parses account boc into a JSON
+
+[parse_block](mod\_boc.md#parse_block) – Parses block boc into a JSON
+
+[parse_shardstate](mod\_boc.md#parse_shardstate) – Parses shardstate boc into a JSON
+
+[get_blockchain_config](mod\_boc.md#get_blockchain_config) – Extract blockchain configuration from key block and also from zerostate.
+
+[get_boc_hash](mod\_boc.md#get_boc_hash) – Calculates BOC root hash
+
+[get_boc_depth](mod\_boc.md#get_boc_depth) – Calculates BOC depth
+
+[get_code_from_tvc](mod\_boc.md#get_code_from_tvc) – Extracts code from TVC contract image
+
+[cache_get](mod\_boc.md#cache_get) – Get BOC from cache
+
+[cache_set](mod\_boc.md#cache_set) – Save BOC into cache or increase pin counter for existing pinned BOC
+
+[cache_unpin](mod\_boc.md#cache_unpin) – Unpin BOCs with specified pin defined in the `cache_set`. Decrease pin reference counter for BOCs with specified pin defined in the `cache_set`.
+
+[encode_boc](mod\_boc.md#encode_boc) – Encodes bag of cells (BOC) with builder operations. This method provides the same functionality as Solidity TvmBuilder. Resulting BOC of this method can be passed into Solidity and C++ contracts as TvmCell type.
+
+[get_code_salt](mod\_boc.md#get_code_salt) – Returns the contract code's salt if it is present.
+
+[set_code_salt](mod\_boc.md#set_code_salt) – Sets new salt to contract code.
+
+[decode_state_init](mod\_boc.md#decode_state_init) – Decodes contract's initial state into code, data, libraries and special options.
+
+[encode_state_init](mod\_boc.md#encode_state_init) – Encodes initial contract state from code, data, libraries ans special options (see input params)
+
+[encode_external_in_message](mod\_boc.md#encode_external_in_message) – Encodes a message
+
+[get_compiler_version](mod\_boc.md#get_compiler_version) – Returns the compiler version used to compile the code.
+
+## Types
+[BocCacheTypePinnedVariant](mod\_boc.md#boccachetypepinnedvariant) – Pin the BOC with `pin` name.
+
+[BocCacheTypeUnpinnedVariant](mod\_boc.md#boccachetypeunpinnedvariant) – BOC is placed into a common BOC pool with limited size regulated by LRU (least recently used) cache lifecycle.
+
+[BocCacheType](mod\_boc.md#boccachetype)
+
+[BuilderOpIntegerVariant](mod\_boc.md#builderopintegervariant) – Append integer to cell data.
+
+[BuilderOpBitStringVariant](mod\_boc.md#builderopbitstringvariant) – Append bit string to cell data.
+
+[BuilderOpCellVariant](mod\_boc.md#builderopcellvariant) – Append ref to nested cells.
+
+[BuilderOpCellBocVariant](mod\_boc.md#builderopcellbocvariant) – Append ref to nested cell.
+
+[BuilderOpAddressVariant](mod\_boc.md#builderopaddressvariant) – Address.
+
+[BuilderOp](mod\_boc.md#builderop) – Cell builder operation.
+
+[TvcV1Variant](mod\_boc.md#tvcv1variant)
+
+[Tvc](mod\_boc.md#tvc)
+
+[TvcV1](mod\_boc.md#tvcv1)
+
+[BocErrorCode](mod\_boc.md#bocerrorcode)
+
+[ParamsOfDecodeTvc](mod\_boc.md#paramsofdecodetvc)
+
+[ResultOfDecodeTvc](mod\_boc.md#resultofdecodetvc)
+
+[ParamsOfParse](mod\_boc.md#paramsofparse)
+
+[ResultOfParse](mod\_boc.md#resultofparse)
+
+[ParamsOfParseShardstate](mod\_boc.md#paramsofparseshardstate)
+
+[ParamsOfGetBlockchainConfig](mod\_boc.md#paramsofgetblockchainconfig)
+
+[ResultOfGetBlockchainConfig](mod\_boc.md#resultofgetblockchainconfig)
+
+[ParamsOfGetBocHash](mod\_boc.md#paramsofgetbochash)
+
+[ResultOfGetBocHash](mod\_boc.md#resultofgetbochash)
+
+[ParamsOfGetBocDepth](mod\_boc.md#paramsofgetbocdepth)
+
+[ResultOfGetBocDepth](mod\_boc.md#resultofgetbocdepth)
+
+[ParamsOfGetCodeFromTvc](mod\_boc.md#paramsofgetcodefromtvc)
+
+[ResultOfGetCodeFromTvc](mod\_boc.md#resultofgetcodefromtvc)
+
+[ParamsOfBocCacheGet](mod\_boc.md#paramsofboccacheget)
+
+[ResultOfBocCacheGet](mod\_boc.md#resultofboccacheget)
+
+[ParamsOfBocCacheSet](mod\_boc.md#paramsofboccacheset)
+
+[ResultOfBocCacheSet](mod\_boc.md#resultofboccacheset)
+
+[ParamsOfBocCacheUnpin](mod\_boc.md#paramsofboccacheunpin)
+
+[ParamsOfEncodeBoc](mod\_boc.md#paramsofencodeboc)
+
+[ResultOfEncodeBoc](mod\_boc.md#resultofencodeboc)
+
+[ParamsOfGetCodeSalt](mod\_boc.md#paramsofgetcodesalt)
+
+[ResultOfGetCodeSalt](mod\_boc.md#resultofgetcodesalt)
+
+[ParamsOfSetCodeSalt](mod\_boc.md#paramsofsetcodesalt)
+
+[ResultOfSetCodeSalt](mod\_boc.md#resultofsetcodesalt)
+
+[ParamsOfDecodeStateInit](mod\_boc.md#paramsofdecodestateinit)
+
+[ResultOfDecodeStateInit](mod\_boc.md#resultofdecodestateinit)
+
+[ParamsOfEncodeStateInit](mod\_boc.md#paramsofencodestateinit)
+
+[ResultOfEncodeStateInit](mod\_boc.md#resultofencodestateinit)
+
+[ParamsOfEncodeExternalInMessage](mod\_boc.md#paramsofencodeexternalinmessage)
+
+[ResultOfEncodeExternalInMessage](mod\_boc.md#resultofencodeexternalinmessage)
+
+[ParamsOfGetCompilerVersion](mod\_boc.md#paramsofgetcompilerversion)
+
+[ResultOfGetCompilerVersion](mod\_boc.md#resultofgetcompilerversion)
+
+
+# Functions
+## decode_tvc
+
+Decodes tvc according to the tvc spec. Read more about tvc structure here https://github.com/tonlabs/ever-struct/blob/main/src/scheme/mod.rs#L30
 
 ```ts
 type ParamsOfDecodeTvc = {
@@ -161,18 +158,17 @@ function decode_tvc_sync(
     params: ParamsOfDecodeTvc,
 ): ResultOfDecodeTvc;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `tvc`: _string_ – Contract TVC BOC encoded as base64 or BOC handle
 
-#### Parameters
 
-* `tvc`: _string_ – Contract TVC BOC encoded as base64 or BOC handle
+### Result
 
-#### Result
+- `tvc`: _[Tvc](mod\_boc.md#tvc)_ – Decoded TVC
 
-* `tvc`: [_Tvc_](mod_boc.md#tvc) – Decoded TVC
 
-### parse\_message
+## parse_message
 
 Parses message boc into a JSON
 
@@ -195,18 +191,17 @@ function parse_message_sync(
     params: ParamsOfParse,
 ): ResultOfParse;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `boc`: _string_ – BOC encoded as base64
 
-#### Parameters
 
-* `boc`: _string_ – BOC encoded as base64
+### Result
 
-#### Result
+- `parsed`: _any_ – JSON containing parsed BOC
 
-* `parsed`: _any_ – JSON containing parsed BOC
 
-### parse\_transaction
+## parse_transaction
 
 Parses transaction boc into a JSON
 
@@ -229,18 +224,17 @@ function parse_transaction_sync(
     params: ParamsOfParse,
 ): ResultOfParse;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `boc`: _string_ – BOC encoded as base64
 
-#### Parameters
 
-* `boc`: _string_ – BOC encoded as base64
+### Result
 
-#### Result
+- `parsed`: _any_ – JSON containing parsed BOC
 
-* `parsed`: _any_ – JSON containing parsed BOC
 
-### parse\_account
+## parse_account
 
 Parses account boc into a JSON
 
@@ -263,18 +257,17 @@ function parse_account_sync(
     params: ParamsOfParse,
 ): ResultOfParse;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `boc`: _string_ – BOC encoded as base64
 
-#### Parameters
 
-* `boc`: _string_ – BOC encoded as base64
+### Result
 
-#### Result
+- `parsed`: _any_ – JSON containing parsed BOC
 
-* `parsed`: _any_ – JSON containing parsed BOC
 
-### parse\_block
+## parse_block
 
 Parses block boc into a JSON
 
@@ -297,18 +290,17 @@ function parse_block_sync(
     params: ParamsOfParse,
 ): ResultOfParse;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `boc`: _string_ – BOC encoded as base64
 
-#### Parameters
 
-* `boc`: _string_ – BOC encoded as base64
+### Result
 
-#### Result
+- `parsed`: _any_ – JSON containing parsed BOC
 
-* `parsed`: _any_ – JSON containing parsed BOC
 
-### parse\_shardstate
+## parse_shardstate
 
 Parses shardstate boc into a JSON
 
@@ -333,20 +325,19 @@ function parse_shardstate_sync(
     params: ParamsOfParseShardstate,
 ): ResultOfParse;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `boc`: _string_ – BOC encoded as base64
+- `id`: _string_ – Shardstate identifier
+- `workchain_id`: _number_ – Workchain shardstate belongs to
 
-#### Parameters
 
-* `boc`: _string_ – BOC encoded as base64
-* `id`: _string_ – Shardstate identifier
-* `workchain_id`: _number_ – Workchain shardstate belongs to
+### Result
 
-#### Result
+- `parsed`: _any_ – JSON containing parsed BOC
 
-* `parsed`: _any_ – JSON containing parsed BOC
 
-### get\_blockchain\_config
+## get_blockchain_config
 
 Extract blockchain configuration from key block and also from zerostate.
 
@@ -367,18 +358,17 @@ function get_blockchain_config_sync(
     params: ParamsOfGetBlockchainConfig,
 ): ResultOfGetBlockchainConfig;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `block_boc`: _string_ – Key block BOC or zerostate BOC encoded as base64
 
-#### Parameters
 
-* `block_boc`: _string_ – Key block BOC or zerostate BOC encoded as base64
+### Result
 
-#### Result
+- `config_boc`: _string_ – Blockchain config BOC encoded as base64
 
-* `config_boc`: _string_ – Blockchain config BOC encoded as base64
 
-### get\_boc\_hash
+## get_boc_hash
 
 Calculates BOC root hash
 
@@ -399,18 +389,17 @@ function get_boc_hash_sync(
     params: ParamsOfGetBocHash,
 ): ResultOfGetBocHash;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `boc`: _string_ – BOC encoded as base64 or BOC handle
 
-#### Parameters
 
-* `boc`: _string_ – BOC encoded as base64 or BOC handle
+### Result
 
-#### Result
+- `hash`: _string_ – BOC root hash encoded with hex
 
-* `hash`: _string_ – BOC root hash encoded with hex
 
-### get\_boc\_depth
+## get_boc_depth
 
 Calculates BOC depth
 
@@ -431,18 +420,17 @@ function get_boc_depth_sync(
     params: ParamsOfGetBocDepth,
 ): ResultOfGetBocDepth;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `boc`: _string_ – BOC encoded as base64 or BOC handle
 
-#### Parameters
 
-* `boc`: _string_ – BOC encoded as base64 or BOC handle
+### Result
 
-#### Result
+- `depth`: _number_ – BOC root cell depth
 
-* `depth`: _number_ – BOC root cell depth
 
-### get\_code\_from\_tvc
+## get_code_from_tvc
 
 Extracts code from TVC contract image
 
@@ -463,18 +451,17 @@ function get_code_from_tvc_sync(
     params: ParamsOfGetCodeFromTvc,
 ): ResultOfGetCodeFromTvc;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `tvc`: _string_ – Contract TVC image or image BOC handle
 
-#### Parameters
 
-* `tvc`: _string_ – Contract TVC image or image BOC handle
+### Result
 
-#### Result
+- `code`: _string_ – Contract code encoded as base64
 
-* `code`: _string_ – Contract code encoded as base64
 
-### cache\_get
+## cache_get
 
 Get BOC from cache
 
@@ -495,18 +482,17 @@ function cache_get_sync(
     params: ParamsOfBocCacheGet,
 ): ResultOfBocCacheGet;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `boc_ref`: _string_ – Reference to the cached BOC
 
-#### Parameters
 
-* `boc_ref`: _string_ – Reference to the cached BOC
+### Result
 
-#### Result
+- `boc`?: _string_ – BOC encoded as base64.
 
-* `boc`?: _string_ – BOC encoded as base64.
 
-### cache\_set
+## cache_set
 
 Save BOC into cache or increase pin counter for existing pinned BOC
 
@@ -528,21 +514,22 @@ function cache_set_sync(
     params: ParamsOfBocCacheSet,
 ): ResultOfBocCacheSet;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `boc`: _string_ – BOC encoded as base64 or BOC reference
+- `cache_type`: _[BocCacheType](mod\_boc.md#boccachetype)_ – Cache type
 
-#### Parameters
 
-* `boc`: _string_ – BOC encoded as base64 or BOC reference
-* `cache_type`: [_BocCacheType_](mod_boc.md#boccachetype) – Cache type
+### Result
 
-#### Result
+- `boc_ref`: _string_ – Reference to the cached BOC
 
-* `boc_ref`: _string_ – Reference to the cached BOC
 
-### cache\_unpin
+## cache_unpin
 
-Unpin BOCs with specified pin defined in the `cache_set`. Decrease pin reference counter for BOCs with specified pin defined in the `cache_set`. BOCs which have only 1 pin and its reference counter become 0 will be removed from cache
+Unpin BOCs with specified pin defined in the `cache_set`. Decrease pin reference counter for BOCs with specified pin defined in the `cache_set`.
+
+BOCs which have only 1 pin and its reference counter become 0 will be removed from cache
 
 ```ts
 type ParamsOfBocCacheUnpin = {
@@ -558,16 +545,14 @@ function cache_unpin_sync(
     params: ParamsOfBocCacheUnpin,
 ): void;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `pin`: _string_ – Pinned name
+- `boc_ref`?: _string_ – Reference to the cached BOC.
+<br>If it is provided then only referenced BOC is unpinned
 
-#### Parameters
 
-* `pin`: _string_ – Pinned name
-* `boc_ref`?: _string_ – Reference to the cached BOC.\
-  If it is provided then only referenced BOC is unpinned
-
-### encode\_boc
+## encode_boc
 
 Encodes bag of cells (BOC) with builder operations. This method provides the same functionality as Solidity TvmBuilder. Resulting BOC of this method can be passed into Solidity and C++ contracts as TvmCell type.
 
@@ -589,19 +574,18 @@ function encode_boc_sync(
     params: ParamsOfEncodeBoc,
 ): ResultOfEncodeBoc;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `builder`: _[BuilderOp](mod\_boc.md#builderop)[]_ – Cell builder operations.
+- `boc_cache`?: _[BocCacheType](mod\_boc.md#boccachetype)_ – Cache type to put the result. The BOC itself returned if no cache type provided.
 
-#### Parameters
 
-* `builder`: [_BuilderOp_](mod_boc.md#builderop)_\[]_ – Cell builder operations.
-* `boc_cache`?: [_BocCacheType_](mod_boc.md#boccachetype) – Cache type to put the result. The BOC itself returned if no cache type provided.
+### Result
 
-#### Result
+- `boc`: _string_ – Encoded cell BOC or BOC cache key.
 
-* `boc`: _string_ – Encoded cell BOC or BOC cache key.
 
-### get\_code\_salt
+## get_code_salt
 
 Returns the contract code's salt if it is present.
 
@@ -623,20 +607,19 @@ function get_code_salt_sync(
     params: ParamsOfGetCodeSalt,
 ): ResultOfGetCodeSalt;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `code`: _string_ – Contract code BOC encoded as base64 or code BOC handle
+- `boc_cache`?: _[BocCacheType](mod\_boc.md#boccachetype)_ – Cache type to put the result. The BOC itself returned if no cache type provided.
 
-#### Parameters
 
-* `code`: _string_ – Contract code BOC encoded as base64 or code BOC handle
-* `boc_cache`?: [_BocCacheType_](mod_boc.md#boccachetype) – Cache type to put the result. The BOC itself returned if no cache type provided.
+### Result
 
-#### Result
+- `salt`?: _string_ – Contract code salt if present.
+<br>BOC encoded as base64 or BOC handle
 
-* `salt`?: _string_ – Contract code salt if present.\
-  BOC encoded as base64 or BOC handle
 
-### set\_code\_salt
+## set_code_salt
 
 Sets new salt to contract code.
 
@@ -661,22 +644,21 @@ function set_code_salt_sync(
     params: ParamsOfSetCodeSalt,
 ): ResultOfSetCodeSalt;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `code`: _string_ – Contract code BOC encoded as base64 or code BOC handle
+- `salt`: _string_ – Code salt to set.
+<br>BOC encoded as base64 or BOC handle
+- `boc_cache`?: _[BocCacheType](mod\_boc.md#boccachetype)_ – Cache type to put the result. The BOC itself returned if no cache type provided.
 
-#### Parameters
 
-* `code`: _string_ – Contract code BOC encoded as base64 or code BOC handle
-* `salt`: _string_ – Code salt to set.\
-  BOC encoded as base64 or BOC handle
-* `boc_cache`?: [_BocCacheType_](mod_boc.md#boccachetype) – Cache type to put the result. The BOC itself returned if no cache type provided.
+### Result
 
-#### Result
+- `code`: _string_ – Contract code with salt set.
+<br>BOC encoded as base64 or BOC handle
 
-* `code`: _string_ – Contract code with salt set.\
-  BOC encoded as base64 or BOC handle
 
-### decode\_state\_init
+## decode_state_init
 
 Decodes contract's initial state into code, data, libraries and special options.
 
@@ -708,31 +690,30 @@ function decode_state_init_sync(
     params: ParamsOfDecodeStateInit,
 ): ResultOfDecodeStateInit;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `state_init`: _string_ – Contract StateInit image BOC encoded as base64 or BOC handle
+- `boc_cache`?: _[BocCacheType](mod\_boc.md#boccachetype)_ – Cache type to put the result. The BOC itself returned if no cache type provided.
 
-#### Parameters
 
-* `state_init`: _string_ – Contract StateInit image BOC encoded as base64 or BOC handle
-* `boc_cache`?: [_BocCacheType_](mod_boc.md#boccachetype) – Cache type to put the result. The BOC itself returned if no cache type provided.
+### Result
 
-#### Result
+- `code`?: _string_ – Contract code BOC encoded as base64 or BOC handle
+- `code_hash`?: _string_ – Contract code hash
+- `code_depth`?: _number_ – Contract code depth
+- `data`?: _string_ – Contract data BOC encoded as base64 or BOC handle
+- `data_hash`?: _string_ – Contract data hash
+- `data_depth`?: _number_ – Contract data depth
+- `library`?: _string_ – Contract library BOC encoded as base64 or BOC handle
+- `tick`?: _boolean_ – `special.tick` field.
+<br>Specifies the contract ability to handle tick transactions
+- `tock`?: _boolean_ – `special.tock` field.
+<br>Specifies the contract ability to handle tock transactions
+- `split_depth`?: _number_ – Is present and non-zero only in instances of large smart contracts
+- `compiler_version`?: _string_ – Compiler version, for example 'sol 0.49.0'
 
-* `code`?: _string_ – Contract code BOC encoded as base64 or BOC handle
-* `code_hash`?: _string_ – Contract code hash
-* `code_depth`?: _number_ – Contract code depth
-* `data`?: _string_ – Contract data BOC encoded as base64 or BOC handle
-* `data_hash`?: _string_ – Contract data hash
-* `data_depth`?: _number_ – Contract data depth
-* `library`?: _string_ – Contract library BOC encoded as base64 or BOC handle
-* `tick`?: _boolean_ – `special.tick` field.\
-  Specifies the contract ability to handle tick transactions
-* `tock`?: _boolean_ – `special.tock` field.\
-  Specifies the contract ability to handle tock transactions
-* `split_depth`?: _number_ – Is present and non-zero only in instances of large smart contracts
-* `compiler_version`?: _string_ – Compiler version, for example 'sol 0.49.0'
 
-### encode\_state\_init
+## encode_state_init
 
 Encodes initial contract state from code, data, libraries ans special options (see input params)
 
@@ -759,26 +740,25 @@ function encode_state_init_sync(
     params: ParamsOfEncodeStateInit,
 ): ResultOfEncodeStateInit;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `code`?: _string_ – Contract code BOC encoded as base64 or BOC handle
+- `data`?: _string_ – Contract data BOC encoded as base64 or BOC handle
+- `library`?: _string_ – Contract library BOC encoded as base64 or BOC handle
+- `tick`?: _boolean_ – `special.tick` field.
+<br>Specifies the contract ability to handle tick transactions
+- `tock`?: _boolean_ – `special.tock` field.
+<br>Specifies the contract ability to handle tock transactions
+- `split_depth`?: _number_ – Is present and non-zero only in instances of large smart contracts
+- `boc_cache`?: _[BocCacheType](mod\_boc.md#boccachetype)_ – Cache type to put the result. The BOC itself returned if no cache type provided.
 
-#### Parameters
 
-* `code`?: _string_ – Contract code BOC encoded as base64 or BOC handle
-* `data`?: _string_ – Contract data BOC encoded as base64 or BOC handle
-* `library`?: _string_ – Contract library BOC encoded as base64 or BOC handle
-* `tick`?: _boolean_ – `special.tick` field.\
-  Specifies the contract ability to handle tick transactions
-* `tock`?: _boolean_ – `special.tock` field.\
-  Specifies the contract ability to handle tock transactions
-* `split_depth`?: _number_ – Is present and non-zero only in instances of large smart contracts
-* `boc_cache`?: [_BocCacheType_](mod_boc.md#boccachetype) – Cache type to put the result. The BOC itself returned if no cache type provided.
+### Result
 
-#### Result
+- `state_init`: _string_ – Contract StateInit image BOC encoded as base64 or BOC handle of boc_cache parameter was specified
 
-* `state_init`: _string_ – Contract StateInit image BOC encoded as base64 or BOC handle of boc\_cache parameter was specified
 
-### encode\_external\_in\_message
+## encode_external_in_message
 
 Encodes a message
 
@@ -806,24 +786,23 @@ function encode_external_in_message_sync(
     params: ParamsOfEncodeExternalInMessage,
 ): ResultOfEncodeExternalInMessage;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `src`?: _string_ – Source address.
+- `dst`: _string_ – Destination address.
+- `init`?: _string_ – Bag of cells with state init (used in deploy messages).
+- `body`?: _string_ – Bag of cells with the message body encoded as base64.
+- `boc_cache`?: _[BocCacheType](mod\_boc.md#boccachetype)_ – Cache type to put the result.
+<br>The BOC itself returned if no cache type provided
 
-#### Parameters
 
-* `src`?: _string_ – Source address.
-* `dst`: _string_ – Destination address.
-* `init`?: _string_ – Bag of cells with state init (used in deploy messages).
-* `body`?: _string_ – Bag of cells with the message body encoded as base64.
-* `boc_cache`?: [_BocCacheType_](mod_boc.md#boccachetype) – Cache type to put the result.\
-  The BOC itself returned if no cache type provided
+### Result
 
-#### Result
+- `message`: _string_ – Message BOC encoded with `base64`.
+- `message_id`: _string_ – Message id.
 
-* `message`: _string_ – Message BOC encoded with `base64`.
-* `message_id`: _string_ – Message id.
 
-### get\_compiler\_version
+## get_compiler_version
 
 Returns the compiler version used to compile the code.
 
@@ -844,35 +823,34 @@ function get_compiler_version_sync(
     params: ParamsOfGetCompilerVersion,
 ): ResultOfGetCompilerVersion;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `code`: _string_ – Contract code BOC encoded as base64 or code BOC handle
 
-#### Parameters
 
-* `code`: _string_ – Contract code BOC encoded as base64 or code BOC handle
+### Result
 
-#### Result
+- `version`?: _string_ – Compiler version, for example 'sol 0.49.0'
 
-* `version`?: _string_ – Compiler version, for example 'sol 0.49.0'
 
-## Types
-
-### BocCacheTypePinnedVariant
-
+# Types
+## BocCacheTypePinnedVariant
 Pin the BOC with `pin` name.
 
-Such BOC will not be removed from cache until it is unpinned BOCs can have several pins and each of the pins has reference counter indicating how many times the BOC was pinned with the pin. BOC is removed from cache after all references for all pins are unpinned with `cache_unpin` function calls.
+Such BOC will not be removed from cache until it is unpinned BOCs can have several pins and each of the pins
+has reference counter indicating how many times the BOC was pinned
+with the pin. BOC is removed from cache after all references for all
+pins are unpinned with `cache_unpin` function calls.
 
 ```ts
 type BocCacheTypePinnedVariant = {
     pin: string
 }
 ```
+- `pin`: _string_
 
-* `pin`: _string_
 
-### BocCacheTypeUnpinnedVariant
-
+## BocCacheTypeUnpinnedVariant
 BOC is placed into a common BOC pool with limited size regulated by LRU (least recently used) cache lifecycle.
 
 BOC resides there until it is replaced with other BOCs if it is not used
@@ -883,8 +861,8 @@ type BocCacheTypeUnpinnedVariant = {
 }
 ```
 
-### BocCacheType
 
+## BocCacheType
 ```ts
 type BocCacheType = ({
     type: 'Pinned'
@@ -892,22 +870,26 @@ type BocCacheType = ({
     type: 'Unpinned'
 } & BocCacheTypeUnpinnedVariant)
 ```
-
-Depends on value of the `type` field.
+Depends on value of the  `type` field.
 
 When _type_ is _'Pinned'_
 
 Pin the BOC with `pin` name.
 
-Such BOC will not be removed from cache until it is unpinned BOCs can have several pins and each of the pins has reference counter indicating how many times the BOC was pinned with the pin. BOC is removed from cache after all references for all pins are unpinned with `cache_unpin` function calls.
+Such BOC will not be removed from cache until it is unpinned BOCs can have several pins and each of the pins
+has reference counter indicating how many times the BOC was pinned
+with the pin. BOC is removed from cache after all references for all
+pins are unpinned with `cache_unpin` function calls.
 
-* `pin`: _string_
+- `pin`: _string_
 
 When _type_ is _'Unpinned'_
 
 BOC is placed into a common BOC pool with limited size regulated by LRU (least recently used) cache lifecycle.
 
 BOC resides there until it is replaced with other BOCs if it is not used
+
+
 
 Variant constructors:
 
@@ -916,8 +898,7 @@ function bocCacheTypePinned(pin: string): BocCacheType;
 function bocCacheTypeUnpinned(): BocCacheType;
 ```
 
-### BuilderOpIntegerVariant
-
+## BuilderOpIntegerVariant
 Append integer to cell data.
 
 ```ts
@@ -926,15 +907,12 @@ type BuilderOpIntegerVariant = {
     value: any
 }
 ```
+- `size`: _number_ – Bit size of the value.
+- `value`: _any_ – Value: - `Number` containing integer number.
+<br>e.g. `123`, `-123`. - Decimal string. e.g. `"123"`, `"-123"`.<br>- `0x` prefixed hexadecimal string. e.g `0x123`, `0X123`, `-0x123`.
 
-* `size`: _number_ – Bit size of the value.
-* `value`: _any_ – Value: - `Number` containing integer number.\
-  e.g. `123`, `-123`. - Decimal string. e.g. `"123"`, `"-123"`.\
-  \- `0x` prefixed hexadecimal string.\
-  e.g `0x123`, `0X123`, `-0x123`.
 
-### BuilderOpBitStringVariant
-
+## BuilderOpBitStringVariant
 Append bit string to cell data.
 
 ```ts
@@ -942,23 +920,11 @@ type BuilderOpBitStringVariant = {
     value: string
 }
 ```
+- `value`: _string_ – Bit string content using bitstring notation. See `TON VM specification` 1.0.
+<br>Contains hexadecimal string representation:<br>- Can end with `_` tag.<br>- Can be prefixed with `x` or `X`.<br>- Can be prefixed with `x{` or `X{` and ended with `}`.<br><br>Contains binary string represented as a sequence<br>of `0` and `1` prefixed with `n` or `N`.<br><br>Examples:<br>`1AB`, `x1ab`, `X1AB`, `x{1abc}`, `X{1ABC}`<br>`2D9_`, `x2D9_`, `X2D9_`, `x{2D9_}`, `X{2D9_}`<br>`n00101101100`, `N00101101100`
 
-* `value`: _string_ – Bit string content using bitstring notation. See `TON specification` 1.0.\
-  Contains hexadecimal string representation:\
-  \- Can end with `_` tag.\
-  \- Can be prefixed with `x` or `X`.\
-  \- Can be prefixed with `x{` or `X{` and ended with `}`.\
-  \
-  Contains binary string represented as a sequence\
-  of `0` and `1` prefixed with `n` or `N`.\
-  \
-  Examples:\
-  `1AB`, `x1ab`, `X1AB`, `x{1abc}`, `X{1ABC}`\
-  `2D9_`, `x2D9_`, `X2D9_`, `x{2D9_}`, `X{2D9_}`\
-  `n00101101100`, `N00101101100`
 
-### BuilderOpCellVariant
-
+## BuilderOpCellVariant
 Append ref to nested cells.
 
 ```ts
@@ -966,11 +932,10 @@ type BuilderOpCellVariant = {
     builder: BuilderOp[]
 }
 ```
+- `builder`: _[BuilderOp](mod\_boc.md#builderop)[]_ – Nested cell builder.
 
-* `builder`: [_BuilderOp_](mod_boc.md#builderop)_\[]_ – Nested cell builder.
 
-### BuilderOpCellBocVariant
-
+## BuilderOpCellBocVariant
 Append ref to nested cell.
 
 ```ts
@@ -978,11 +943,10 @@ type BuilderOpCellBocVariant = {
     boc: string
 }
 ```
+- `boc`: _string_ – Nested cell BOC encoded with `base64` or BOC cache key.
 
-* `boc`: _string_ – Nested cell BOC encoded with `base64` or BOC cache key.
 
-### BuilderOpAddressVariant
-
+## BuilderOpAddressVariant
 Address.
 
 ```ts
@@ -990,11 +954,10 @@ type BuilderOpAddressVariant = {
     address: string
 }
 ```
+- `address`: _string_ – Address in a common `workchain:account` or base64 format.
 
-* `address`: _string_ – Address in a common `workchain:account` or base64 format.
 
-### BuilderOp
-
+## BuilderOp
 Cell builder operation.
 
 ```ts
@@ -1010,54 +973,41 @@ type BuilderOp = ({
     type: 'Address'
 } & BuilderOpAddressVariant)
 ```
-
-Depends on value of the `type` field.
+Depends on value of the  `type` field.
 
 When _type_ is _'Integer'_
 
 Append integer to cell data.
 
-* `size`: _number_ – Bit size of the value.
-* `value`: _any_ – Value: - `Number` containing integer number.\
-  e.g. `123`, `-123`. - Decimal string. e.g. `"123"`, `"-123"`.\
-  \- `0x` prefixed hexadecimal string.\
-  e.g `0x123`, `0X123`, `-0x123`.
+- `size`: _number_ – Bit size of the value.
+- `value`: _any_ – Value: - `Number` containing integer number.
+<br>e.g. `123`, `-123`. - Decimal string. e.g. `"123"`, `"-123"`.<br>- `0x` prefixed hexadecimal string. e.g `0x123`, `0X123`, `-0x123`.
 
 When _type_ is _'BitString'_
 
 Append bit string to cell data.
 
-* `value`: _string_ – Bit string content using bitstring notation. See `TVM specification` 1.0.\
-  Contains hexadecimal string representation:\
-  \- Can end with `_` tag.\
-  \- Can be prefixed with `x` or `X`.\
-  \- Can be prefixed with `x{` or `X{` and ended with `}`.\
-  \
-  Contains binary string represented as a sequence\
-  of `0` and `1` prefixed with `n` or `N`.\
-  \
-  Examples:\
-  `1AB`, `x1ab`, `X1AB`, `x{1abc}`, `X{1ABC}`\
-  `2D9_`, `x2D9_`, `X2D9_`, `x{2D9_}`, `X{2D9_}`\
-  `n00101101100`, `N00101101100`
+- `value`: _string_ – Bit string content using bitstring notation. See `TON VM specification` 1.0.
+<br>Contains hexadecimal string representation:<br>- Can end with `_` tag.<br>- Can be prefixed with `x` or `X`.<br>- Can be prefixed with `x{` or `X{` and ended with `}`.<br><br>Contains binary string represented as a sequence<br>of `0` and `1` prefixed with `n` or `N`.<br><br>Examples:<br>`1AB`, `x1ab`, `X1AB`, `x{1abc}`, `X{1ABC}`<br>`2D9_`, `x2D9_`, `X2D9_`, `x{2D9_}`, `X{2D9_}`<br>`n00101101100`, `N00101101100`
 
 When _type_ is _'Cell'_
 
 Append ref to nested cells.
 
-* `builder`: [_BuilderOp_](mod_boc.md#builderop)_\[]_ – Nested cell builder.
+- `builder`: _[BuilderOp](mod\_boc.md#builderop)[]_ – Nested cell builder.
 
 When _type_ is _'CellBoc'_
 
 Append ref to nested cell.
 
-* `boc`: _string_ – Nested cell BOC encoded with `base64` or BOC cache key.
+- `boc`: _string_ – Nested cell BOC encoded with `base64` or BOC cache key.
 
 When _type_ is _'Address'_
 
 Address.
 
-* `address`: _string_ – Address in a common `workchain:account` or base64 format.
+- `address`: _string_ – Address in a common `workchain:account` or base64 format.
+
 
 Variant constructors:
 
@@ -1069,29 +1019,27 @@ function builderOpCellBoc(boc: string): BuilderOp;
 function builderOpAddress(address: string): BuilderOp;
 ```
 
-### TvcV1Variant
-
+## TvcV1Variant
 ```ts
 type TvcV1Variant = {
     value: TvcV1
 }
 ```
+- `value`: _[TvcV1](mod\_boc.md#tvcv1)_
 
-* `value`: [_TvcV1_](mod_boc.md#tvcv1)
 
-### Tvc
-
+## Tvc
 ```ts
 type Tvc = ({
     type: 'V1'
 } & TvcV1Variant)
 ```
-
-Depends on value of the `type` field.
+Depends on value of the  `type` field.
 
 When _type_ is _'V1'_
 
-* `value`: [_TvcV1_](mod_boc.md#tvcv1)
+- `value`: _[TvcV1](mod\_boc.md#tvcv1)_
+
 
 Variant constructors:
 
@@ -1099,20 +1047,18 @@ Variant constructors:
 function tvcV1(value: TvcV1): Tvc;
 ```
 
-### TvcV1
-
+## TvcV1
 ```ts
 type TvcV1 = {
     code?: string,
     description?: string
 }
 ```
+- `code`?: _string_
+- `description`?: _string_
 
-* `code`?: _string_
-* `description`?: _string_
 
-### BocErrorCode
-
+## BocErrorCode
 ```ts
 enum BocErrorCode {
     InvalidBoc = 201,
@@ -1124,59 +1070,54 @@ enum BocErrorCode {
     InvalidBocRef = 207
 }
 ```
-
 One of the following value:
 
-* `InvalidBoc = 201`
-* `SerializationError = 202`
-* `InappropriateBlock = 203`
-* `MissingSourceBoc = 204`
-* `InsufficientCacheSize = 205`
-* `BocRefNotFound = 206`
-* `InvalidBocRef = 207`
+- `InvalidBoc = 201`
+- `SerializationError = 202`
+- `InappropriateBlock = 203`
+- `MissingSourceBoc = 204`
+- `InsufficientCacheSize = 205`
+- `BocRefNotFound = 206`
+- `InvalidBocRef = 207`
 
-### ParamsOfDecodeTvc
 
+## ParamsOfDecodeTvc
 ```ts
 type ParamsOfDecodeTvc = {
     tvc: string
 }
 ```
+- `tvc`: _string_ – Contract TVC BOC encoded as base64 or BOC handle
 
-* `tvc`: _string_ – Contract TVC BOC encoded as base64 or BOC handle
 
-### ResultOfDecodeTvc
-
+## ResultOfDecodeTvc
 ```ts
 type ResultOfDecodeTvc = {
     tvc: Tvc
 }
 ```
+- `tvc`: _[Tvc](mod\_boc.md#tvc)_ – Decoded TVC
 
-* `tvc`: [_Tvc_](mod_boc.md#tvc) – Decoded TVC
 
-### ParamsOfParse
-
+## ParamsOfParse
 ```ts
 type ParamsOfParse = {
     boc: string
 }
 ```
+- `boc`: _string_ – BOC encoded as base64
 
-* `boc`: _string_ – BOC encoded as base64
 
-### ResultOfParse
-
+## ResultOfParse
 ```ts
 type ResultOfParse = {
     parsed: any
 }
 ```
+- `parsed`: _any_ – JSON containing parsed BOC
 
-* `parsed`: _any_ – JSON containing parsed BOC
 
-### ParamsOfParseShardstate
-
+## ParamsOfParseShardstate
 ```ts
 type ParamsOfParseShardstate = {
     boc: string,
@@ -1184,193 +1125,175 @@ type ParamsOfParseShardstate = {
     workchain_id: number
 }
 ```
+- `boc`: _string_ – BOC encoded as base64
+- `id`: _string_ – Shardstate identifier
+- `workchain_id`: _number_ – Workchain shardstate belongs to
 
-* `boc`: _string_ – BOC encoded as base64
-* `id`: _string_ – Shardstate identifier
-* `workchain_id`: _number_ – Workchain shardstate belongs to
 
-### ParamsOfGetBlockchainConfig
-
+## ParamsOfGetBlockchainConfig
 ```ts
 type ParamsOfGetBlockchainConfig = {
     block_boc: string
 }
 ```
+- `block_boc`: _string_ – Key block BOC or zerostate BOC encoded as base64
 
-* `block_boc`: _string_ – Key block BOC or zerostate BOC encoded as base64
 
-### ResultOfGetBlockchainConfig
-
+## ResultOfGetBlockchainConfig
 ```ts
 type ResultOfGetBlockchainConfig = {
     config_boc: string
 }
 ```
+- `config_boc`: _string_ – Blockchain config BOC encoded as base64
 
-* `config_boc`: _string_ – Blockchain config BOC encoded as base64
 
-### ParamsOfGetBocHash
-
+## ParamsOfGetBocHash
 ```ts
 type ParamsOfGetBocHash = {
     boc: string
 }
 ```
+- `boc`: _string_ – BOC encoded as base64 or BOC handle
 
-* `boc`: _string_ – BOC encoded as base64 or BOC handle
 
-### ResultOfGetBocHash
-
+## ResultOfGetBocHash
 ```ts
 type ResultOfGetBocHash = {
     hash: string
 }
 ```
+- `hash`: _string_ – BOC root hash encoded with hex
 
-* `hash`: _string_ – BOC root hash encoded with hex
 
-### ParamsOfGetBocDepth
-
+## ParamsOfGetBocDepth
 ```ts
 type ParamsOfGetBocDepth = {
     boc: string
 }
 ```
+- `boc`: _string_ – BOC encoded as base64 or BOC handle
 
-* `boc`: _string_ – BOC encoded as base64 or BOC handle
 
-### ResultOfGetBocDepth
-
+## ResultOfGetBocDepth
 ```ts
 type ResultOfGetBocDepth = {
     depth: number
 }
 ```
+- `depth`: _number_ – BOC root cell depth
 
-* `depth`: _number_ – BOC root cell depth
 
-### ParamsOfGetCodeFromTvc
-
+## ParamsOfGetCodeFromTvc
 ```ts
 type ParamsOfGetCodeFromTvc = {
     tvc: string
 }
 ```
+- `tvc`: _string_ – Contract TVC image or image BOC handle
 
-* `tvc`: _string_ – Contract TVC image or image BOC handle
 
-### ResultOfGetCodeFromTvc
-
+## ResultOfGetCodeFromTvc
 ```ts
 type ResultOfGetCodeFromTvc = {
     code: string
 }
 ```
+- `code`: _string_ – Contract code encoded as base64
 
-* `code`: _string_ – Contract code encoded as base64
 
-### ParamsOfBocCacheGet
-
+## ParamsOfBocCacheGet
 ```ts
 type ParamsOfBocCacheGet = {
     boc_ref: string
 }
 ```
+- `boc_ref`: _string_ – Reference to the cached BOC
 
-* `boc_ref`: _string_ – Reference to the cached BOC
 
-### ResultOfBocCacheGet
-
+## ResultOfBocCacheGet
 ```ts
 type ResultOfBocCacheGet = {
     boc?: string
 }
 ```
+- `boc`?: _string_ – BOC encoded as base64.
 
-* `boc`?: _string_ – BOC encoded as base64.
 
-### ParamsOfBocCacheSet
-
+## ParamsOfBocCacheSet
 ```ts
 type ParamsOfBocCacheSet = {
     boc: string,
     cache_type: BocCacheType
 }
 ```
+- `boc`: _string_ – BOC encoded as base64 or BOC reference
+- `cache_type`: _[BocCacheType](mod\_boc.md#boccachetype)_ – Cache type
 
-* `boc`: _string_ – BOC encoded as base64 or BOC reference
-* `cache_type`: [_BocCacheType_](mod_boc.md#boccachetype) – Cache type
 
-### ResultOfBocCacheSet
-
+## ResultOfBocCacheSet
 ```ts
 type ResultOfBocCacheSet = {
     boc_ref: string
 }
 ```
+- `boc_ref`: _string_ – Reference to the cached BOC
 
-* `boc_ref`: _string_ – Reference to the cached BOC
 
-### ParamsOfBocCacheUnpin
-
+## ParamsOfBocCacheUnpin
 ```ts
 type ParamsOfBocCacheUnpin = {
     pin: string,
     boc_ref?: string
 }
 ```
+- `pin`: _string_ – Pinned name
+- `boc_ref`?: _string_ – Reference to the cached BOC.
+<br>If it is provided then only referenced BOC is unpinned
 
-* `pin`: _string_ – Pinned name
-* `boc_ref`?: _string_ – Reference to the cached BOC.\
-  If it is provided then only referenced BOC is unpinned
 
-### ParamsOfEncodeBoc
-
+## ParamsOfEncodeBoc
 ```ts
 type ParamsOfEncodeBoc = {
     builder: BuilderOp[],
     boc_cache?: BocCacheType
 }
 ```
+- `builder`: _[BuilderOp](mod\_boc.md#builderop)[]_ – Cell builder operations.
+- `boc_cache`?: _[BocCacheType](mod\_boc.md#boccachetype)_ – Cache type to put the result. The BOC itself returned if no cache type provided.
 
-* `builder`: [_BuilderOp_](mod_boc.md#builderop)_\[]_ – Cell builder operations.
-* `boc_cache`?: [_BocCacheType_](mod_boc.md#boccachetype) – Cache type to put the result. The BOC itself returned if no cache type provided.
 
-### ResultOfEncodeBoc
-
+## ResultOfEncodeBoc
 ```ts
 type ResultOfEncodeBoc = {
     boc: string
 }
 ```
+- `boc`: _string_ – Encoded cell BOC or BOC cache key.
 
-* `boc`: _string_ – Encoded cell BOC or BOC cache key.
 
-### ParamsOfGetCodeSalt
-
+## ParamsOfGetCodeSalt
 ```ts
 type ParamsOfGetCodeSalt = {
     code: string,
     boc_cache?: BocCacheType
 }
 ```
+- `code`: _string_ – Contract code BOC encoded as base64 or code BOC handle
+- `boc_cache`?: _[BocCacheType](mod\_boc.md#boccachetype)_ – Cache type to put the result. The BOC itself returned if no cache type provided.
 
-* `code`: _string_ – Contract code BOC encoded as base64 or code BOC handle
-* `boc_cache`?: [_BocCacheType_](mod_boc.md#boccachetype) – Cache type to put the result. The BOC itself returned if no cache type provided.
 
-### ResultOfGetCodeSalt
-
+## ResultOfGetCodeSalt
 ```ts
 type ResultOfGetCodeSalt = {
     salt?: string
 }
 ```
+- `salt`?: _string_ – Contract code salt if present.
+<br>BOC encoded as base64 or BOC handle
 
-* `salt`?: _string_ – Contract code salt if present.\
-  BOC encoded as base64 or BOC handle
 
-### ParamsOfSetCodeSalt
-
+## ParamsOfSetCodeSalt
 ```ts
 type ParamsOfSetCodeSalt = {
     code: string,
@@ -1378,37 +1301,34 @@ type ParamsOfSetCodeSalt = {
     boc_cache?: BocCacheType
 }
 ```
+- `code`: _string_ – Contract code BOC encoded as base64 or code BOC handle
+- `salt`: _string_ – Code salt to set.
+<br>BOC encoded as base64 or BOC handle
+- `boc_cache`?: _[BocCacheType](mod\_boc.md#boccachetype)_ – Cache type to put the result. The BOC itself returned if no cache type provided.
 
-* `code`: _string_ – Contract code BOC encoded as base64 or code BOC handle
-* `salt`: _string_ – Code salt to set.\
-  BOC encoded as base64 or BOC handle
-* `boc_cache`?: [_BocCacheType_](mod_boc.md#boccachetype) – Cache type to put the result. The BOC itself returned if no cache type provided.
 
-### ResultOfSetCodeSalt
-
+## ResultOfSetCodeSalt
 ```ts
 type ResultOfSetCodeSalt = {
     code: string
 }
 ```
+- `code`: _string_ – Contract code with salt set.
+<br>BOC encoded as base64 or BOC handle
 
-* `code`: _string_ – Contract code with salt set.\
-  BOC encoded as base64 or BOC handle
 
-### ParamsOfDecodeStateInit
-
+## ParamsOfDecodeStateInit
 ```ts
 type ParamsOfDecodeStateInit = {
     state_init: string,
     boc_cache?: BocCacheType
 }
 ```
+- `state_init`: _string_ – Contract StateInit image BOC encoded as base64 or BOC handle
+- `boc_cache`?: _[BocCacheType](mod\_boc.md#boccachetype)_ – Cache type to put the result. The BOC itself returned if no cache type provided.
 
-* `state_init`: _string_ – Contract StateInit image BOC encoded as base64 or BOC handle
-* `boc_cache`?: [_BocCacheType_](mod_boc.md#boccachetype) – Cache type to put the result. The BOC itself returned if no cache type provided.
 
-### ResultOfDecodeStateInit
-
+## ResultOfDecodeStateInit
 ```ts
 type ResultOfDecodeStateInit = {
     code?: string,
@@ -1424,23 +1344,22 @@ type ResultOfDecodeStateInit = {
     compiler_version?: string
 }
 ```
+- `code`?: _string_ – Contract code BOC encoded as base64 or BOC handle
+- `code_hash`?: _string_ – Contract code hash
+- `code_depth`?: _number_ – Contract code depth
+- `data`?: _string_ – Contract data BOC encoded as base64 or BOC handle
+- `data_hash`?: _string_ – Contract data hash
+- `data_depth`?: _number_ – Contract data depth
+- `library`?: _string_ – Contract library BOC encoded as base64 or BOC handle
+- `tick`?: _boolean_ – `special.tick` field.
+<br>Specifies the contract ability to handle tick transactions
+- `tock`?: _boolean_ – `special.tock` field.
+<br>Specifies the contract ability to handle tock transactions
+- `split_depth`?: _number_ – Is present and non-zero only in instances of large smart contracts
+- `compiler_version`?: _string_ – Compiler version, for example 'sol 0.49.0'
 
-* `code`?: _string_ – Contract code BOC encoded as base64 or BOC handle
-* `code_hash`?: _string_ – Contract code hash
-* `code_depth`?: _number_ – Contract code depth
-* `data`?: _string_ – Contract data BOC encoded as base64 or BOC handle
-* `data_hash`?: _string_ – Contract data hash
-* `data_depth`?: _number_ – Contract data depth
-* `library`?: _string_ – Contract library BOC encoded as base64 or BOC handle
-* `tick`?: _boolean_ – `special.tick` field.\
-  Specifies the contract ability to handle tick transactions
-* `tock`?: _boolean_ – `special.tock` field.\
-  Specifies the contract ability to handle tock transactions
-* `split_depth`?: _number_ – Is present and non-zero only in instances of large smart contracts
-* `compiler_version`?: _string_ – Compiler version, for example 'sol 0.49.0'
 
-### ParamsOfEncodeStateInit
-
+## ParamsOfEncodeStateInit
 ```ts
 type ParamsOfEncodeStateInit = {
     code?: string,
@@ -1452,29 +1371,27 @@ type ParamsOfEncodeStateInit = {
     boc_cache?: BocCacheType
 }
 ```
+- `code`?: _string_ – Contract code BOC encoded as base64 or BOC handle
+- `data`?: _string_ – Contract data BOC encoded as base64 or BOC handle
+- `library`?: _string_ – Contract library BOC encoded as base64 or BOC handle
+- `tick`?: _boolean_ – `special.tick` field.
+<br>Specifies the contract ability to handle tick transactions
+- `tock`?: _boolean_ – `special.tock` field.
+<br>Specifies the contract ability to handle tock transactions
+- `split_depth`?: _number_ – Is present and non-zero only in instances of large smart contracts
+- `boc_cache`?: _[BocCacheType](mod\_boc.md#boccachetype)_ – Cache type to put the result. The BOC itself returned if no cache type provided.
 
-* `code`?: _string_ – Contract code BOC encoded as base64 or BOC handle
-* `data`?: _string_ – Contract data BOC encoded as base64 or BOC handle
-* `library`?: _string_ – Contract library BOC encoded as base64 or BOC handle
-* `tick`?: _boolean_ – `special.tick` field.\
-  Specifies the contract ability to handle tick transactions
-* `tock`?: _boolean_ – `special.tock` field.\
-  Specifies the contract ability to handle tock transactions
-* `split_depth`?: _number_ – Is present and non-zero only in instances of large smart contracts
-* `boc_cache`?: [_BocCacheType_](mod_boc.md#boccachetype) – Cache type to put the result. The BOC itself returned if no cache type provided.
 
-### ResultOfEncodeStateInit
-
+## ResultOfEncodeStateInit
 ```ts
 type ResultOfEncodeStateInit = {
     state_init: string
 }
 ```
+- `state_init`: _string_ – Contract StateInit image BOC encoded as base64 or BOC handle of boc_cache parameter was specified
 
-* `state_init`: _string_ – Contract StateInit image BOC encoded as base64 or BOC handle of boc\_cache parameter was specified
 
-### ParamsOfEncodeExternalInMessage
-
+## ParamsOfEncodeExternalInMessage
 ```ts
 type ParamsOfEncodeExternalInMessage = {
     src?: string,
@@ -1484,42 +1401,40 @@ type ParamsOfEncodeExternalInMessage = {
     boc_cache?: BocCacheType
 }
 ```
+- `src`?: _string_ – Source address.
+- `dst`: _string_ – Destination address.
+- `init`?: _string_ – Bag of cells with state init (used in deploy messages).
+- `body`?: _string_ – Bag of cells with the message body encoded as base64.
+- `boc_cache`?: _[BocCacheType](mod\_boc.md#boccachetype)_ – Cache type to put the result.
+<br>The BOC itself returned if no cache type provided
 
-* `src`?: _string_ – Source address.
-* `dst`: _string_ – Destination address.
-* `init`?: _string_ – Bag of cells with state init (used in deploy messages).
-* `body`?: _string_ – Bag of cells with the message body encoded as base64.
-* `boc_cache`?: [_BocCacheType_](mod_boc.md#boccachetype) – Cache type to put the result.\
-  The BOC itself returned if no cache type provided
 
-### ResultOfEncodeExternalInMessage
-
+## ResultOfEncodeExternalInMessage
 ```ts
 type ResultOfEncodeExternalInMessage = {
     message: string,
     message_id: string
 }
 ```
+- `message`: _string_ – Message BOC encoded with `base64`.
+- `message_id`: _string_ – Message id.
 
-* `message`: _string_ – Message BOC encoded with `base64`.
-* `message_id`: _string_ – Message id.
 
-### ParamsOfGetCompilerVersion
-
+## ParamsOfGetCompilerVersion
 ```ts
 type ParamsOfGetCompilerVersion = {
     code: string
 }
 ```
+- `code`: _string_ – Contract code BOC encoded as base64 or code BOC handle
 
-* `code`: _string_ – Contract code BOC encoded as base64 or code BOC handle
 
-### ResultOfGetCompilerVersion
-
+## ResultOfGetCompilerVersion
 ```ts
 type ResultOfGetCompilerVersion = {
     version?: string
 }
 ```
+- `version`?: _string_ – Compiler version, for example 'sol 0.49.0'
 
-* `version`?: _string_ – Compiler version, for example 'sol 0.49.0'
+

--- a/docs/acki-nacki-sdk/types-and-methods/mod_client.md
+++ b/docs/acki-nacki-sdk/types-and-methods/mod_client.md
@@ -1,64 +1,61 @@
 # Module client
 
-## Module client
-
 Provides information about library.
 
-### Functions
-
-[get\_api\_reference](mod_client.md#get_api_reference) – Returns Core Library API reference
-
-[version](mod_client.md#version) – Returns Core Library version
-
-[config](mod_client.md#config) – Returns Core Library API reference
-
-[build\_info](mod_client.md#build_info) – Returns detailed information about this build.
-
-[resolve\_app\_request](mod_client.md#resolve_app_request) – Resolves application request processing result
-
-### Types
-
-[ClientErrorCode](mod_client.md#clienterrorcode)
-
-[ClientError](mod_client.md#clienterror)
-
-[ClientConfig](mod_client.md#clientconfig)
-
-[NetworkConfig](mod_client.md#networkconfig)
-
-[BindingConfig](mod_client.md#bindingconfig)
-
-[NetworkQueriesProtocol](mod_client.md#networkqueriesprotocol) – Network protocol used to perform GraphQL queries.
-
-[CryptoConfig](mod_client.md#cryptoconfig) – Crypto config.
-
-[AbiConfig](mod_client.md#abiconfig)
-
-[BocConfig](mod_client.md#bocconfig)
-
-[ProofsConfig](mod_client.md#proofsconfig)
-
-[BuildInfoDependency](mod_client.md#buildinfodependency)
-
-[ParamsOfAppRequest](mod_client.md#paramsofapprequest)
-
-[AppRequestResultErrorVariant](mod_client.md#apprequestresulterrorvariant) – Error occurred during request processing
-
-[AppRequestResultOkVariant](mod_client.md#apprequestresultokvariant) – Request processed successfully
-
-[AppRequestResult](mod_client.md#apprequestresult)
-
-[ResultOfGetApiReference](mod_client.md#resultofgetapireference)
-
-[ResultOfVersion](mod_client.md#resultofversion)
-
-[ResultOfBuildInfo](mod_client.md#resultofbuildinfo)
-
-[ParamsOfResolveAppRequest](mod_client.md#paramsofresolveapprequest)
 
 ## Functions
+[get_api_reference](mod\_client.md#get_api_reference) – Returns Core Library API reference
 
-### get\_api\_reference
+[version](mod\_client.md#version) – Returns Core Library version
+
+[config](mod\_client.md#config) – Returns Core Library API reference
+
+[build_info](mod\_client.md#build_info) – Returns detailed information about this build.
+
+[resolve_app_request](mod\_client.md#resolve_app_request) – Resolves application request processing result
+
+## Types
+[ClientErrorCode](mod\_client.md#clienterrorcode)
+
+[ClientError](mod\_client.md#clienterror)
+
+[ClientConfig](mod\_client.md#clientconfig)
+
+[NetworkConfig](mod\_client.md#networkconfig)
+
+[BindingConfig](mod\_client.md#bindingconfig)
+
+[NetworkQueriesProtocol](mod\_client.md#networkqueriesprotocol) – Network protocol used to perform GraphQL queries.
+
+[CryptoConfig](mod\_client.md#cryptoconfig) – Crypto config.
+
+[AbiConfig](mod\_client.md#abiconfig)
+
+[BocConfig](mod\_client.md#bocconfig)
+
+[ProofsConfig](mod\_client.md#proofsconfig)
+
+[BuildInfoDependency](mod\_client.md#buildinfodependency)
+
+[ParamsOfAppRequest](mod\_client.md#paramsofapprequest)
+
+[AppRequestResultErrorVariant](mod\_client.md#apprequestresulterrorvariant) – Error occurred during request processing
+
+[AppRequestResultOkVariant](mod\_client.md#apprequestresultokvariant) – Request processed successfully
+
+[AppRequestResult](mod\_client.md#apprequestresult)
+
+[ResultOfGetApiReference](mod\_client.md#resultofgetapireference)
+
+[ResultOfVersion](mod\_client.md#resultofversion)
+
+[ResultOfBuildInfo](mod\_client.md#resultofbuildinfo)
+
+[ParamsOfResolveAppRequest](mod\_client.md#paramsofresolveapprequest)
+
+
+# Functions
+## get_api_reference
 
 Returns Core Library API reference
 
@@ -71,14 +68,15 @@ function get_api_reference(): Promise<ResultOfGetApiReference>;
 
 function get_api_reference_sync(): ResultOfGetApiReference;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
 
-#### Result
 
-* `api`: _API_
+### Result
 
-### version
+- `api`: _API_
+
+
+## version
 
 Returns Core Library version
 
@@ -91,14 +89,15 @@ function version(): Promise<ResultOfVersion>;
 
 function version_sync(): ResultOfVersion;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
 
-#### Result
 
-* `version`: _string_ – Core Library version
+### Result
 
-### config
+- `version`: _string_ – Core Library version
+
+
+## config
 
 Returns Core Library API reference
 
@@ -117,20 +116,21 @@ function config(): Promise<ClientConfig>;
 
 function config_sync(): ClientConfig;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
 
-#### Result
 
-* `binding`?: [_BindingConfig_](mod_client.md#bindingconfig)
-* `network`?: [_NetworkConfig_](mod_client.md#networkconfig)
-* `crypto`?: [_CryptoConfig_](mod_client.md#cryptoconfig)
-* `abi`?: [_AbiConfig_](mod_client.md#abiconfig)
-* `boc`?: [_BocConfig_](mod_client.md#bocconfig)
-* `proofs`?: [_ProofsConfig_](mod_client.md#proofsconfig)
-* `local_storage_path`?: _string_ – For file based storage is a folder name where SDK will store its data. For browser based is a browser async storage key prefix. Default (recommended) value is "\~/.tvmclient" for native environments and ".tvmclient" for web-browser.
+### Result
 
-### build\_info
+- `binding`?: _[BindingConfig](mod\_client.md#bindingconfig)_
+- `network`?: _[NetworkConfig](mod\_client.md#networkconfig)_
+- `crypto`?: _[CryptoConfig](mod\_client.md#cryptoconfig)_
+- `abi`?: _[AbiConfig](mod\_client.md#abiconfig)_
+- `boc`?: _[BocConfig](mod\_client.md#bocconfig)_
+- `proofs`?: _[ProofsConfig](mod\_client.md#proofsconfig)_
+- `local_storage_path`?: _string_ – For file based storage is a folder name where SDK will store its data. For browser based is a browser async storage key prefix. Default (recommended) value is "~/.tonclient" for native environments and ".tonclient" for web-browser.
+
+
+## build_info
 
 Returns detailed information about this build.
 
@@ -144,15 +144,16 @@ function build_info(): Promise<ResultOfBuildInfo>;
 
 function build_info_sync(): ResultOfBuildInfo;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
 
-#### Result
 
-* `build_number`: _number_ – Build number assigned to this build by the CI.
-* `dependencies`: [_BuildInfoDependency_](mod_client.md#buildinfodependency)_\[]_ – Fingerprint of the most important dependencies.
+### Result
 
-### resolve\_app\_request
+- `build_number`: _number_ – Build number assigned to this build by the CI.
+- `dependencies`: _[BuildInfoDependency](mod\_client.md#buildinfodependency)[]_ – Fingerprint of the most important dependencies.
+
+
+## resolve_app_request
 
 Resolves application request processing result
 
@@ -170,18 +171,14 @@ function resolve_app_request_sync(
     params: ParamsOfResolveAppRequest,
 ): void;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `app_request_id`: _number_ – Request ID received from SDK
+- `result`: _[AppRequestResult](mod\_client.md#apprequestresult)_ – Result of request processing
 
-#### Parameters
 
-* `app_request_id`: _number_ – Request ID received from SDK
-* `result`: [_AppRequestResult_](mod_client.md#apprequestresult) – Result of request processing
-
-## Types
-
-### ClientErrorCode
-
+# Types
+## ClientErrorCode
 ```ts
 enum ClientErrorCode {
     NotImplemented = 1,
@@ -222,62 +219,53 @@ enum ClientErrorCode {
     InvalidData = 36
 }
 ```
-
 One of the following value:
 
-* `NotImplemented = 1`
-* `InvalidHex = 2`
-* `InvalidBase64 = 3`
-* `InvalidAddress = 4`
-* `CallbackParamsCantBeConvertedToJson = 5`
-* `WebsocketConnectError = 6`
-* `WebsocketReceiveError = 7`
-* `WebsocketSendError = 8`
-* `HttpClientCreateError = 9`
-* `HttpRequestCreateError = 10`
-* `HttpRequestSendError = 11`
-* `HttpRequestParseError = 12`
-* `CallbackNotRegistered = 13`
-* `NetModuleNotInit = 14`
-* `InvalidConfig = 15`
-* `CannotCreateRuntime = 16`
-* `InvalidContextHandle = 17`
-* `CannotSerializeResult = 18`
-* `CannotSerializeError = 19`
-* `CannotConvertJsValueToJson = 20`
-* `CannotReceiveSpawnedResult = 21`
-* `SetTimerError = 22`
-* `InvalidParams = 23`
-* `ContractsAddressConversionFailed = 24`
-* `UnknownFunction = 25`
-* `AppRequestError = 26`
-* `NoSuchRequest = 27`
-* `CanNotSendRequestResult = 28`
-* `CanNotReceiveRequestResult = 29`
-* `CanNotParseRequestResult = 30`
-* `UnexpectedCallbackResponse = 31`
-* `CanNotParseNumber = 32`
-* `InternalError = 33`
-* `InvalidHandle = 34`
-* `LocalStorageError = 35`
-* `InvalidData = 36`
+- `NotImplemented = 1`
+- `InvalidHex = 2`
+- `InvalidBase64 = 3`
+- `InvalidAddress = 4`
+- `CallbackParamsCantBeConvertedToJson = 5`
+- `WebsocketConnectError = 6`
+- `WebsocketReceiveError = 7`
+- `WebsocketSendError = 8`
+- `HttpClientCreateError = 9`
+- `HttpRequestCreateError = 10`
+- `HttpRequestSendError = 11`
+- `HttpRequestParseError = 12`
+- `CallbackNotRegistered = 13`
+- `NetModuleNotInit = 14`
+- `InvalidConfig = 15`
+- `CannotCreateRuntime = 16`
+- `InvalidContextHandle = 17`
+- `CannotSerializeResult = 18`
+- `CannotSerializeError = 19`
+- `CannotConvertJsValueToJson = 20`
+- `CannotReceiveSpawnedResult = 21`
+- `SetTimerError = 22`
+- `InvalidParams = 23`
+- `ContractsAddressConversionFailed = 24`
+- `UnknownFunction = 25`
+- `AppRequestError = 26`
+- `NoSuchRequest = 27`
+- `CanNotSendRequestResult = 28`
+- `CanNotReceiveRequestResult = 29`
+- `CanNotParseRequestResult = 30`
+- `UnexpectedCallbackResponse = 31`
+- `CanNotParseNumber = 32`
+- `InternalError = 33`
+- `InvalidHandle = 34`
+- `LocalStorageError = 35`
+- `InvalidData = 36`
 
-### ClientError
 
+## ClientError
 ```ts
-type ClientError = {
-    code: number,
-    message: string,
-    data: any
-}
+type ClientError = Generic
 ```
 
-* `code`: _number_
-* `message`: _string_
-* `data`: _any_
 
-### ClientConfig
-
+## ClientConfig
 ```ts
 type ClientConfig = {
     binding?: BindingConfig,
@@ -289,20 +277,18 @@ type ClientConfig = {
     local_storage_path?: string
 }
 ```
+- `binding`?: _[BindingConfig](mod\_client.md#bindingconfig)_
+- `network`?: _[NetworkConfig](mod\_client.md#networkconfig)_
+- `crypto`?: _[CryptoConfig](mod\_client.md#cryptoconfig)_
+- `abi`?: _[AbiConfig](mod\_client.md#abiconfig)_
+- `boc`?: _[BocConfig](mod\_client.md#bocconfig)_
+- `proofs`?: _[ProofsConfig](mod\_client.md#proofsconfig)_
+- `local_storage_path`?: _string_ – For file based storage is a folder name where SDK will store its data. For browser based is a browser async storage key prefix. Default (recommended) value is "~/.tonclient" for native environments and ".tonclient" for web-browser.
 
-* `binding`?: [_BindingConfig_](mod_client.md#bindingconfig)
-* `network`?: [_NetworkConfig_](mod_client.md#networkconfig)
-* `crypto`?: [_CryptoConfig_](mod_client.md#cryptoconfig)
-* `abi`?: [_AbiConfig_](mod_client.md#abiconfig)
-* `boc`?: [_BocConfig_](mod_client.md#bocconfig)
-* `proofs`?: [_ProofsConfig_](mod_client.md#proofsconfig)
-* `local_storage_path`?: _string_ – For file based storage is a folder name where SDK will store its data. For browser based is a browser async storage key prefix. Default (recommended) value is "\~/.tvmclient" for native environments and ".tvmclient" for web-browser.
 
-### NetworkConfig
-
+## NetworkConfig
 ```ts
 type NetworkConfig = {
-    server_address?: string,
     endpoints?: string[],
     network_retries_count?: number,
     max_reconnect_timeout?: number,
@@ -319,74 +305,56 @@ type NetworkConfig = {
     first_remp_status_timeout?: number,
     next_remp_status_timeout?: number,
     signature_id?: number,
-    access_key?: string
+    access_key?: string,
+    api_token?: string
 }
 ```
+- `endpoints`?: _string[]_ – List of Evernode endpoints.
+<br>Any correct URL format can be specified, including IP addresses.
+- `network_retries_count`?: _number_ – Deprecated.
+<br>You must use `network.max_reconnect_timeout` that allows to specify maximum network resolving timeout.
+- `max_reconnect_timeout`?: _number_ – Maximum time for sequential reconnections.
+<br>Must be specified in milliseconds. Default is 120000 (2 min).
+- `reconnect_timeout`?: _number_ – Deprecated
+- `message_retries_count`?: _number_ – The number of automatic message processing retries that SDK performs in case of `Message Expired (507)` error - but only for those messages which local emulation was successful or failed with replay protection error.
+<br>Default is 5.
+- `message_processing_timeout`?: _number_ – Timeout that is used to process message delivery for the contracts which ABI does not include "expire" header. If the message is not delivered within the specified timeout the appropriate error occurs.
+<br>Must be specified in milliseconds. Default is 40000 (40 sec).
+- `wait_for_timeout`?: _number_ – Maximum timeout that is used for query response.
+<br>Must be specified in milliseconds. Default is 40000 (40 sec).
+- `out_of_sync_threshold`?: _number_ – **DEPRECATED**: This parameter was deprecated.
+- `sending_endpoint_count`?: _number_ – Maximum number of randomly chosen endpoints the library uses to broadcast a message.
+<br>Default is 1.
+- `latency_detection_interval`?: _number_ – Frequency of sync latency detection.
+<br>Library periodically checks the current endpoint for blockchain data synchronization latency.<br>If the latency (time-lag) is less then `NetworkConfig.max_latency`<br>then library selects another endpoint.<br><br>Must be specified in milliseconds. Default is 60000 (1 min).
+- `max_latency`?: _number_ – Maximum value for the endpoint's blockchain data synchronization latency (time-lag).
+<br>Library periodically checks the current endpoint for blockchain data synchronization latency.<br>If the latency (time-lag) is less then `NetworkConfig.max_latency`<br>then library selects another endpoint.<br><br>Must be specified in milliseconds. Default is 60000 (1 min).
+- `query_timeout`?: _number_ – Default timeout for http requests.
+<br>Is is used when no timeout specified for the request to limit the answer waiting time. If no answer<br>received during the timeout requests ends with error.<br><br>Must be specified in milliseconds. Default is 60000 (1 min).
+- `queries_protocol`?: _[NetworkQueriesProtocol](mod\_client.md#networkqueriesprotocol)_ – Queries protocol.
+<br>`HTTP` or `WS`. <br>Default is `HTTP`.
+- `first_remp_status_timeout`?: _number_ – UNSTABLE.
+<br>First REMP status awaiting timeout. If no status received during the timeout than fallback transaction scenario is activated.<br><br>Must be specified in milliseconds. Default is 1 (1 ms) in order to start<br>fallback scenario together with REMP statuses processing while REMP<br>is not properly tuned yet.
+- `next_remp_status_timeout`?: _number_ – UNSTABLE.
+<br>Subsequent REMP status awaiting timeout. If no status received during the timeout than fallback transaction scenario is activated.<br><br>Must be specified in milliseconds. Default is 5000 (5 sec).
+- `signature_id`?: _number_ – Network signature ID which is used by VM in signature verifying instructions if capability `CapSignatureWithId` is enabled in blockchain configuration parameters.
+<br>This parameter should be set to `global_id` field from any blockchain<br>block if network can not be reachable at the moment of message<br>encoding and the message is aimed to be sent into network with<br>`CapSignatureWithId` enabled. Otherwise signature ID is detected<br>automatically inside message encoding functions
+- `access_key`?: _string_ – Access key to GraphQL API (Project secret)
+- `api_token`?: _string_ – Access token to the Node REST API
 
-* `server_address`?: _string_ – **This field is deprecated, but left for backward-compatibility.** Acki Nacki endpoint.
-* `endpoints`?: _string\[]_ – List of Acki NAcki endpoints.\
-  Any correct URL format can be specified, including IP addresses. This parameter is prevailing over `server_address`.\
-  Check the full list of [supported network endpoints](https://docs.evercloud.dev/products/evercloud/networks-endpoints).
-* `network_retries_count`?: _number_ – Deprecated.\
-  You must use `network.max_reconnect_timeout` that allows to specify maximum network resolving timeout.
-* `max_reconnect_timeout`?: _number_ – Maximum time for sequential reconnections.\
-  Must be specified in milliseconds. Default is 120000 (2 min).
-* `reconnect_timeout`?: _number_ – Deprecated
-* `message_retries_count`?: _number_ – The number of automatic message processing retries that SDK performs in case of `Message Expired (507)` error - but only for those messages which local emulation was successful or failed with replay protection error.\
-  Default is 5.
-* `message_processing_timeout`?: _number_ – Timeout that is used to process message delivery for the contracts which ABI does not include "expire" header. If the message is not delivered within the specified timeout the appropriate error occurs.\
-  Must be specified in milliseconds. Default is 40000 (40 sec).
-* `wait_for_timeout`?: _number_ – Maximum timeout that is used for query response.\
-  Must be specified in milliseconds. Default is 40000 (40 sec).
-* `out_of_sync_threshold`?: _number_ – **DEPRECATED**: This parameter was deprecated.
-* `sending_endpoint_count`?: _number_ – Maximum number of randomly chosen endpoints the library uses to broadcast a message.\
-  Default is 1.
-* `latency_detection_interval`?: _number_ – Frequency of sync latency detection.\
-  Library periodically checks the current endpoint for blockchain data synchronization latency.\
-  If the latency (time-lag) is less then `NetworkConfig.max_latency`\
-  then library selects another endpoint.\
-  \
-  Must be specified in milliseconds. Default is 60000 (1 min).
-* `max_latency`?: _number_ – Maximum value for the endpoint's blockchain data synchronization latency (time-lag). Library periodically checks the current endpoint for blockchain data synchronization latency. If the latency (time-lag) is less then `NetworkConfig.max_latency` then library selects another endpoint.\
-  Must be specified in milliseconds. Default is 60000 (1 min).
-* `query_timeout`?: _number_ – Default timeout for http requests.\
-  Is is used when no timeout specified for the request to limit the answer waiting time. If no answer received during the timeout requests ends with\
-  error.\
-  \
-  Must be specified in milliseconds. Default is 60000 (1 min).
-* `queries_protocol`?: [_NetworkQueriesProtocol_](mod_client.md#networkqueriesprotocol) – Queries protocol.\
-  `HTTP` or `WS`.\
-  Default is `HTTP`.
-* `first_remp_status_timeout`?: _number_ – UNSTABLE.\
-  First REMP status awaiting timeout. If no status received during the timeout than fallback transaction scenario is activated.\
-  \
-  Must be specified in milliseconds. Default is 1 (1 ms) in order to start fallback scenario\
-  together with REMP statuses processing while REMP is not properly tuned yet.
-* `next_remp_status_timeout`?: _number_ – UNSTABLE.\
-  Subsequent REMP status awaiting timeout. If no status received during the timeout than fallback transaction scenario is activated.\
-  \
-  Must be specified in milliseconds. Default is 5000 (5 sec).
-* `signature_id`?: _number_ – Network signature ID which is used by VM in signature verifying instructions if capability `CapSignatureWithId` is enabled in blockchain configuration parameters.\
-  This parameter should be set to `global_id` field from any blockchain block if network can\
-  not be reachable at the moment of message encoding and the message is aimed to be sent into\
-  network with `CapSignatureWithId` enabled. Otherwise signature ID is detected automatically\
-  inside message encoding functions
-* `access_key`?: _string_ – Access key to GraphQL API (Project secret)
 
-### BindingConfig
-
+## BindingConfig
 ```ts
 type BindingConfig = {
     library?: string,
     version?: string
 }
 ```
+- `library`?: _string_
+- `version`?: _string_
 
-* `library`?: _string_
-* `version`?: _string_
 
-### NetworkQueriesProtocol
-
+## NetworkQueriesProtocol
 Network protocol used to perform GraphQL queries.
 
 ```ts
@@ -395,14 +363,13 @@ enum NetworkQueriesProtocol {
     WS = "WS"
 }
 ```
-
 One of the following value:
 
-* `HTTP = "HTTP"` – Each GraphQL query uses separate HTTP request.
-* `WS = "WS"` – All GraphQL queries will be served using single web socket connection. SDK is tested to reliably handle 5000 parallel network requests (sending and processing messages, quering and awaiting blockchain data)
+- `HTTP = "HTTP"` – Each GraphQL query uses separate HTTP request.
+- `WS = "WS"` – All GraphQL queries will be served using single web socket connection. SDK is tested to reliably handle 5000 parallel network requests (sending and processing messages, quering and awaiting blockchain data)
 
-### CryptoConfig
 
+## CryptoConfig
 Crypto config.
 
 ```ts
@@ -412,13 +379,12 @@ type CryptoConfig = {
     hdkey_derivation_path?: string
 }
 ```
+- `mnemonic_dictionary`?: _[MnemonicDictionary](mod\_crypto.md#mnemonicdictionary)_ – Mnemonic dictionary that will be used by default in crypto functions. If not specified, `English` dictionary will be used.
+- `mnemonic_word_count`?: _number_ – Mnemonic word count that will be used by default in crypto functions. If not specified the default value will be 12.
+- `hdkey_derivation_path`?: _string_ – Derivation path that will be used by default in crypto functions. If not specified `m/44'/1331'/0'/0/0` will be used.
 
-* `mnemonic_dictionary`?: [_MnemonicDictionary_](/broken/pages/b7U0dxs59ESc6rtN09mV#mnemonicdictionary) – Mnemonic dictionary that will be used by default in crypto functions. If not specified, `English` dictionary will be used.
-* `mnemonic_word_count`?: _number_ – Mnemonic word count that will be used by default in crypto functions. If not specified the default value will be 12.
-* `hdkey_derivation_path`?: _string_ – Derivation path that will be used by default in crypto functions. If not specified `m/44'/396'/0'/0/0` will be used.
 
-### AbiConfig
-
+## AbiConfig
 ```ts
 type AbiConfig = {
     workchain?: number,
@@ -426,66 +392,58 @@ type AbiConfig = {
     message_expiration_timeout_grow_factor?: number
 }
 ```
+- `workchain`?: _number_ – Workchain id that is used by default in DeploySet
+- `message_expiration_timeout`?: _number_ – Message lifetime for contracts which ABI includes "expire" header.
+<br>Must be specified in milliseconds. Default is 40000 (40 sec).
+- `message_expiration_timeout_grow_factor`?: _number_ – Factor that increases the expiration timeout for each retry
+<br>Default is 1.5
 
-* `workchain`?: _number_ – Workchain id that is used by default in DeploySet
-* `message_expiration_timeout`?: _number_ – Message lifetime for contracts which ABI includes "expire" header.\
-  Must be specified in milliseconds. Default is 40000 (40 sec).
-* `message_expiration_timeout_grow_factor`?: _number_ – Factor that increases the expiration timeout for each retry\
-  Default is 1.5
 
-### BocConfig
-
+## BocConfig
 ```ts
 type BocConfig = {
     cache_max_size?: number
 }
 ```
+- `cache_max_size`?: _number_ – Maximum BOC cache size in kilobytes.
+<br>Default is 10 MB
 
-* `cache_max_size`?: _number_ – Maximum BOC cache size in kilobytes.\
-  Default is 10 MB
 
-### ProofsConfig
-
+## ProofsConfig
 ```ts
 type ProofsConfig = {
     cache_in_local_storage?: boolean
 }
 ```
+- `cache_in_local_storage`?: _boolean_ – Cache proofs in the local storage.
+<br>Default is `true`. If this value is set to `true`, downloaded proofs and master-chain BOCs<br>are saved into the persistent local storage (e.g. file system for<br>native environments or browser's IndexedDB for the web); otherwise<br>all the data is cached only in memory in current client's context<br>and will be lost after destruction of the client.
 
-* `cache_in_local_storage`?: _boolean_ – Cache proofs in the local storage.\
-  Default is `true`. If this value is set to `true`, downloaded proofs and master-chain BOCs are saved into the\
-  persistent local storage (e.g. file system for native environments or browser's IndexedDB\
-  for the web); otherwise all the data is cached only in memory in current client's context\
-  and will be lost after destruction of the client.
 
-### BuildInfoDependency
-
+## BuildInfoDependency
 ```ts
 type BuildInfoDependency = {
     name: string,
     git_commit: string
 }
 ```
+- `name`: _string_ – Dependency name.
+<br>Usually it is a crate name.
+- `git_commit`: _string_ – Git commit hash of the related repository.
 
-* `name`: _string_ – Dependency name.\
-  Usually it is a crate name.
-* `git_commit`: _string_ – Git commit hash of the related repository.
 
-### ParamsOfAppRequest
-
+## ParamsOfAppRequest
 ```ts
 type ParamsOfAppRequest = {
     app_request_id: number,
     request_data: any
 }
 ```
+- `app_request_id`: _number_ – Request ID.
+<br>Should be used in `resolve_app_request` call
+- `request_data`: _any_ – Request describing data
 
-* `app_request_id`: _number_ – Request ID.\
-  Should be used in `resolve_app_request` call
-* `request_data`: _any_ – Request describing data
 
-### AppRequestResultErrorVariant
-
+## AppRequestResultErrorVariant
 Error occurred during request processing
 
 ```ts
@@ -493,11 +451,10 @@ type AppRequestResultErrorVariant = {
     text: string
 }
 ```
+- `text`: _string_ – Error description
 
-* `text`: _string_ – Error description
 
-### AppRequestResultOkVariant
-
+## AppRequestResultOkVariant
 Request processed successfully
 
 ```ts
@@ -505,11 +462,10 @@ type AppRequestResultOkVariant = {
     result: any
 }
 ```
+- `result`: _any_ – Request processing result
 
-* `result`: _any_ – Request processing result
 
-### AppRequestResult
-
+## AppRequestResult
 ```ts
 type AppRequestResult = ({
     type: 'Error'
@@ -517,20 +473,20 @@ type AppRequestResult = ({
     type: 'Ok'
 } & AppRequestResultOkVariant)
 ```
-
-Depends on value of the `type` field.
+Depends on value of the  `type` field.
 
 When _type_ is _'Error'_
 
 Error occurred during request processing
 
-* `text`: _string_ – Error description
+- `text`: _string_ – Error description
 
 When _type_ is _'Ok'_
 
 Request processed successfully
 
-* `result`: _any_ – Request processing result
+- `result`: _any_ – Request processing result
+
 
 Variant constructors:
 
@@ -539,46 +495,43 @@ function appRequestResultError(text: string): AppRequestResult;
 function appRequestResultOk(result: any): AppRequestResult;
 ```
 
-### ResultOfGetApiReference
-
+## ResultOfGetApiReference
 ```ts
 type ResultOfGetApiReference = {
     api: any
 }
 ```
+- `api`: _API_
 
-* `api`: _API_
 
-### ResultOfVersion
-
+## ResultOfVersion
 ```ts
 type ResultOfVersion = {
     version: string
 }
 ```
+- `version`: _string_ – Core Library version
 
-* `version`: _string_ – Core Library version
 
-### ResultOfBuildInfo
-
+## ResultOfBuildInfo
 ```ts
 type ResultOfBuildInfo = {
     build_number: number,
     dependencies: BuildInfoDependency[]
 }
 ```
+- `build_number`: _number_ – Build number assigned to this build by the CI.
+- `dependencies`: _[BuildInfoDependency](mod\_client.md#buildinfodependency)[]_ – Fingerprint of the most important dependencies.
 
-* `build_number`: _number_ – Build number assigned to this build by the CI.
-* `dependencies`: [_BuildInfoDependency_](mod_client.md#buildinfodependency)_\[]_ – Fingerprint of the most important dependencies.
 
-### ParamsOfResolveAppRequest
-
+## ParamsOfResolveAppRequest
 ```ts
 type ParamsOfResolveAppRequest = {
     app_request_id: number,
     result: AppRequestResult
 }
 ```
+- `app_request_id`: _number_ – Request ID received from SDK
+- `result`: _[AppRequestResult](mod\_client.md#apprequestresult)_ – Result of request processing
 
-* `app_request_id`: _number_ – Request ID received from SDK
-* `result`: [_AppRequestResult_](mod_client.md#apprequestresult) – Result of request processing
+

--- a/docs/acki-nacki-sdk/types-and-methods/mod_crypto.md
+++ b/docs/acki-nacki-sdk/types-and-methods/mod_crypto.md
@@ -1,366 +1,365 @@
 # Module crypto
 
-## Module crypto
-
 Crypto functions.
 
-### Functions
-
-[factorize](mod_crypto.md#factorize) – Integer factorization
-
-[modular\_power](mod_crypto.md#modular_power) – Modular exponentiation
-
-[tvm\_crc16](mod_crypto.md#tvm_crc16) – Calculates CRC16 using TVM algorithm.
-
-[generate\_random\_bytes](mod_crypto.md#generate_random_bytes) – Generates random byte array of the specified length and returns it in `base64` format
-
-[convert\_public\_key\_to\_tvm\_safe\_format](mod_crypto.md#convert_public_key_to_tvm_safe_format) – Converts public key to tvm safe\_format
-
-[generate\_random\_sign\_keys](mod_crypto.md#generate_random_sign_keys) – Generates random ed25519 key pair.
-
-[sign](mod_crypto.md#sign) – Signs a data using the provided keys.
-
-[verify\_signature](mod_crypto.md#verify_signature) – Verifies signed data using the provided public key. Raises error if verification is failed.
-
-[sha256](mod_crypto.md#sha256) – Calculates SHA256 hash of the specified data.
-
-[sha512](mod_crypto.md#sha512) – Calculates SHA512 hash of the specified data.
-
-[scrypt](mod_crypto.md#scrypt) – Perform `scrypt` encryption
-
-[nacl\_sign\_keypair\_from\_secret\_key](mod_crypto.md#nacl_sign_keypair_from_secret_key) – Generates a key pair for signing from the secret key
-
-[nacl\_sign](mod_crypto.md#nacl_sign) – Signs data using the signer's secret key.
-
-[nacl\_sign\_open](mod_crypto.md#nacl_sign_open) – Verifies the signature and returns the unsigned message
-
-[nacl\_sign\_detached](mod_crypto.md#nacl_sign_detached) – Signs the message using the secret key and returns a signature.
-
-[nacl\_sign\_detached\_verify](mod_crypto.md#nacl_sign_detached_verify) – Verifies the signature with public key and `unsigned` data.
-
-[nacl\_box\_keypair](mod_crypto.md#nacl_box_keypair) – Generates a random NaCl key pair
-
-[nacl\_box\_keypair\_from\_secret\_key](mod_crypto.md#nacl_box_keypair_from_secret_key) – Generates key pair from a secret key
-
-[nacl\_box](mod_crypto.md#nacl_box) – Public key authenticated encryption
-
-[nacl\_box\_open](mod_crypto.md#nacl_box_open) – Decrypt and verify the cipher text using the receivers secret key, the senders public key, and the nonce.
-
-[nacl\_secret\_box](mod_crypto.md#nacl_secret_box) – Encrypt and authenticate message using nonce and secret key.
-
-[nacl\_secret\_box\_open](mod_crypto.md#nacl_secret_box_open) – Decrypts and verifies cipher text using `nonce` and secret `key`.
-
-[mnemonic\_words](mod_crypto.md#mnemonic_words) – Prints the list of words from the specified dictionary
-
-[mnemonic\_from\_random](mod_crypto.md#mnemonic_from_random) – Generates a random mnemonic
-
-[mnemonic\_from\_entropy](mod_crypto.md#mnemonic_from_entropy) – Generates mnemonic from pre-generated entropy
-
-[mnemonic\_verify](mod_crypto.md#mnemonic_verify) – Validates a mnemonic phrase
-
-[mnemonic\_derive\_sign\_keys](mod_crypto.md#mnemonic_derive_sign_keys) – Derives a key pair for signing from the seed phrase
-
-[hdkey\_xprv\_from\_mnemonic](mod_crypto.md#hdkey_xprv_from_mnemonic) – Generates an extended master private key that will be the root for all the derived keys
-
-[hdkey\_derive\_from\_xprv](mod_crypto.md#hdkey_derive_from_xprv) – Returns extended private key derived from the specified extended private key and child index
-
-[hdkey\_derive\_from\_xprv\_path](mod_crypto.md#hdkey_derive_from_xprv_path) – Derives the extended private key from the specified key and path
-
-[hdkey\_secret\_from\_xprv](mod_crypto.md#hdkey_secret_from_xprv) – Extracts the private key from the serialized extended private key
-
-[hdkey\_public\_from\_xprv](mod_crypto.md#hdkey_public_from_xprv) – Extracts the public key from the serialized extended private key
-
-[chacha20](mod_crypto.md#chacha20) – Performs symmetric `chacha20` encryption.
-
-[create\_crypto\_box](mod_crypto.md#create_crypto_box) – Creates a Crypto Box instance.
-
-[remove\_crypto\_box](mod_crypto.md#remove_crypto_box) – Removes Crypto Box. Clears all secret data.
-
-[get\_crypto\_box\_info](mod_crypto.md#get_crypto_box_info) – Get Crypto Box Info. Used to get `encrypted_secret` that should be used for all the cryptobox initializations except the first one.
-
-[get\_crypto\_box\_seed\_phrase](mod_crypto.md#get_crypto_box_seed_phrase) – Get Crypto Box Seed Phrase.
-
-[get\_signing\_box\_from\_crypto\_box](mod_crypto.md#get_signing_box_from_crypto_box) – Get handle of Signing Box derived from Crypto Box.
-
-[get\_encryption\_box\_from\_crypto\_box](mod_crypto.md#get_encryption_box_from_crypto_box) – Gets Encryption Box from Crypto Box.
-
-[clear\_crypto\_box\_secret\_cache](mod_crypto.md#clear_crypto_box_secret_cache) – Removes cached secrets (overwrites with zeroes) from all signing and encryption boxes, derived from crypto box.
-
-[register\_signing\_box](mod_crypto.md#register_signing_box) – Register an application implemented signing box.
-
-[get\_signing\_box](mod_crypto.md#get_signing_box) – Creates a default signing box implementation.
-
-[signing\_box\_get\_public\_key](mod_crypto.md#signing_box_get_public_key) – Returns public key of signing key pair.
-
-[signing\_box\_sign](mod_crypto.md#signing_box_sign) – Returns signed user data.
-
-[remove\_signing\_box](mod_crypto.md#remove_signing_box) – Removes signing box from SDK.
-
-[register\_encryption\_box](mod_crypto.md#register_encryption_box) – Register an application implemented encryption box.
-
-[remove\_encryption\_box](mod_crypto.md#remove_encryption_box) – Removes encryption box from SDK
-
-[encryption\_box\_get\_info](mod_crypto.md#encryption_box_get_info) – Queries info from the given encryption box
-
-[encryption\_box\_encrypt](mod_crypto.md#encryption_box_encrypt) – Encrypts data using given encryption box Note.
-
-[encryption\_box\_decrypt](mod_crypto.md#encryption_box_decrypt) – Decrypts data using given encryption box Note.
-
-[create\_encryption\_box](mod_crypto.md#create_encryption_box) – Creates encryption box with specified algorithm
-
-### Types
-
-[CryptoErrorCode](mod_crypto.md#cryptoerrorcode)
-
-[SigningBoxHandle](mod_crypto.md#signingboxhandle)
-
-[EncryptionBoxHandle](mod_crypto.md#encryptionboxhandle)
-
-[EncryptionBoxInfo](mod_crypto.md#encryptionboxinfo) – Encryption box information.
-
-[EncryptionAlgorithmAESVariant](mod_crypto.md#encryptionalgorithmaesvariant)
-
-[EncryptionAlgorithmChaCha20Variant](mod_crypto.md#encryptionalgorithmchacha20variant)
-
-[EncryptionAlgorithmNaclBoxVariant](mod_crypto.md#encryptionalgorithmnaclboxvariant)
-
-[EncryptionAlgorithmNaclSecretBoxVariant](mod_crypto.md#encryptionalgorithmnaclsecretboxvariant)
-
-[EncryptionAlgorithm](mod_crypto.md#encryptionalgorithm)
-
-[CipherMode](mod_crypto.md#ciphermode)
-
-[AesParamsEB](mod_crypto.md#aesparamseb)
-
-[AesInfo](mod_crypto.md#aesinfo)
-
-[ChaCha20ParamsEB](mod_crypto.md#chacha20paramseb)
-
-[NaclBoxParamsEB](mod_crypto.md#naclboxparamseb)
-
-[NaclSecretBoxParamsEB](mod_crypto.md#naclsecretboxparamseb)
-
-[CryptoBoxSecretRandomSeedPhraseVariant](mod_crypto.md#cryptoboxsecretrandomseedphrasevariant) – Creates Crypto Box from a random seed phrase. This option can be used if a developer doesn't want the seed phrase to leave the core library's memory, where it is stored encrypted.
-
-[CryptoBoxSecretPredefinedSeedPhraseVariant](mod_crypto.md#cryptoboxsecretpredefinedseedphrasevariant) – Restores crypto box instance from an existing seed phrase. This type should be used when Crypto Box is initialized from a seed phrase, entered by a user.
-
-[CryptoBoxSecretEncryptedSecretVariant](mod_crypto.md#cryptoboxsecretencryptedsecretvariant) – Use this type for wallet reinitializations, when you already have `encrypted_secret` on hands. To get `encrypted_secret`, use `get_crypto_box_info` function after you initialized your crypto box for the first time.
-
-[CryptoBoxSecret](mod_crypto.md#cryptoboxsecret) – Crypto Box Secret.
-
-[CryptoBoxHandle](mod_crypto.md#cryptoboxhandle)
-
-[BoxEncryptionAlgorithmChaCha20Variant](mod_crypto.md#boxencryptionalgorithmchacha20variant)
-
-[BoxEncryptionAlgorithmNaclBoxVariant](mod_crypto.md#boxencryptionalgorithmnaclboxvariant)
-
-[BoxEncryptionAlgorithmNaclSecretBoxVariant](mod_crypto.md#boxencryptionalgorithmnaclsecretboxvariant)
-
-[BoxEncryptionAlgorithm](mod_crypto.md#boxencryptionalgorithm)
-
-[ChaCha20ParamsCB](mod_crypto.md#chacha20paramscb)
-
-[NaclBoxParamsCB](mod_crypto.md#naclboxparamscb)
-
-[NaclSecretBoxParamsCB](mod_crypto.md#naclsecretboxparamscb)
-
-[MnemonicDictionary](mod_crypto.md#mnemonicdictionary)
-
-[ParamsOfFactorize](mod_crypto.md#paramsoffactorize)
-
-[ResultOfFactorize](mod_crypto.md#resultoffactorize)
-
-[ParamsOfModularPower](mod_crypto.md#paramsofmodularpower)
-
-[ResultOfModularPower](mod_crypto.md#resultofmodularpower)
-
-[ParamsOfTvmCrc16](mod_crypto.md#paramsoftoncrc16)
-
-[ResultOfTvmCrc16](mod_crypto.md#resultoftoncrc16)
-
-[ParamsOfGenerateRandomBytes](mod_crypto.md#paramsofgeneraterandombytes)
-
-[ResultOfGenerateRandomBytes](mod_crypto.md#resultofgeneraterandombytes)
-
-[ParamsOfConvertPublicKeyToTvmSafeFormat](mod_crypto.md#paramsofconvertpublickeytotonsafeformat)
-
-[ResultOfConvertPublicKeyToTvmSafeFormat](mod_crypto.md#resultofconvertpublickeytotonsafeformat)
-
-[KeyPair](mod_crypto.md#keypair)
-
-[ParamsOfSign](mod_crypto.md#paramsofsign)
-
-[ResultOfSign](mod_crypto.md#resultofsign)
-
-[ParamsOfVerifySignature](mod_crypto.md#paramsofverifysignature)
-
-[ResultOfVerifySignature](mod_crypto.md#resultofverifysignature)
-
-[ParamsOfHash](mod_crypto.md#paramsofhash)
-
-[ResultOfHash](mod_crypto.md#resultofhash)
-
-[ParamsOfScrypt](mod_crypto.md#paramsofscrypt)
-
-[ResultOfScrypt](mod_crypto.md#resultofscrypt)
-
-[ParamsOfNaclSignKeyPairFromSecret](mod_crypto.md#paramsofnaclsignkeypairfromsecret)
-
-[ParamsOfNaclSign](mod_crypto.md#paramsofnaclsign)
-
-[ResultOfNaclSign](mod_crypto.md#resultofnaclsign)
-
-[ParamsOfNaclSignOpen](mod_crypto.md#paramsofnaclsignopen)
-
-[ResultOfNaclSignOpen](mod_crypto.md#resultofnaclsignopen)
-
-[ResultOfNaclSignDetached](mod_crypto.md#resultofnaclsigndetached)
-
-[ParamsOfNaclSignDetachedVerify](mod_crypto.md#paramsofnaclsigndetachedverify)
-
-[ResultOfNaclSignDetachedVerify](mod_crypto.md#resultofnaclsigndetachedverify)
-
-[ParamsOfNaclBoxKeyPairFromSecret](mod_crypto.md#paramsofnaclboxkeypairfromsecret)
-
-[ParamsOfNaclBox](mod_crypto.md#paramsofnaclbox)
-
-[ResultOfNaclBox](mod_crypto.md#resultofnaclbox)
-
-[ParamsOfNaclBoxOpen](mod_crypto.md#paramsofnaclboxopen)
-
-[ResultOfNaclBoxOpen](mod_crypto.md#resultofnaclboxopen)
-
-[ParamsOfNaclSecretBox](mod_crypto.md#paramsofnaclsecretbox)
-
-[ParamsOfNaclSecretBoxOpen](mod_crypto.md#paramsofnaclsecretboxopen)
-
-[ParamsOfMnemonicWords](mod_crypto.md#paramsofmnemonicwords)
-
-[ResultOfMnemonicWords](mod_crypto.md#resultofmnemonicwords)
-
-[ParamsOfMnemonicFromRandom](mod_crypto.md#paramsofmnemonicfromrandom)
-
-[ResultOfMnemonicFromRandom](mod_crypto.md#resultofmnemonicfromrandom)
-
-[ParamsOfMnemonicFromEntropy](mod_crypto.md#paramsofmnemonicfromentropy)
-
-[ResultOfMnemonicFromEntropy](mod_crypto.md#resultofmnemonicfromentropy)
-
-[ParamsOfMnemonicVerify](mod_crypto.md#paramsofmnemonicverify)
-
-[ResultOfMnemonicVerify](mod_crypto.md#resultofmnemonicverify)
-
-[ParamsOfMnemonicDeriveSignKeys](mod_crypto.md#paramsofmnemonicderivesignkeys)
-
-[ParamsOfHDKeyXPrvFromMnemonic](mod_crypto.md#paramsofhdkeyxprvfrommnemonic)
-
-[ResultOfHDKeyXPrvFromMnemonic](mod_crypto.md#resultofhdkeyxprvfrommnemonic)
-
-[ParamsOfHDKeyDeriveFromXPrv](mod_crypto.md#paramsofhdkeyderivefromxprv)
-
-[ResultOfHDKeyDeriveFromXPrv](mod_crypto.md#resultofhdkeyderivefromxprv)
-
-[ParamsOfHDKeyDeriveFromXPrvPath](mod_crypto.md#paramsofhdkeyderivefromxprvpath)
-
-[ResultOfHDKeyDeriveFromXPrvPath](mod_crypto.md#resultofhdkeyderivefromxprvpath)
-
-[ParamsOfHDKeySecretFromXPrv](mod_crypto.md#paramsofhdkeysecretfromxprv)
-
-[ResultOfHDKeySecretFromXPrv](mod_crypto.md#resultofhdkeysecretfromxprv)
-
-[ParamsOfHDKeyPublicFromXPrv](mod_crypto.md#paramsofhdkeypublicfromxprv)
-
-[ResultOfHDKeyPublicFromXPrv](mod_crypto.md#resultofhdkeypublicfromxprv)
-
-[ParamsOfChaCha20](mod_crypto.md#paramsofchacha20)
-
-[ResultOfChaCha20](mod_crypto.md#resultofchacha20)
-
-[ParamsOfCreateCryptoBox](mod_crypto.md#paramsofcreatecryptobox)
-
-[RegisteredCryptoBox](mod_crypto.md#registeredcryptobox)
-
-[ParamsOfAppPasswordProviderGetPasswordVariant](mod_crypto.md#paramsofapppasswordprovidergetpasswordvariant)
-
-[ParamsOfAppPasswordProvider](mod_crypto.md#paramsofapppasswordprovider) – Interface that provides a callback that returns an encrypted password, used for cryptobox secret encryption
-
-[ResultOfAppPasswordProviderGetPasswordVariant](mod_crypto.md#resultofapppasswordprovidergetpasswordvariant)
-
-[ResultOfAppPasswordProvider](mod_crypto.md#resultofapppasswordprovider)
-
-[ResultOfGetCryptoBoxInfo](mod_crypto.md#resultofgetcryptoboxinfo)
-
-[ResultOfGetCryptoBoxSeedPhrase](mod_crypto.md#resultofgetcryptoboxseedphrase)
-
-[ParamsOfGetSigningBoxFromCryptoBox](mod_crypto.md#paramsofgetsigningboxfromcryptobox)
-
-[RegisteredSigningBox](mod_crypto.md#registeredsigningbox)
-
-[ParamsOfGetEncryptionBoxFromCryptoBox](mod_crypto.md#paramsofgetencryptionboxfromcryptobox)
-
-[RegisteredEncryptionBox](mod_crypto.md#registeredencryptionbox)
-
-[ParamsOfAppSigningBoxGetPublicKeyVariant](mod_crypto.md#paramsofappsigningboxgetpublickeyvariant) – Get signing box public key
-
-[ParamsOfAppSigningBoxSignVariant](mod_crypto.md#paramsofappsigningboxsignvariant) – Sign data
-
-[ParamsOfAppSigningBox](mod_crypto.md#paramsofappsigningbox) – Signing box callbacks.
-
-[ResultOfAppSigningBoxGetPublicKeyVariant](mod_crypto.md#resultofappsigningboxgetpublickeyvariant) – Result of getting public key
-
-[ResultOfAppSigningBoxSignVariant](mod_crypto.md#resultofappsigningboxsignvariant) – Result of signing data
-
-[ResultOfAppSigningBox](mod_crypto.md#resultofappsigningbox) – Returning values from signing box callbacks.
-
-[ResultOfSigningBoxGetPublicKey](mod_crypto.md#resultofsigningboxgetpublickey)
-
-[ParamsOfSigningBoxSign](mod_crypto.md#paramsofsigningboxsign)
-
-[ResultOfSigningBoxSign](mod_crypto.md#resultofsigningboxsign)
-
-[ParamsOfAppEncryptionBoxGetInfoVariant](mod_crypto.md#paramsofappencryptionboxgetinfovariant) – Get encryption box info
-
-[ParamsOfAppEncryptionBoxEncryptVariant](mod_crypto.md#paramsofappencryptionboxencryptvariant) – Encrypt data
-
-[ParamsOfAppEncryptionBoxDecryptVariant](mod_crypto.md#paramsofappencryptionboxdecryptvariant) – Decrypt data
-
-[ParamsOfAppEncryptionBox](mod_crypto.md#paramsofappencryptionbox) – Interface for data encryption/decryption
-
-[ResultOfAppEncryptionBoxGetInfoVariant](mod_crypto.md#resultofappencryptionboxgetinfovariant) – Result of getting encryption box info
-
-[ResultOfAppEncryptionBoxEncryptVariant](mod_crypto.md#resultofappencryptionboxencryptvariant) – Result of encrypting data
-
-[ResultOfAppEncryptionBoxDecryptVariant](mod_crypto.md#resultofappencryptionboxdecryptvariant) – Result of decrypting data
-
-[ResultOfAppEncryptionBox](mod_crypto.md#resultofappencryptionbox) – Returning values from signing box callbacks.
-
-[ParamsOfEncryptionBoxGetInfo](mod_crypto.md#paramsofencryptionboxgetinfo)
-
-[ResultOfEncryptionBoxGetInfo](mod_crypto.md#resultofencryptionboxgetinfo)
-
-[ParamsOfEncryptionBoxEncrypt](mod_crypto.md#paramsofencryptionboxencrypt)
-
-[ResultOfEncryptionBoxEncrypt](mod_crypto.md#resultofencryptionboxencrypt)
-
-[ParamsOfEncryptionBoxDecrypt](mod_crypto.md#paramsofencryptionboxdecrypt)
-
-[ResultOfEncryptionBoxDecrypt](mod_crypto.md#resultofencryptionboxdecrypt)
-
-[ParamsOfCreateEncryptionBox](mod_crypto.md#paramsofcreateencryptionbox)
-
-[AppPasswordProvider](mod_crypto.md#apppasswordprovider) – Interface that provides a callback that returns an encrypted password, used for cryptobox secret encryption
-
-[AppSigningBox](mod_crypto.md#appsigningbox) – Signing box callbacks.
-
-[AppEncryptionBox](mod_crypto.md#appencryptionbox) – Interface for data encryption/decryption
 
 ## Functions
+[factorize](mod\_crypto.md#factorize) – Integer factorization
 
-### factorize
+[modular_power](mod\_crypto.md#modular_power) – Modular exponentiation
+
+[tvm_crc16](mod\_crypto.md#tvm_crc16) – Calculates CRC16 using TON algorithm.
+
+[generate_random_bytes](mod\_crypto.md#generate_random_bytes) – Generates random byte array of the specified length and returns it in `base64` format
+
+[convert_public_key_to_tvm_safe_format](mod\_crypto.md#convert_public_key_to_tvm_safe_format) – Converts public key to ton safe_format
+
+[generate_random_sign_keys](mod\_crypto.md#generate_random_sign_keys) – Generates random ed25519 key pair.
+
+[sign](mod\_crypto.md#sign) – Signs a data using the provided keys.
+
+[verify_signature](mod\_crypto.md#verify_signature) – Verifies signed data using the provided public key. Raises error if verification is failed.
+
+[sha256](mod\_crypto.md#sha256) – Calculates SHA256 hash of the specified data.
+
+[sha512](mod\_crypto.md#sha512) – Calculates SHA512 hash of the specified data.
+
+[scrypt](mod\_crypto.md#scrypt) – Perform `scrypt` encryption
+
+[nacl_sign_keypair_from_secret_key](mod\_crypto.md#nacl_sign_keypair_from_secret_key) – Generates a key pair for signing from the secret key
+
+[nacl_sign](mod\_crypto.md#nacl_sign) – Signs data using the signer's secret key.
+
+[nacl_sign_open](mod\_crypto.md#nacl_sign_open) – Verifies the signature and returns the unsigned message
+
+[nacl_sign_detached](mod\_crypto.md#nacl_sign_detached) – Signs the message using the secret key and returns a signature.
+
+[nacl_sign_detached_verify](mod\_crypto.md#nacl_sign_detached_verify) – Verifies the signature with public key and `unsigned` data.
+
+[nacl_box_keypair](mod\_crypto.md#nacl_box_keypair) – Generates a random NaCl key pair
+
+[nacl_box_keypair_from_secret_key](mod\_crypto.md#nacl_box_keypair_from_secret_key) – Generates key pair from a secret key
+
+[nacl_box](mod\_crypto.md#nacl_box) – Public key authenticated encryption
+
+[nacl_box_open](mod\_crypto.md#nacl_box_open) – Decrypt and verify the cipher text using the receivers secret key, the senders public key, and the nonce.
+
+[nacl_secret_box](mod\_crypto.md#nacl_secret_box) – Encrypt and authenticate message using nonce and secret key.
+
+[nacl_secret_box_open](mod\_crypto.md#nacl_secret_box_open) – Decrypts and verifies cipher text using `nonce` and secret `key`.
+
+[mnemonic_words](mod\_crypto.md#mnemonic_words) – Prints the list of words from the specified dictionary
+
+[mnemonic_from_random](mod\_crypto.md#mnemonic_from_random) – Generates a random mnemonic
+
+[mnemonic_from_entropy](mod\_crypto.md#mnemonic_from_entropy) – Generates mnemonic from pre-generated entropy
+
+[mnemonic_verify](mod\_crypto.md#mnemonic_verify) – Validates a mnemonic phrase
+
+[mnemonic_derive_sign_keys](mod\_crypto.md#mnemonic_derive_sign_keys) – Derives a key pair for signing from the seed phrase
+
+[hdkey_xprv_from_mnemonic](mod\_crypto.md#hdkey_xprv_from_mnemonic) – Generates an extended master private key that will be the root for all the derived keys
+
+[hdkey_derive_from_xprv](mod\_crypto.md#hdkey_derive_from_xprv) – Returns extended private key derived from the specified extended private key and child index
+
+[hdkey_derive_from_xprv_path](mod\_crypto.md#hdkey_derive_from_xprv_path) – Derives the extended private key from the specified key and path
+
+[hdkey_secret_from_xprv](mod\_crypto.md#hdkey_secret_from_xprv) – Extracts the private key from the serialized extended private key
+
+[hdkey_public_from_xprv](mod\_crypto.md#hdkey_public_from_xprv) – Extracts the public key from the serialized extended private key
+
+[chacha20](mod\_crypto.md#chacha20) – Performs symmetric `chacha20` encryption.
+
+[create_crypto_box](mod\_crypto.md#create_crypto_box) – Creates a Crypto Box instance.
+
+[remove_crypto_box](mod\_crypto.md#remove_crypto_box) – Removes Crypto Box. Clears all secret data.
+
+[get_crypto_box_info](mod\_crypto.md#get_crypto_box_info) – Get Crypto Box Info. Used to get `encrypted_secret` that should be used for all the cryptobox initializations except the first one.
+
+[get_crypto_box_seed_phrase](mod\_crypto.md#get_crypto_box_seed_phrase) – Get Crypto Box Seed Phrase.
+
+[get_signing_box_from_crypto_box](mod\_crypto.md#get_signing_box_from_crypto_box) – Get handle of Signing Box derived from Crypto Box.
+
+[get_encryption_box_from_crypto_box](mod\_crypto.md#get_encryption_box_from_crypto_box) – Gets Encryption Box from Crypto Box.
+
+[clear_crypto_box_secret_cache](mod\_crypto.md#clear_crypto_box_secret_cache) – Removes cached secrets (overwrites with zeroes) from all signing and encryption boxes, derived from crypto box.
+
+[register_signing_box](mod\_crypto.md#register_signing_box) – Register an application implemented signing box.
+
+[get_signing_box](mod\_crypto.md#get_signing_box) – Creates a default signing box implementation.
+
+[signing_box_get_public_key](mod\_crypto.md#signing_box_get_public_key) – Returns public key of signing key pair.
+
+[signing_box_sign](mod\_crypto.md#signing_box_sign) – Returns signed user data.
+
+[remove_signing_box](mod\_crypto.md#remove_signing_box) – Removes signing box from SDK.
+
+[register_encryption_box](mod\_crypto.md#register_encryption_box) – Register an application implemented encryption box.
+
+[remove_encryption_box](mod\_crypto.md#remove_encryption_box) – Removes encryption box from SDK
+
+[encryption_box_get_info](mod\_crypto.md#encryption_box_get_info) – Queries info from the given encryption box
+
+[encryption_box_encrypt](mod\_crypto.md#encryption_box_encrypt) – Encrypts data using given encryption box Note.
+
+[encryption_box_decrypt](mod\_crypto.md#encryption_box_decrypt) – Decrypts data using given encryption box Note.
+
+[create_encryption_box](mod\_crypto.md#create_encryption_box) – Creates encryption box with specified algorithm
+
+## Types
+[CryptoErrorCode](mod\_crypto.md#cryptoerrorcode)
+
+[SigningBoxHandle](mod\_crypto.md#signingboxhandle)
+
+[EncryptionBoxHandle](mod\_crypto.md#encryptionboxhandle)
+
+[EncryptionBoxInfo](mod\_crypto.md#encryptionboxinfo) – Encryption box information.
+
+[EncryptionAlgorithmAESVariant](mod\_crypto.md#encryptionalgorithmaesvariant)
+
+[EncryptionAlgorithmChaCha20Variant](mod\_crypto.md#encryptionalgorithmchacha20variant)
+
+[EncryptionAlgorithmNaclBoxVariant](mod\_crypto.md#encryptionalgorithmnaclboxvariant)
+
+[EncryptionAlgorithmNaclSecretBoxVariant](mod\_crypto.md#encryptionalgorithmnaclsecretboxvariant)
+
+[EncryptionAlgorithm](mod\_crypto.md#encryptionalgorithm)
+
+[CipherMode](mod\_crypto.md#ciphermode)
+
+[AesParamsEB](mod\_crypto.md#aesparamseb)
+
+[AesInfo](mod\_crypto.md#aesinfo)
+
+[ChaCha20ParamsEB](mod\_crypto.md#chacha20paramseb)
+
+[NaclBoxParamsEB](mod\_crypto.md#naclboxparamseb)
+
+[NaclSecretBoxParamsEB](mod\_crypto.md#naclsecretboxparamseb)
+
+[CryptoBoxSecretRandomSeedPhraseVariant](mod\_crypto.md#cryptoboxsecretrandomseedphrasevariant) – Creates Crypto Box from a random seed phrase. This option can be used if a developer doesn't want the seed phrase to leave the core library's memory, where it is stored encrypted.
+
+[CryptoBoxSecretPredefinedSeedPhraseVariant](mod\_crypto.md#cryptoboxsecretpredefinedseedphrasevariant) – Restores crypto box instance from an existing seed phrase. This type should be used when Crypto Box is initialized from a seed phrase, entered by a user.
+
+[CryptoBoxSecretEncryptedSecretVariant](mod\_crypto.md#cryptoboxsecretencryptedsecretvariant) – Use this type for wallet reinitializations, when you already have `encrypted_secret` on hands.
+
+[CryptoBoxSecret](mod\_crypto.md#cryptoboxsecret) – Crypto Box Secret.
+
+[CryptoBoxHandle](mod\_crypto.md#cryptoboxhandle)
+
+[BoxEncryptionAlgorithmChaCha20Variant](mod\_crypto.md#boxencryptionalgorithmchacha20variant)
+
+[BoxEncryptionAlgorithmNaclBoxVariant](mod\_crypto.md#boxencryptionalgorithmnaclboxvariant)
+
+[BoxEncryptionAlgorithmNaclSecretBoxVariant](mod\_crypto.md#boxencryptionalgorithmnaclsecretboxvariant)
+
+[BoxEncryptionAlgorithm](mod\_crypto.md#boxencryptionalgorithm)
+
+[ChaCha20ParamsCB](mod\_crypto.md#chacha20paramscb)
+
+[NaclBoxParamsCB](mod\_crypto.md#naclboxparamscb)
+
+[NaclSecretBoxParamsCB](mod\_crypto.md#naclsecretboxparamscb)
+
+[MnemonicDictionary](mod\_crypto.md#mnemonicdictionary)
+
+[ParamsOfFactorize](mod\_crypto.md#paramsoffactorize)
+
+[ResultOfFactorize](mod\_crypto.md#resultoffactorize)
+
+[ParamsOfModularPower](mod\_crypto.md#paramsofmodularpower)
+
+[ResultOfModularPower](mod\_crypto.md#resultofmodularpower)
+
+[ParamsOfTonCrc16](mod\_crypto.md#paramsoftoncrc16)
+
+[ResultOfTonCrc16](mod\_crypto.md#resultoftoncrc16)
+
+[ParamsOfGenerateRandomBytes](mod\_crypto.md#paramsofgeneraterandombytes)
+
+[ResultOfGenerateRandomBytes](mod\_crypto.md#resultofgeneraterandombytes)
+
+[ParamsOfConvertPublicKeyToTonSafeFormat](mod\_crypto.md#paramsofconvertpublickeytotonsafeformat) – ParamsOfConvertPublicKeyToTonSafeFormat
+
+[ResultOfConvertPublicKeyToTonSafeFormat](mod\_crypto.md#resultofconvertpublickeytotonsafeformat)
+
+[KeyPair](mod\_crypto.md#keypair) – KeyPair
+
+[ParamsOfSign](mod\_crypto.md#paramsofsign) – ParamsOfSign
+
+[ResultOfSign](mod\_crypto.md#resultofsign)
+
+[ParamsOfVerifySignature](mod\_crypto.md#paramsofverifysignature) – ParamsOfVerifySignature
+
+[ResultOfVerifySignature](mod\_crypto.md#resultofverifysignature)
+
+[ParamsOfHash](mod\_crypto.md#paramsofhash)
+
+[ResultOfHash](mod\_crypto.md#resultofhash)
+
+[ParamsOfScrypt](mod\_crypto.md#paramsofscrypt)
+
+[ResultOfScrypt](mod\_crypto.md#resultofscrypt)
+
+[ParamsOfNaclSignKeyPairFromSecret](mod\_crypto.md#paramsofnaclsignkeypairfromsecret) – ParamsOfNaclSignKeyPairFromSecret
+
+[ParamsOfNaclSign](mod\_crypto.md#paramsofnaclsign) – ParamsOfNaclSign
+
+[ResultOfNaclSign](mod\_crypto.md#resultofnaclsign)
+
+[ParamsOfNaclSignOpen](mod\_crypto.md#paramsofnaclsignopen) – ParamsOfNaclSignOpen
+
+[ResultOfNaclSignOpen](mod\_crypto.md#resultofnaclsignopen)
+
+[ResultOfNaclSignDetached](mod\_crypto.md#resultofnaclsigndetached)
+
+[ParamsOfNaclSignDetachedVerify](mod\_crypto.md#paramsofnaclsigndetachedverify) – ParamsOfNaclSignDetachedVerify
+
+[ResultOfNaclSignDetachedVerify](mod\_crypto.md#resultofnaclsigndetachedverify)
+
+[ParamsOfNaclBoxKeyPairFromSecret](mod\_crypto.md#paramsofnaclboxkeypairfromsecret) – ParamsOfNaclBoxKeyPairFromSecret
+
+[ParamsOfNaclBox](mod\_crypto.md#paramsofnaclbox) – ParamsOfNaclBox
+
+[ResultOfNaclBox](mod\_crypto.md#resultofnaclbox)
+
+[ParamsOfNaclBoxOpen](mod\_crypto.md#paramsofnaclboxopen) – ParamsOfNaclBoxOpen
+
+[ResultOfNaclBoxOpen](mod\_crypto.md#resultofnaclboxopen)
+
+[ParamsOfNaclSecretBox](mod\_crypto.md#paramsofnaclsecretbox) – ParamsOfNaclSecretBox
+
+[ParamsOfNaclSecretBoxOpen](mod\_crypto.md#paramsofnaclsecretboxopen) – ParamsOfNaclSecretBoxOpen
+
+[ParamsOfMnemonicWords](mod\_crypto.md#paramsofmnemonicwords)
+
+[ResultOfMnemonicWords](mod\_crypto.md#resultofmnemonicwords)
+
+[ParamsOfMnemonicFromRandom](mod\_crypto.md#paramsofmnemonicfromrandom)
+
+[ResultOfMnemonicFromRandom](mod\_crypto.md#resultofmnemonicfromrandom)
+
+[ParamsOfMnemonicFromEntropy](mod\_crypto.md#paramsofmnemonicfromentropy)
+
+[ResultOfMnemonicFromEntropy](mod\_crypto.md#resultofmnemonicfromentropy)
+
+[ParamsOfMnemonicVerify](mod\_crypto.md#paramsofmnemonicverify)
+
+[ResultOfMnemonicVerify](mod\_crypto.md#resultofmnemonicverify)
+
+[ParamsOfMnemonicDeriveSignKeys](mod\_crypto.md#paramsofmnemonicderivesignkeys)
+
+[ParamsOfHDKeyXPrvFromMnemonic](mod\_crypto.md#paramsofhdkeyxprvfrommnemonic)
+
+[ResultOfHDKeyXPrvFromMnemonic](mod\_crypto.md#resultofhdkeyxprvfrommnemonic)
+
+[ParamsOfHDKeyDeriveFromXPrv](mod\_crypto.md#paramsofhdkeyderivefromxprv)
+
+[ResultOfHDKeyDeriveFromXPrv](mod\_crypto.md#resultofhdkeyderivefromxprv)
+
+[ParamsOfHDKeyDeriveFromXPrvPath](mod\_crypto.md#paramsofhdkeyderivefromxprvpath)
+
+[ResultOfHDKeyDeriveFromXPrvPath](mod\_crypto.md#resultofhdkeyderivefromxprvpath)
+
+[ParamsOfHDKeySecretFromXPrv](mod\_crypto.md#paramsofhdkeysecretfromxprv)
+
+[ResultOfHDKeySecretFromXPrv](mod\_crypto.md#resultofhdkeysecretfromxprv)
+
+[ParamsOfHDKeyPublicFromXPrv](mod\_crypto.md#paramsofhdkeypublicfromxprv)
+
+[ResultOfHDKeyPublicFromXPrv](mod\_crypto.md#resultofhdkeypublicfromxprv)
+
+[ParamsOfChaCha20](mod\_crypto.md#paramsofchacha20)
+
+[ResultOfChaCha20](mod\_crypto.md#resultofchacha20)
+
+[ParamsOfCreateCryptoBox](mod\_crypto.md#paramsofcreatecryptobox)
+
+[RegisteredCryptoBox](mod\_crypto.md#registeredcryptobox)
+
+[ParamsOfAppPasswordProviderGetPasswordVariant](mod\_crypto.md#paramsofapppasswordprovidergetpasswordvariant)
+
+[ParamsOfAppPasswordProvider](mod\_crypto.md#paramsofapppasswordprovider) – Interface that provides a callback that returns an encrypted password, used for cryptobox secret encryption
+
+[ResultOfAppPasswordProviderGetPasswordVariant](mod\_crypto.md#resultofapppasswordprovidergetpasswordvariant)
+
+[ResultOfAppPasswordProvider](mod\_crypto.md#resultofapppasswordprovider)
+
+[ResultOfGetCryptoBoxInfo](mod\_crypto.md#resultofgetcryptoboxinfo)
+
+[ResultOfGetCryptoBoxSeedPhrase](mod\_crypto.md#resultofgetcryptoboxseedphrase)
+
+[ParamsOfGetSigningBoxFromCryptoBox](mod\_crypto.md#paramsofgetsigningboxfromcryptobox)
+
+[RegisteredSigningBox](mod\_crypto.md#registeredsigningbox)
+
+[ParamsOfGetEncryptionBoxFromCryptoBox](mod\_crypto.md#paramsofgetencryptionboxfromcryptobox)
+
+[RegisteredEncryptionBox](mod\_crypto.md#registeredencryptionbox)
+
+[ParamsOfAppSigningBoxGetPublicKeyVariant](mod\_crypto.md#paramsofappsigningboxgetpublickeyvariant) – Get signing box public key
+
+[ParamsOfAppSigningBoxSignVariant](mod\_crypto.md#paramsofappsigningboxsignvariant) – Sign data
+
+[ParamsOfAppSigningBox](mod\_crypto.md#paramsofappsigningbox) – Signing box callbacks.
+
+[ResultOfAppSigningBoxGetPublicKeyVariant](mod\_crypto.md#resultofappsigningboxgetpublickeyvariant) – Result of getting public key
+
+[ResultOfAppSigningBoxSignVariant](mod\_crypto.md#resultofappsigningboxsignvariant) – Result of signing data
+
+[ResultOfAppSigningBox](mod\_crypto.md#resultofappsigningbox) – Returning values from signing box callbacks.
+
+[ResultOfSigningBoxGetPublicKey](mod\_crypto.md#resultofsigningboxgetpublickey)
+
+[ParamsOfSigningBoxSign](mod\_crypto.md#paramsofsigningboxsign)
+
+[ResultOfSigningBoxSign](mod\_crypto.md#resultofsigningboxsign)
+
+[ParamsOfAppEncryptionBoxGetInfoVariant](mod\_crypto.md#paramsofappencryptionboxgetinfovariant) – Get encryption box info
+
+[ParamsOfAppEncryptionBoxEncryptVariant](mod\_crypto.md#paramsofappencryptionboxencryptvariant) – Encrypt data
+
+[ParamsOfAppEncryptionBoxDecryptVariant](mod\_crypto.md#paramsofappencryptionboxdecryptvariant) – Decrypt data
+
+[ParamsOfAppEncryptionBox](mod\_crypto.md#paramsofappencryptionbox) – Interface for data encryption/decryption
+
+[ResultOfAppEncryptionBoxGetInfoVariant](mod\_crypto.md#resultofappencryptionboxgetinfovariant) – Result of getting encryption box info
+
+[ResultOfAppEncryptionBoxEncryptVariant](mod\_crypto.md#resultofappencryptionboxencryptvariant) – Result of encrypting data
+
+[ResultOfAppEncryptionBoxDecryptVariant](mod\_crypto.md#resultofappencryptionboxdecryptvariant) – Result of decrypting data
+
+[ResultOfAppEncryptionBox](mod\_crypto.md#resultofappencryptionbox) – Returning values from signing box callbacks.
+
+[ParamsOfEncryptionBoxGetInfo](mod\_crypto.md#paramsofencryptionboxgetinfo)
+
+[ResultOfEncryptionBoxGetInfo](mod\_crypto.md#resultofencryptionboxgetinfo)
+
+[ParamsOfEncryptionBoxEncrypt](mod\_crypto.md#paramsofencryptionboxencrypt)
+
+[ResultOfEncryptionBoxEncrypt](mod\_crypto.md#resultofencryptionboxencrypt)
+
+[ParamsOfEncryptionBoxDecrypt](mod\_crypto.md#paramsofencryptionboxdecrypt)
+
+[ResultOfEncryptionBoxDecrypt](mod\_crypto.md#resultofencryptionboxdecrypt)
+
+[ParamsOfCreateEncryptionBox](mod\_crypto.md#paramsofcreateencryptionbox)
+
+[AppPasswordProvider](mod\_crypto.md#apppasswordprovider) – Interface that provides a callback that returns an encrypted password, used for cryptobox secret encryption
+
+[AppSigningBox](mod\_crypto.md#appsigningbox) – Signing box callbacks.
+
+[AppEncryptionBox](mod\_crypto.md#appencryptionbox) – Interface for data encryption/decryption
+
+
+# Functions
+## factorize
 
 Integer factorization
 
-Performs prime factorization – decomposition of a composite number into a product of smaller prime integers (factors). See \[https://en.wikipedia.org/wiki/Integer\_factorization]
+Performs prime factorization – decomposition of a composite number
+into a product of smaller prime integers (factors).
+See [https://en.wikipedia.org/wiki/Integer_factorization]
 
 ```ts
 type ParamsOfFactorize = {
@@ -379,22 +378,22 @@ function factorize_sync(
     params: ParamsOfFactorize,
 ): ResultOfFactorize;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `composite`: _string_ – Hexadecimal representation of u64 composite number.
 
-#### Parameters
 
-* `composite`: _string_ – Hexadecimal representation of u64 composite number.
+### Result
 
-#### Result
+- `factors`: _string[]_ – Two factors of composite or empty if composite can't be factorized.
 
-* `factors`: _string\[]_ – Two factors of composite or empty if composite can't be factorized.
 
-### modular\_power
+## modular_power
 
 Modular exponentiation
 
-Performs modular exponentiation for big integers (`base`^`exponent` mod `modulus`). See \[https://en.wikipedia.org/wiki/Modular\_exponentiation]
+Performs modular exponentiation for big integers (`base`^`exponent` mod
+`modulus`). See [https://en.wikipedia.org/wiki/Modular_exponentiation]
 
 ```ts
 type ParamsOfModularPower = {
@@ -415,53 +414,51 @@ function modular_power_sync(
     params: ParamsOfModularPower,
 ): ResultOfModularPower;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `base`: _string_ – `base` argument of calculation.
+- `exponent`: _string_ – `exponent` argument of calculation.
+- `modulus`: _string_ – `modulus` argument of calculation.
 
-#### Parameters
 
-* `base`: _string_ – `base` argument of calculation.
-* `exponent`: _string_ – `exponent` argument of calculation.
-* `modulus`: _string_ – `modulus` argument of calculation.
+### Result
 
-#### Result
+- `modular_power`: _string_ – Result of modular exponentiation
 
-* `modular_power`: _string_ – Result of modular exponentiation
 
-### tvm\_crc16
+## tvm_crc16
 
-Calculates CRC16 using TVM algorithm.
+Calculates CRC16 using TON algorithm.
 
 ```ts
-type ParamsOfTvmCrc16 = {
+type ParamsOfTonCrc16 = {
     data: string
 }
 
-type ResultOfTvmCrc16 = {
+type ResultOfTonCrc16 = {
     crc: number
 }
 
 function tvm_crc16(
-    params: ParamsOfTvmCrc16,
-): Promise<ResultOfTvmCrc16>;
+    params: ParamsOfTonCrc16,
+): Promise<ResultOfTonCrc16>;
 
 function tvm_crc16_sync(
-    params: ParamsOfTvmCrc16,
-): ResultOfTvmCrc16;
+    params: ParamsOfTonCrc16,
+): ResultOfTonCrc16;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `data`: _string_ – Input data for CRC calculation.
+<br>Encoded with `base64`.
 
-#### Parameters
 
-* `data`: _string_ – Input data for CRC calculation.\
-  Encoded with `base64`.
+### Result
 
-#### Result
+- `crc`: _number_ – Calculated CRC for input data.
 
-* `crc`: _number_ – Calculated CRC for input data.
 
-### generate\_random\_bytes
+## generate_random_bytes
 
 Generates random byte array of the specified length and returns it in `base64` format
 
@@ -482,50 +479,48 @@ function generate_random_bytes_sync(
     params: ParamsOfGenerateRandomBytes,
 ): ResultOfGenerateRandomBytes;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `length`: _number_ – Size of random byte array.
 
-#### Parameters
 
-* `length`: _number_ – Size of random byte array.
+### Result
 
-#### Result
+- `bytes`: _string_ – Generated bytes encoded in `base64`.
 
-* `bytes`: _string_ – Generated bytes encoded in `base64`.
 
-### convert\_public\_key\_to\_tvm\_safe\_format
+## convert_public_key_to_tvm_safe_format
 
-Converts public key to tvm safe\_format
+Converts public key to ton safe_format
 
 ```ts
-type ParamsOfConvertPublicKeyToTvmSafeFormat = {
+type ParamsOfConvertPublicKeyToTonSafeFormat = {
     public_key: string
 }
 
-type ResultOfConvertPublicKeyToTvmSafeFormat = {
+type ResultOfConvertPublicKeyToTonSafeFormat = {
     tvm_public_key: string
 }
 
 function convert_public_key_to_tvm_safe_format(
-    params: ParamsOfConvertPublicKeyToTvmSafeFormat,
-): Promise<ResultOfConvertPublicKeyToTvmSafeFormat>;
+    params: ParamsOfConvertPublicKeyToTonSafeFormat,
+): Promise<ResultOfConvertPublicKeyToTonSafeFormat>;
 
 function convert_public_key_to_tvm_safe_format_sync(
-    params: ParamsOfConvertPublicKeyToTvmSafeFormat,
-): ResultOfConvertPublicKeyToTvmSafeFormat;
+    params: ParamsOfConvertPublicKeyToTonSafeFormat,
+): ResultOfConvertPublicKeyToTonSafeFormat;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `public_key`: _string_ – Public key - 64 symbols hex string
 
-#### Parameters
 
-* `public_key`: _string_ – Public key - 64 symbols hex string
+### Result
 
-#### Result
+- `tvm_public_key`: _string_ – Public key represented in TON safe format.
 
-* `tvm_public_key`: _string_ – Public key represented in TVM safe format.
 
-### generate\_random\_sign\_keys
+## generate_random_sign_keys
 
 Generates random ed25519 key pair.
 
@@ -539,15 +534,16 @@ function generate_random_sign_keys(): Promise<KeyPair>;
 
 function generate_random_sign_keys_sync(): KeyPair;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
 
-#### Result
 
-* `public`: _string_ – Public key - 64 symbols hex string
-* `secret`: _string_ – Private key - u64 symbols hex string
+### Result
 
-### sign
+- `public`: _string_ – Public key - 64 symbols hex string
+- `secret`: _string_ – Private key - u64 symbols hex string
+
+
+## sign
 
 Signs a data using the provided keys.
 
@@ -570,20 +566,19 @@ function sign_sync(
     params: ParamsOfSign,
 ): ResultOfSign;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `unsigned`: _string_ – Data that must be signed encoded in `base64`.
+- `keys`: _[KeyPair](mod\_crypto.md#keypair)_ – Sign keys.
 
-#### Parameters
 
-* `unsigned`: _string_ – Data that must be signed encoded in `base64`.
-* `keys`: [_KeyPair_](mod_crypto.md#keypair) – Sign keys.
+### Result
 
-#### Result
+- `signed`: _string_ – Signed data combined with signature encoded in `base64`.
+- `signature`: _string_ – Signature encoded in `hex`.
 
-* `signed`: _string_ – Signed data combined with signature encoded in `base64`.
-* `signature`: _string_ – Signature encoded in `hex`.
 
-### verify\_signature
+## verify_signature
 
 Verifies signed data using the provided public key. Raises error if verification is failed.
 
@@ -605,19 +600,18 @@ function verify_signature_sync(
     params: ParamsOfVerifySignature,
 ): ResultOfVerifySignature;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `signed`: _string_ – Signed data that must be verified encoded in `base64`.
+- `public`: _string_ – Signer's public key - 64 symbols hex string
 
-#### Parameters
 
-* `signed`: _string_ – Signed data that must be verified encoded in `base64`.
-* `public`: _string_ – Signer's public key - 64 symbols hex string
+### Result
 
-#### Result
+- `unsigned`: _string_ – Unsigned data encoded in `base64`.
 
-* `unsigned`: _string_ – Unsigned data encoded in `base64`.
 
-### sha256
+## sha256
 
 Calculates SHA256 hash of the specified data.
 
@@ -638,20 +632,19 @@ function sha256_sync(
     params: ParamsOfHash,
 ): ResultOfHash;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `data`: _string_ – Input data for hash calculation.
+<br>Encoded with `base64`.
 
-#### Parameters
 
-* `data`: _string_ – Input data for hash calculation.\
-  Encoded with `base64`.
+### Result
 
-#### Result
+- `hash`: _string_ – Hash of input `data`.
+<br>Encoded with 'hex'.
 
-* `hash`: _string_ – Hash of input `data`.\
-  Encoded with 'hex'.
 
-### sha512
+## sha512
 
 Calculates SHA512 hash of the specified data.
 
@@ -672,42 +665,37 @@ function sha512_sync(
     params: ParamsOfHash,
 ): ResultOfHash;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `data`: _string_ – Input data for hash calculation.
+<br>Encoded with `base64`.
 
-#### Parameters
 
-* `data`: _string_ – Input data for hash calculation.\
-  Encoded with `base64`.
+### Result
 
-#### Result
+- `hash`: _string_ – Hash of input `data`.
+<br>Encoded with 'hex'.
 
-* `hash`: _string_ – Hash of input `data`.\
-  Encoded with 'hex'.
 
-### scrypt
+## scrypt
 
 Perform `scrypt` encryption
 
-Derives key from `password` and `key` using `scrypt` algorithm. See \[https://en.wikipedia.org/wiki/Scrypt].
+Derives key from `password` and `key` using `scrypt` algorithm.
+See [https://en.wikipedia.org/wiki/Scrypt].
 
-## Arguments
-
-* `log_n` - The log2 of the Scrypt parameter `N`
-* `r` - The Scrypt parameter `r`
-* `p` - The Scrypt parameter `p`
-
-## Conditions
-
-* `log_n` must be less than `64`
-* `r` must be greater than `0` and less than or equal to `4294967295`
-* `p` must be greater than `0` and less than `4294967295`
-
-## Recommended values sufficient for most use-cases
-
-* `log_n = 15` (`n = 32768`)
-* `r = 8`
-* `p = 1`
+# Arguments
+- `log_n` - The log2 of the Scrypt parameter `N`
+- `r` - The Scrypt parameter `r`
+- `p` - The Scrypt parameter `p`
+# Conditions
+- `log_n` must be less than `64`
+- `r` must be greater than `0` and less than or equal to `4294967295`
+- `p` must be greater than `0` and less than `4294967295`
+# Recommended values sufficient for most use-cases
+- `log_n = 15` (`n = 32768`)
+- `r = 8`
+- `p = 1`
 
 ```ts
 type ParamsOfScrypt = {
@@ -731,28 +719,30 @@ function scrypt_sync(
     params: ParamsOfScrypt,
 ): ResultOfScrypt;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `password`: _string_ – The password bytes to be hashed. Must be encoded with `base64`.
+- `salt`: _string_ – Salt bytes that modify the hash to protect against Rainbow table attacks.
+<br>Must be encoded with `base64`.
+- `log_n`: _number_ – CPU/memory cost parameter
+- `r`: _number_ – The block size parameter, which fine-tunes sequential memory read size and performance.
+- `p`: _number_ – Parallelization parameter.
+- `dk_len`: _number_ – Intended output length in octets of the derived key.
 
-#### Parameters
 
-* `password`: _string_ – The password bytes to be hashed. Must be encoded with `base64`.
-* `salt`: _string_ – Salt bytes that modify the hash to protect against Rainbow table attacks. Must be encoded with `base64`.
-* `log_n`: _number_ – CPU/memory cost parameter
-* `r`: _number_ – The block size parameter, which fine-tunes sequential memory read size and performance.
-* `p`: _number_ – Parallelization parameter.
-* `dk_len`: _number_ – Intended output length in octets of the derived key.
+### Result
 
-#### Result
+- `key`: _string_ – Derived key.
+<br>Encoded with `hex`.
 
-* `key`: _string_ – Derived key.\
-  Encoded with `hex`.
 
-### nacl\_sign\_keypair\_from\_secret\_key
+## nacl_sign_keypair_from_secret_key
 
 Generates a key pair for signing from the secret key
 
-**NOTE:** In the result the secret key is actually the concatenation of secret and public keys (128 symbols hex string) by design of [NaCL](http://nacl.cr.yp.to/sign.html). See also [the stackexchange question](https://crypto.stackexchange.com/questions/54353/).
+**NOTE:** In the result the secret key is actually the concatenation
+of secret and public keys (128 symbols hex string) by design of [NaCL](http://nacl.cr.yp.to/sign.html).
+See also [the stackexchange question](https://crypto.stackexchange.com/questions/54353/).
 
 ```ts
 type ParamsOfNaclSignKeyPairFromSecret = {
@@ -772,19 +762,18 @@ function nacl_sign_keypair_from_secret_key_sync(
     params: ParamsOfNaclSignKeyPairFromSecret,
 ): KeyPair;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `secret`: _string_ – Secret key - unprefixed 0-padded to 64 symbols hex string
 
-#### Parameters
 
-* `secret`: _string_ – Secret key - unprefixed 0-padded to 64 symbols hex string
+### Result
 
-#### Result
+- `public`: _string_ – Public key - 64 symbols hex string
+- `secret`: _string_ – Private key - u64 symbols hex string
 
-* `public`: _string_ – Public key - 64 symbols hex string
-* `secret`: _string_ – Private key - u64 symbols hex string
 
-### nacl\_sign
+## nacl_sign
 
 Signs data using the signer's secret key.
 
@@ -806,25 +795,25 @@ function nacl_sign_sync(
     params: ParamsOfNaclSign,
 ): ResultOfNaclSign;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `unsigned`: _string_ – Data that must be signed encoded in `base64`.
+- `secret`: _string_ – Signer's secret key - unprefixed 0-padded to 128 symbols hex string (concatenation of 64 symbols secret and 64 symbols public keys). See `nacl_sign_keypair_from_secret_key`.
 
-#### Parameters
 
-* `unsigned`: _string_ – Data that must be signed encoded in `base64`.
-* `secret`: _string_ – Signer's secret key - unprefixed 0-padded to 128 symbols hex string (concatenation of 64 symbols secret and 64 symbols public keys). See `nacl_sign_keypair_from_secret_key`.
+### Result
 
-#### Result
+- `signed`: _string_ – Signed data, encoded in `base64`.
 
-* `signed`: _string_ – Signed data, encoded in `base64`.
 
-### nacl\_sign\_open
+## nacl_sign_open
 
 Verifies the signature and returns the unsigned message
 
-Verifies the signature in `signed` using the signer's public key `public` and returns the message `unsigned`.
+Verifies the signature in `signed` using the signer's public key `public`
+and returns the message `unsigned`.
 
-If the signature fails verification, crypto\_sign\_open raises an exception.
+If the signature fails verification, crypto_sign_open raises an exception.
 
 ```ts
 type ParamsOfNaclSignOpen = {
@@ -844,24 +833,24 @@ function nacl_sign_open_sync(
     params: ParamsOfNaclSignOpen,
 ): ResultOfNaclSignOpen;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `signed`: _string_ – Signed data that must be unsigned.
+<br>Encoded with `base64`.
+- `public`: _string_ – Signer's public key - unprefixed 0-padded to 64 symbols hex string
 
-#### Parameters
 
-* `signed`: _string_ – Signed data that must be unsigned.\
-  Encoded with `base64`.
-* `public`: _string_ – Signer's public key - unprefixed 0-padded to 64 symbols hex string
+### Result
 
-#### Result
+- `unsigned`: _string_ – Unsigned data, encoded in `base64`.
 
-* `unsigned`: _string_ – Unsigned data, encoded in `base64`.
 
-### nacl\_sign\_detached
+## nacl_sign_detached
 
 Signs the message using the secret key and returns a signature.
 
-Signs the message `unsigned` using the secret key `secret` and returns a signature `signature`.
+Signs the message `unsigned` using the secret key `secret`
+and returns a signature `signature`.
 
 ```ts
 type ParamsOfNaclSign = {
@@ -881,19 +870,18 @@ function nacl_sign_detached_sync(
     params: ParamsOfNaclSign,
 ): ResultOfNaclSignDetached;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `unsigned`: _string_ – Data that must be signed encoded in `base64`.
+- `secret`: _string_ – Signer's secret key - unprefixed 0-padded to 128 symbols hex string (concatenation of 64 symbols secret and 64 symbols public keys). See `nacl_sign_keypair_from_secret_key`.
 
-#### Parameters
 
-* `unsigned`: _string_ – Data that must be signed encoded in `base64`.
-* `secret`: _string_ – Signer's secret key - unprefixed 0-padded to 128 symbols hex string (concatenation of 64 symbols secret and 64 symbols public keys). See `nacl_sign_keypair_from_secret_key`.
+### Result
 
-#### Result
+- `signature`: _string_ – Signature encoded in `hex`.
 
-* `signature`: _string_ – Signature encoded in `hex`.
 
-### nacl\_sign\_detached\_verify
+## nacl_sign_detached_verify
 
 Verifies the signature with public key and `unsigned` data.
 
@@ -916,22 +904,21 @@ function nacl_sign_detached_verify_sync(
     params: ParamsOfNaclSignDetachedVerify,
 ): ResultOfNaclSignDetachedVerify;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `unsigned`: _string_ – Unsigned data that must be verified.
+<br>Encoded with `base64`.
+- `signature`: _string_ – Signature that must be verified.
+<br>Encoded with `hex`.
+- `public`: _string_ – Signer's public key - unprefixed 0-padded to 64 symbols hex string.
 
-#### Parameters
 
-* `unsigned`: _string_ – Unsigned data that must be verified.\
-  Encoded with `base64`.
-* `signature`: _string_ – Signature that must be verified.\
-  Encoded with `hex`.
-* `public`: _string_ – Signer's public key - unprefixed 0-padded to 64 symbols hex string.
+### Result
 
-#### Result
+- `succeeded`: _boolean_ – `true` if verification succeeded or `false` if it failed
 
-* `succeeded`: _boolean_ – `true` if verification succeeded or `false` if it failed
 
-### nacl\_box\_keypair
+## nacl_box_keypair
 
 Generates a random NaCl key pair
 
@@ -945,15 +932,16 @@ function nacl_box_keypair(): Promise<KeyPair>;
 
 function nacl_box_keypair_sync(): KeyPair;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
 
-#### Result
 
-* `public`: _string_ – Public key - 64 symbols hex string
-* `secret`: _string_ – Private key - u64 symbols hex string
+### Result
 
-### nacl\_box\_keypair\_from\_secret\_key
+- `public`: _string_ – Public key - 64 symbols hex string
+- `secret`: _string_ – Private key - u64 symbols hex string
+
+
+## nacl_box_keypair_from_secret_key
 
 Generates key pair from a secret key
 
@@ -975,23 +963,23 @@ function nacl_box_keypair_from_secret_key_sync(
     params: ParamsOfNaclBoxKeyPairFromSecret,
 ): KeyPair;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `secret`: _string_ – Secret key - unprefixed 0-padded to 64 symbols hex string
 
-#### Parameters
 
-* `secret`: _string_ – Secret key - unprefixed 0-padded to 64 symbols hex string
+### Result
 
-#### Result
+- `public`: _string_ – Public key - 64 symbols hex string
+- `secret`: _string_ – Private key - u64 symbols hex string
 
-* `public`: _string_ – Public key - 64 symbols hex string
-* `secret`: _string_ – Private key - u64 symbols hex string
 
-### nacl\_box
+## nacl_box
 
 Public key authenticated encryption
 
-Encrypt and authenticate a message using the senders secret key, the receivers public key, and a nonce.
+Encrypt and authenticate a message using the senders secret key, the
+receivers public key, and a nonce.
 
 ```ts
 type ParamsOfNaclBox = {
@@ -1013,21 +1001,20 @@ function nacl_box_sync(
     params: ParamsOfNaclBox,
 ): ResultOfNaclBox;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `decrypted`: _string_ – Data that must be encrypted encoded in `base64`.
+- `nonce`: _string_ – Nonce, encoded in `hex`
+- `their_public`: _string_ – Receiver's public key - unprefixed 0-padded to 64 symbols hex string
+- `secret`: _string_ – Sender's private key - unprefixed 0-padded to 64 symbols hex string
 
-#### Parameters
 
-* `decrypted`: _string_ – Data that must be encrypted encoded in `base64`.
-* `nonce`: _string_ – Nonce, encoded in `hex`
-* `their_public`: _string_ – Receiver's public key - unprefixed 0-padded to 64 symbols hex string
-* `secret`: _string_ – Sender's private key - unprefixed 0-padded to 64 symbols hex string
+### Result
 
-#### Result
+- `encrypted`: _string_ – Encrypted data encoded in `base64`.
 
-* `encrypted`: _string_ – Encrypted data encoded in `base64`.
 
-### nacl\_box\_open
+## nacl_box_open
 
 Decrypt and verify the cipher text using the receivers secret key, the senders public key, and the nonce.
 
@@ -1051,22 +1038,21 @@ function nacl_box_open_sync(
     params: ParamsOfNaclBoxOpen,
 ): ResultOfNaclBoxOpen;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `encrypted`: _string_ – Data that must be decrypted.
+<br>Encoded with `base64`.
+- `nonce`: _string_ – Nonce
+- `their_public`: _string_ – Sender's public key - unprefixed 0-padded to 64 symbols hex string
+- `secret`: _string_ – Receiver's private key - unprefixed 0-padded to 64 symbols hex string
 
-#### Parameters
 
-* `encrypted`: _string_ – Data that must be decrypted.\
-  Encoded with `base64`.
-* `nonce`: _string_ – Nonce
-* `their_public`: _string_ – Sender's public key - unprefixed 0-padded to 64 symbols hex string
-* `secret`: _string_ – Receiver's private key - unprefixed 0-padded to 64 symbols hex string
+### Result
 
-#### Result
+- `decrypted`: _string_ – Decrypted data encoded in `base64`.
 
-* `decrypted`: _string_ – Decrypted data encoded in `base64`.
 
-### nacl\_secret\_box
+## nacl_secret_box
 
 Encrypt and authenticate message using nonce and secret key.
 
@@ -1089,21 +1075,20 @@ function nacl_secret_box_sync(
     params: ParamsOfNaclSecretBox,
 ): ResultOfNaclBox;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `decrypted`: _string_ – Data that must be encrypted.
+<br>Encoded with `base64`.
+- `nonce`: _string_ – Nonce in `hex`
+- `key`: _string_ – Secret key - unprefixed 0-padded to 64 symbols hex string
 
-#### Parameters
 
-* `decrypted`: _string_ – Data that must be encrypted.\
-  Encoded with `base64`.
-* `nonce`: _string_ – Nonce in `hex`
-* `key`: _string_ – Secret key - unprefixed 0-padded to 64 symbols hex string
+### Result
 
-#### Result
+- `encrypted`: _string_ – Encrypted data encoded in `base64`.
 
-* `encrypted`: _string_ – Encrypted data encoded in `base64`.
 
-### nacl\_secret\_box\_open
+## nacl_secret_box_open
 
 Decrypts and verifies cipher text using `nonce` and secret `key`.
 
@@ -1126,21 +1111,20 @@ function nacl_secret_box_open_sync(
     params: ParamsOfNaclSecretBoxOpen,
 ): ResultOfNaclBoxOpen;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `encrypted`: _string_ – Data that must be decrypted.
+<br>Encoded with `base64`.
+- `nonce`: _string_ – Nonce in `hex`
+- `key`: _string_ – Secret key - unprefixed 0-padded to 64 symbols hex string
 
-#### Parameters
 
-* `encrypted`: _string_ – Data that must be decrypted.\
-  Encoded with `base64`.
-* `nonce`: _string_ – Nonce in `hex`
-* `key`: _string_ – Secret key - unprefixed 0-padded to 64 symbols hex string
+### Result
 
-#### Result
+- `decrypted`: _string_ – Decrypted data encoded in `base64`.
 
-* `decrypted`: _string_ – Decrypted data encoded in `base64`.
 
-### mnemonic\_words
+## mnemonic_words
 
 Prints the list of words from the specified dictionary
 
@@ -1161,18 +1145,17 @@ function mnemonic_words_sync(
     params: ParamsOfMnemonicWords,
 ): ResultOfMnemonicWords;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `dictionary`?: _[MnemonicDictionary](mod\_crypto.md#mnemonicdictionary)_ – Dictionary identifier
 
-#### Parameters
 
-* `dictionary`?: [_MnemonicDictionary_](mod_crypto.md#mnemonicdictionary) – Dictionary identifier
+### Result
 
-#### Result
+- `words`: _string_ – The list of mnemonic words
 
-* `words`: _string_ – The list of mnemonic words
 
-### mnemonic\_from\_random
+## mnemonic_from_random
 
 Generates a random mnemonic
 
@@ -1196,19 +1179,18 @@ function mnemonic_from_random_sync(
     params: ParamsOfMnemonicFromRandom,
 ): ResultOfMnemonicFromRandom;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `dictionary`?: _[MnemonicDictionary](mod\_crypto.md#mnemonicdictionary)_ – Dictionary identifier
+- `word_count`?: _number_ – Mnemonic word count
 
-#### Parameters
 
-* `dictionary`?: [_MnemonicDictionary_](mod_crypto.md#mnemonicdictionary) – Dictionary identifier
-* `word_count`?: _number_ – Mnemonic word count
+### Result
 
-#### Result
+- `phrase`: _string_ – String of mnemonic words
 
-* `phrase`: _string_ – String of mnemonic words
 
-### mnemonic\_from\_entropy
+## mnemonic_from_entropy
 
 Generates mnemonic from pre-generated entropy
 
@@ -1231,25 +1213,25 @@ function mnemonic_from_entropy_sync(
     params: ParamsOfMnemonicFromEntropy,
 ): ResultOfMnemonicFromEntropy;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `entropy`: _string_ – Entropy bytes.
+<br>Hex encoded.
+- `dictionary`?: _[MnemonicDictionary](mod\_crypto.md#mnemonicdictionary)_ – Dictionary identifier
+- `word_count`?: _number_ – Mnemonic word count
 
-#### Parameters
 
-* `entropy`: _string_ – Entropy bytes.\
-  Hex encoded.
-* `dictionary`?: [_MnemonicDictionary_](mod_crypto.md#mnemonicdictionary) – Dictionary identifier
-* `word_count`?: _number_ – Mnemonic word count
+### Result
 
-#### Result
+- `phrase`: _string_ – Phrase
 
-* `phrase`: _string_ – Phrase
 
-### mnemonic\_verify
+## mnemonic_verify
 
 Validates a mnemonic phrase
 
-The phrase supplied will be checked for word length and validated according to the checksum specified in BIP0039.
+The phrase supplied will be checked for word length and validated according
+to the checksum specified in BIP0039.
 
 ```ts
 type ParamsOfMnemonicVerify = {
@@ -1270,24 +1252,24 @@ function mnemonic_verify_sync(
     params: ParamsOfMnemonicVerify,
 ): ResultOfMnemonicVerify;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `phrase`: _string_ – Phrase
+- `dictionary`?: _[MnemonicDictionary](mod\_crypto.md#mnemonicdictionary)_ – Dictionary identifier
+- `word_count`?: _number_ – Word count
 
-#### Parameters
 
-* `phrase`: _string_ – Phrase
-* `dictionary`?: [_MnemonicDictionary_](mod_crypto.md#mnemonicdictionary) – Dictionary identifier
-* `word_count`?: _number_ – Word count
+### Result
 
-#### Result
+- `valid`: _boolean_ – Flag indicating if the mnemonic is valid or not
 
-* `valid`: _boolean_ – Flag indicating if the mnemonic is valid or not
 
-### mnemonic\_derive\_sign\_keys
+## mnemonic_derive_sign_keys
 
 Derives a key pair for signing from the seed phrase
 
-Validates the seed phrase, generates master key and then derives the key pair from the master key and the specified path
+Validates the seed phrase, generates master key and then derives
+the key pair from the master key and the specified path
 
 ```ts
 type ParamsOfMnemonicDeriveSignKeys = {
@@ -1310,22 +1292,21 @@ function mnemonic_derive_sign_keys_sync(
     params: ParamsOfMnemonicDeriveSignKeys,
 ): KeyPair;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `phrase`: _string_ – Phrase
+- `path`?: _string_ – Derivation path, for instance "m/44'/1331'/0'/0/0"
+- `dictionary`?: _[MnemonicDictionary](mod\_crypto.md#mnemonicdictionary)_ – Dictionary identifier
+- `word_count`?: _number_ – Word count
 
-#### Parameters
 
-* `phrase`: _string_ – Phrase
-* `path`?: _string_ – Derivation path, for instance "m/44'/396'/0'/0/0"
-* `dictionary`?: [_MnemonicDictionary_](mod_crypto.md#mnemonicdictionary) – Dictionary identifier
-* `word_count`?: _number_ – Word count
+### Result
 
-#### Result
+- `public`: _string_ – Public key - 64 symbols hex string
+- `secret`: _string_ – Private key - u64 symbols hex string
 
-* `public`: _string_ – Public key - 64 symbols hex string
-* `secret`: _string_ – Private key - u64 symbols hex string
 
-### hdkey\_xprv\_from\_mnemonic
+## hdkey_xprv_from_mnemonic
 
 Generates an extended master private key that will be the root for all the derived keys
 
@@ -1348,20 +1329,19 @@ function hdkey_xprv_from_mnemonic_sync(
     params: ParamsOfHDKeyXPrvFromMnemonic,
 ): ResultOfHDKeyXPrvFromMnemonic;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `phrase`: _string_ – String with seed phrase
+- `dictionary`?: _[MnemonicDictionary](mod\_crypto.md#mnemonicdictionary)_ – Dictionary identifier
+- `word_count`?: _number_ – Mnemonic word count
 
-#### Parameters
 
-* `phrase`: _string_ – String with seed phrase
-* `dictionary`?: [_MnemonicDictionary_](mod_crypto.md#mnemonicdictionary) – Dictionary identifier
-* `word_count`?: _number_ – Mnemonic word count
+### Result
 
-#### Result
+- `xprv`: _string_ – Serialized extended master private key
 
-* `xprv`: _string_ – Serialized extended master private key
 
-### hdkey\_derive\_from\_xprv
+## hdkey_derive_from_xprv
 
 Returns extended private key derived from the specified extended private key and child index
 
@@ -1384,20 +1364,19 @@ function hdkey_derive_from_xprv_sync(
     params: ParamsOfHDKeyDeriveFromXPrv,
 ): ResultOfHDKeyDeriveFromXPrv;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `xprv`: _string_ – Serialized extended private key
+- `child_index`: _number_ – Child index (see BIP-0032)
+- `hardened`: _boolean_ – Indicates the derivation of hardened/not-hardened key (see BIP-0032)
 
-#### Parameters
 
-* `xprv`: _string_ – Serialized extended private key
-* `child_index`: _number_ – Child index (see BIP-0032)
-* `hardened`: _boolean_ – Indicates the derivation of hardened/not-hardened key (see BIP-0032)
+### Result
 
-#### Result
+- `xprv`: _string_ – Serialized extended private key
 
-* `xprv`: _string_ – Serialized extended private key
 
-### hdkey\_derive\_from\_xprv\_path
+## hdkey_derive_from_xprv_path
 
 Derives the extended private key from the specified key and path
 
@@ -1419,19 +1398,18 @@ function hdkey_derive_from_xprv_path_sync(
     params: ParamsOfHDKeyDeriveFromXPrvPath,
 ): ResultOfHDKeyDeriveFromXPrvPath;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `xprv`: _string_ – Serialized extended private key
+- `path`: _string_ – Derivation path, for instance "m/44'/1331'/0'/0/0"
 
-#### Parameters
 
-* `xprv`: _string_ – Serialized extended private key
-* `path`: _string_ – Derivation path, for instance "m/44'/396'/0'/0/0"
+### Result
 
-#### Result
+- `xprv`: _string_ – Derived serialized extended private key
 
-* `xprv`: _string_ – Derived serialized extended private key
 
-### hdkey\_secret\_from\_xprv
+## hdkey_secret_from_xprv
 
 Extracts the private key from the serialized extended private key
 
@@ -1452,18 +1430,17 @@ function hdkey_secret_from_xprv_sync(
     params: ParamsOfHDKeySecretFromXPrv,
 ): ResultOfHDKeySecretFromXPrv;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `xprv`: _string_ – Serialized extended private key
 
-#### Parameters
 
-* `xprv`: _string_ – Serialized extended private key
+### Result
 
-#### Result
+- `secret`: _string_ – Private key - 64 symbols hex string
 
-* `secret`: _string_ – Private key - 64 symbols hex string
 
-### hdkey\_public\_from\_xprv
+## hdkey_public_from_xprv
 
 Extracts the public key from the serialized extended private key
 
@@ -1484,18 +1461,17 @@ function hdkey_public_from_xprv_sync(
     params: ParamsOfHDKeyPublicFromXPrv,
 ): ResultOfHDKeyPublicFromXPrv;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `xprv`: _string_ – Serialized extended private key
 
-#### Parameters
 
-* `xprv`: _string_ – Serialized extended private key
+### Result
 
-#### Result
+- `public`: _string_ – Public key - 64 symbols hex string
 
-* `public`: _string_ – Public key - 64 symbols hex string
 
-### chacha20
+## chacha20
 
 Performs symmetric `chacha20` encryption.
 
@@ -1518,32 +1494,37 @@ function chacha20_sync(
     params: ParamsOfChaCha20,
 ): ResultOfChaCha20;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `data`: _string_ – Source data to be encrypted or decrypted.
+<br>Must be encoded with `base64`.
+- `key`: _string_ – 256-bit key.
+<br>Must be encoded with `hex`.
+- `nonce`: _string_ – 96-bit nonce.
+<br>Must be encoded with `hex`.
 
-#### Parameters
 
-* `data`: _string_ – Source data to be encrypted or decrypted.\
-  Must be encoded with `base64`.
-* `key`: _string_ – 256-bit key.\
-  Must be encoded with `hex`.
-* `nonce`: _string_ – 96-bit nonce.\
-  Must be encoded with `hex`.
+### Result
 
-#### Result
+- `data`: _string_ – Encrypted/decrypted data.
+<br>Encoded with `base64`.
 
-* `data`: _string_ – Encrypted/decrypted data.\
-  Encoded with `base64`.
 
-### create\_crypto\_box
+## create_crypto_box
 
 Creates a Crypto Box instance.
 
-Crypto Box is a root crypto object, that encapsulates some secret (seed phrase usually) in encrypted form and acts as a factory for all crypto primitives used in SDK: keys for signing and encryption, derived from this secret.
+Crypto Box is a root crypto object, that encapsulates some secret (seed
+phrase usually) in encrypted form and acts as a factory for all crypto
+primitives used in SDK: keys for signing and encryption, derived from this
+secret.
 
-Crypto Box encrypts original Seed Phrase with salt and password that is retrieved from `password_provider` callback, implemented on Application side.
+Crypto Box encrypts original Seed Phrase with salt and password that is
+retrieved from `password_provider` callback, implemented on Application
+side.
 
-When used, decrypted secret shows up in core library's memory for a very short period of time and then is immediately overwritten with zeroes.
+When used, decrypted secret shows up in core library's memory for a very
+short period of time and then is immediately overwritten with zeroes.
 
 ```ts
 type ParamsOfCreateCryptoBox = {
@@ -1564,20 +1545,20 @@ function create_crypto_box_sync(
     params: ParamsOfCreateCryptoBox,
 ): RegisteredCryptoBox;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `secret_encryption_salt`: _string_ – Salt used for secret encryption. For example, a mobile device can use device ID as salt.
+- `secret`: _[CryptoBoxSecret](mod\_crypto.md#cryptoboxsecret)_ – Cryptobox secret
+- `obj`: [AppPasswordProvider](mod\_AppPasswordProvider.md#apppasswordprovider) – Interface that provides a callback that returns an encrypted password, used for cryptobox secret encryption
 
-#### Parameters
 
-* `secret_encryption_salt`: _string_ – Salt used for secret encryption. For example, a mobile device can use device ID as salt.
-* `secret`: [_CryptoBoxSecret_](mod_crypto.md#cryptoboxsecret) – Cryptobox secret
-* `obj`: [AppPasswordProvider](../../reference/types-and-methods/mod_AppPasswordProvider.md#apppasswordprovider) – Interface that provides a callback that returns an encrypted password, used for cryptobox secret encryption
 
-#### Result
+### Result
 
-* `handle`: [_CryptoBoxHandle_](mod_crypto.md#cryptoboxhandle)
+- `handle`: _[CryptoBoxHandle](mod\_crypto.md#cryptoboxhandle)_
 
-### remove\_crypto\_box
+
+## remove_crypto_box
 
 Removes Crypto Box. Clears all secret data.
 
@@ -1594,14 +1575,12 @@ function remove_crypto_box_sync(
     params: RegisteredCryptoBox,
 ): void;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `handle`: _[CryptoBoxHandle](mod\_crypto.md#cryptoboxhandle)_
 
-#### Parameters
 
-* `handle`: [_CryptoBoxHandle_](mod_crypto.md#cryptoboxhandle)
-
-### get\_crypto\_box\_info
+## get_crypto_box_info
 
 Get Crypto Box Info. Used to get `encrypted_secret` that should be used for all the cryptobox initializations except the first one.
 
@@ -1622,22 +1601,22 @@ function get_crypto_box_info_sync(
     params: RegisteredCryptoBox,
 ): ResultOfGetCryptoBoxInfo;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `handle`: _[CryptoBoxHandle](mod\_crypto.md#cryptoboxhandle)_
 
-#### Parameters
 
-* `handle`: [_CryptoBoxHandle_](mod_crypto.md#cryptoboxhandle)
+### Result
 
-#### Result
+- `encrypted_secret`: _string_ – Secret (seed phrase) encrypted with salt and password.
 
-* `encrypted_secret`: _string_ – Secret (seed phrase) encrypted with salt and password.
 
-### get\_crypto\_box\_seed\_phrase
+## get_crypto_box_seed_phrase
 
 Get Crypto Box Seed Phrase.
 
-Attention! Store this data in your application for a very short period of time and overwrite it with zeroes ASAP.
+Attention! Store this data in your application for a very short period of
+time and overwrite it with zeroes ASAP.
 
 ```ts
 type RegisteredCryptoBox = {
@@ -1658,20 +1637,19 @@ function get_crypto_box_seed_phrase_sync(
     params: RegisteredCryptoBox,
 ): ResultOfGetCryptoBoxSeedPhrase;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `handle`: _[CryptoBoxHandle](mod\_crypto.md#cryptoboxhandle)_
 
-#### Parameters
 
-* `handle`: [_CryptoBoxHandle_](mod_crypto.md#cryptoboxhandle)
+### Result
 
-#### Result
+- `phrase`: _string_
+- `dictionary`: _[MnemonicDictionary](mod\_crypto.md#mnemonicdictionary)_
+- `wordcount`: _number_
 
-* `phrase`: _string_
-* `dictionary`: [_MnemonicDictionary_](mod_crypto.md#mnemonicdictionary)
-* `wordcount`: _number_
 
-### get\_signing\_box\_from\_crypto\_box
+## get_signing_box_from_crypto_box
 
 Get handle of Signing Box derived from Crypto Box.
 
@@ -1694,25 +1672,28 @@ function get_signing_box_from_crypto_box_sync(
     params: ParamsOfGetSigningBoxFromCryptoBox,
 ): RegisteredSigningBox;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `handle`: _number_ – Crypto Box Handle.
+- `hdpath`?: _string_ – HD key derivation path.
+<br>By default, Acki Nacki HD path is used.
+- `secret_lifetime`?: _number_ – Store derived secret for this lifetime (in ms). The timer starts after each signing box operation. Secrets will be deleted immediately after each signing box operation, if this value is not set.
 
-#### Parameters
 
-* `handle`: _number_ – Crypto Box Handle.
-* `hdpath`?: _string_ – HD key derivation path.\
-  By default, Acki Nacki HD path is used.
-* `secret_lifetime`?: _number_ – Store derived secret for this lifetime (in ms). The timer starts after each signing box operation. Secrets will be deleted immediately after each signing box operation, if this value is not set.
+### Result
 
-#### Result
+- `handle`: _[SigningBoxHandle](mod\_crypto.md#signingboxhandle)_ – Handle of the signing box.
 
-* `handle`: [_SigningBoxHandle_](mod_crypto.md#signingboxhandle) – Handle of the signing box.
 
-### get\_encryption\_box\_from\_crypto\_box
+## get_encryption_box_from_crypto_box
 
 Gets Encryption Box from Crypto Box.
 
-Derives encryption keypair from cryptobox secret and hdpath and stores it in cache for `secret_lifetime` or until explicitly cleared by `clear_crypto_box_secret_cache` method. If `secret_lifetime` is not specified - overwrites encryption secret with zeroes immediately after encryption operation.
+Derives encryption keypair from cryptobox secret and hdpath and
+stores it in cache for `secret_lifetime`
+or until explicitly cleared by `clear_crypto_box_secret_cache` method.
+If `secret_lifetime` is not specified - overwrites encryption secret with
+zeroes immediately after encryption operation.
 
 ```ts
 type ParamsOfGetEncryptionBoxFromCryptoBox = {
@@ -1734,22 +1715,21 @@ function get_encryption_box_from_crypto_box_sync(
     params: ParamsOfGetEncryptionBoxFromCryptoBox,
 ): RegisteredEncryptionBox;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `handle`: _number_ – Crypto Box Handle.
+- `hdpath`?: _string_ – HD key derivation path.
+<br>By default, Acki Nacki HD path is used.
+- `algorithm`: _[BoxEncryptionAlgorithm](mod\_crypto.md#boxencryptionalgorithm)_ – Encryption algorithm.
+- `secret_lifetime`?: _number_ – Store derived secret for encryption algorithm for this lifetime (in ms). The timer starts after each encryption box operation. Secrets will be deleted (overwritten with zeroes) after each encryption operation, if this value is not set.
 
-#### Parameters
 
-* `handle`: _number_ – Crypto Box Handle.
-* `hdpath`?: _string_ – HD key derivation path.\
-  By default, Acki Nacki HD path is used.
-* `algorithm`: [_BoxEncryptionAlgorithm_](mod_crypto.md#boxencryptionalgorithm) – Encryption algorithm.
-* `secret_lifetime`?: _number_ – Store derived secret for encryption algorithm for this lifetime (in ms). The timer starts after each encryption box operation. Secrets will be deleted (overwritten with zeroes) after each encryption operation, if this value is not set.
+### Result
 
-#### Result
+- `handle`: _[EncryptionBoxHandle](mod\_crypto.md#encryptionboxhandle)_ – Handle of the encryption box.
 
-* `handle`: [_EncryptionBoxHandle_](mod_crypto.md#encryptionboxhandle) – Handle of the encryption box.
 
-### clear\_crypto\_box\_secret\_cache
+## clear_crypto_box_secret_cache
 
 Removes cached secrets (overwrites with zeroes) from all signing and encryption boxes, derived from crypto box.
 
@@ -1766,14 +1746,12 @@ function clear_crypto_box_secret_cache_sync(
     params: RegisteredCryptoBox,
 ): void;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `handle`: _[CryptoBoxHandle](mod\_crypto.md#cryptoboxhandle)_
 
-#### Parameters
 
-* `handle`: [_CryptoBoxHandle_](mod_crypto.md#cryptoboxhandle)
-
-### register\_signing\_box
+## register_signing_box
 
 Register an application implemented signing box.
 
@@ -1788,18 +1766,18 @@ function register_signing_box(
 
 function register_signing_box_sync(): RegisteredSigningBox;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `obj`: [AppSigningBox](mod\_AppSigningBox.md#appsigningbox) – Signing box callbacks.
 
-#### Parameters
 
-* `obj`: [AppSigningBox](../../reference/types-and-methods/mod_AppSigningBox.md#appsigningbox) – Signing box callbacks.
 
-#### Result
+### Result
 
-* `handle`: [_SigningBoxHandle_](mod_crypto.md#signingboxhandle) – Handle of the signing box.
+- `handle`: _[SigningBoxHandle](mod\_crypto.md#signingboxhandle)_ – Handle of the signing box.
 
-### get\_signing\_box
+
+## get_signing_box
 
 Creates a default signing box implementation.
 
@@ -1821,19 +1799,18 @@ function get_signing_box_sync(
     params: KeyPair,
 ): RegisteredSigningBox;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `public`: _string_ – Public key - 64 symbols hex string
+- `secret`: _string_ – Private key - u64 symbols hex string
 
-#### Parameters
 
-* `public`: _string_ – Public key - 64 symbols hex string
-* `secret`: _string_ – Private key - u64 symbols hex string
+### Result
 
-#### Result
+- `handle`: _[SigningBoxHandle](mod\_crypto.md#signingboxhandle)_ – Handle of the signing box.
 
-* `handle`: [_SigningBoxHandle_](mod_crypto.md#signingboxhandle) – Handle of the signing box.
 
-### signing\_box\_get\_public\_key
+## signing_box_get_public_key
 
 Returns public key of signing key pair.
 
@@ -1854,19 +1831,18 @@ function signing_box_get_public_key_sync(
     params: RegisteredSigningBox,
 ): ResultOfSigningBoxGetPublicKey;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `handle`: _[SigningBoxHandle](mod\_crypto.md#signingboxhandle)_ – Handle of the signing box.
 
-#### Parameters
 
-* `handle`: [_SigningBoxHandle_](mod_crypto.md#signingboxhandle) – Handle of the signing box.
+### Result
 
-#### Result
+- `pubkey`: _string_ – Public key of signing box.
+<br>Encoded with hex
 
-* `pubkey`: _string_ – Public key of signing box.\
-  Encoded with hex
 
-### signing\_box\_sign
+## signing_box_sign
 
 Returns signed user data.
 
@@ -1888,21 +1864,20 @@ function signing_box_sign_sync(
     params: ParamsOfSigningBoxSign,
 ): ResultOfSigningBoxSign;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `signing_box`: _[SigningBoxHandle](mod\_crypto.md#signingboxhandle)_ – Signing Box handle.
+- `unsigned`: _string_ – Unsigned user data.
+<br>Must be encoded with `base64`.
 
-#### Parameters
 
-* `signing_box`: [_SigningBoxHandle_](mod_crypto.md#signingboxhandle) – Signing Box handle.
-* `unsigned`: _string_ – Unsigned user data.\
-  Must be encoded with `base64`.
+### Result
 
-#### Result
+- `signature`: _string_ – Data signature.
+<br>Encoded with `hex`.
 
-* `signature`: _string_ – Data signature.\
-  Encoded with `hex`.
 
-### remove\_signing\_box
+## remove_signing_box
 
 Removes signing box from SDK.
 
@@ -1919,14 +1894,12 @@ function remove_signing_box_sync(
     params: RegisteredSigningBox,
 ): void;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `handle`: _[SigningBoxHandle](mod\_crypto.md#signingboxhandle)_ – Handle of the signing box.
 
-#### Parameters
 
-* `handle`: [_SigningBoxHandle_](mod_crypto.md#signingboxhandle) – Handle of the signing box.
-
-### register\_encryption\_box
+## register_encryption_box
 
 Register an application implemented encryption box.
 
@@ -1941,18 +1914,18 @@ function register_encryption_box(
 
 function register_encryption_box_sync(): RegisteredEncryptionBox;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `obj`: [AppEncryptionBox](mod\_AppEncryptionBox.md#appencryptionbox) – Interface for data encryption/decryption
 
-#### Parameters
 
-* `obj`: [AppEncryptionBox](../../reference/types-and-methods/mod_AppEncryptionBox.md#appencryptionbox) – Interface for data encryption/decryption
 
-#### Result
+### Result
 
-* `handle`: [_EncryptionBoxHandle_](mod_crypto.md#encryptionboxhandle) – Handle of the encryption box.
+- `handle`: _[EncryptionBoxHandle](mod\_crypto.md#encryptionboxhandle)_ – Handle of the encryption box.
 
-### remove\_encryption\_box
+
+## remove_encryption_box
 
 Removes encryption box from SDK
 
@@ -1969,14 +1942,12 @@ function remove_encryption_box_sync(
     params: RegisteredEncryptionBox,
 ): void;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `handle`: _[EncryptionBoxHandle](mod\_crypto.md#encryptionboxhandle)_ – Handle of the encryption box.
 
-#### Parameters
 
-* `handle`: [_EncryptionBoxHandle_](mod_crypto.md#encryptionboxhandle) – Handle of the encryption box.
-
-### encryption\_box\_get\_info
+## encryption_box_get_info
 
 Queries info from the given encryption box
 
@@ -1997,22 +1968,23 @@ function encryption_box_get_info_sync(
     params: ParamsOfEncryptionBoxGetInfo,
 ): ResultOfEncryptionBoxGetInfo;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `encryption_box`: _[EncryptionBoxHandle](mod\_crypto.md#encryptionboxhandle)_ – Encryption box handle
 
-#### Parameters
 
-* `encryption_box`: [_EncryptionBoxHandle_](mod_crypto.md#encryptionboxhandle) – Encryption box handle
+### Result
 
-#### Result
+- `info`: _[EncryptionBoxInfo](mod\_crypto.md#encryptionboxinfo)_ – Encryption box information
 
-* `info`: [_EncryptionBoxInfo_](mod_crypto.md#encryptionboxinfo) – Encryption box information
 
-### encryption\_box\_encrypt
+## encryption_box_encrypt
 
 Encrypts data using given encryption box Note.
 
-Block cipher algorithms pad data to cipher block size so encrypted data can be longer then original data. Client should store the original data size after encryption and use it after decryption to retrieve the original data from decrypted data.
+Block cipher algorithms pad data to cipher block size so encrypted data can be longer then original data. Client should store the original data
+size after encryption and use it after decryption to retrieve the original
+data from decrypted data.
 
 ```ts
 type ParamsOfEncryptionBoxEncrypt = {
@@ -2032,24 +2004,25 @@ function encryption_box_encrypt_sync(
     params: ParamsOfEncryptionBoxEncrypt,
 ): ResultOfEncryptionBoxEncrypt;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `encryption_box`: _[EncryptionBoxHandle](mod\_crypto.md#encryptionboxhandle)_ – Encryption box handle
+- `data`: _string_ – Data to be encrypted, encoded in Base64
 
-#### Parameters
 
-* `encryption_box`: [_EncryptionBoxHandle_](mod_crypto.md#encryptionboxhandle) – Encryption box handle
-* `data`: _string_ – Data to be encrypted, encoded in Base64
+### Result
 
-#### Result
+- `data`: _string_ – Encrypted data, encoded in Base64.
+<br>Padded to cipher block size
 
-* `data`: _string_ – Encrypted data, encoded in Base64.\
-  Padded to cipher block size
 
-### encryption\_box\_decrypt
+## encryption_box_decrypt
 
 Decrypts data using given encryption box Note.
 
-Block cipher algorithms pad data to cipher block size so encrypted data can be longer then original data. Client should store the original data size after encryption and use it after decryption to retrieve the original data from decrypted data.
+Block cipher algorithms pad data to cipher block size so encrypted data can be longer then original data. Client should store the original data
+size after encryption and use it after decryption to retrieve the original
+data from decrypted data.
 
 ```ts
 type ParamsOfEncryptionBoxDecrypt = {
@@ -2069,19 +2042,18 @@ function encryption_box_decrypt_sync(
     params: ParamsOfEncryptionBoxDecrypt,
 ): ResultOfEncryptionBoxDecrypt;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `encryption_box`: _[EncryptionBoxHandle](mod\_crypto.md#encryptionboxhandle)_ – Encryption box handle
+- `data`: _string_ – Data to be decrypted, encoded in Base64
 
-#### Parameters
 
-* `encryption_box`: [_EncryptionBoxHandle_](mod_crypto.md#encryptionboxhandle) – Encryption box handle
-* `data`: _string_ – Data to be decrypted, encoded in Base64
+### Result
 
-#### Result
+- `data`: _string_ – Decrypted data, encoded in Base64.
 
-* `data`: _string_ – Decrypted data, encoded in Base64.
 
-### create\_encryption\_box
+## create_encryption_box
 
 Creates encryption box with specified algorithm
 
@@ -2102,21 +2074,18 @@ function create_encryption_box_sync(
     params: ParamsOfCreateEncryptionBox,
 ): RegisteredEncryptionBox;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `algorithm`: _[EncryptionAlgorithm](mod\_crypto.md#encryptionalgorithm)_ – Encryption algorithm specifier including cipher parameters (key, IV, etc)
 
-#### Parameters
 
-* `algorithm`: [_EncryptionAlgorithm_](mod_crypto.md#encryptionalgorithm) – Encryption algorithm specifier including cipher parameters (key, IV, etc)
+### Result
 
-#### Result
+- `handle`: _[EncryptionBoxHandle](mod\_crypto.md#encryptionboxhandle)_ – Handle of the encryption box.
 
-* `handle`: [_EncryptionBoxHandle_](mod_crypto.md#encryptionboxhandle) – Handle of the encryption box.
 
-## Types
-
-### CryptoErrorCode
-
+# Types
+## CryptoErrorCode
 ```ts
 enum CryptoErrorCode {
     InvalidPublicKey = 100,
@@ -2153,56 +2122,55 @@ enum CryptoErrorCode {
     InvalidNonceSize = 134
 }
 ```
-
 One of the following value:
 
-* `InvalidPublicKey = 100`
-* `InvalidSecretKey = 101`
-* `InvalidKey = 102`
-* `InvalidFactorizeChallenge = 106`
-* `InvalidBigInt = 107`
-* `ScryptFailed = 108`
-* `InvalidKeySize = 109`
-* `NaclSecretBoxFailed = 110`
-* `NaclBoxFailed = 111`
-* `NaclSignFailed = 112`
-* `Bip39InvalidEntropy = 113`
-* `Bip39InvalidPhrase = 114`
-* `Bip32InvalidKey = 115`
-* `Bip32InvalidDerivePath = 116`
-* `Bip39InvalidDictionary = 117`
-* `Bip39InvalidWordCount = 118`
-* `MnemonicGenerationFailed = 119`
-* `MnemonicFromEntropyFailed = 120`
-* `SigningBoxNotRegistered = 121`
-* `InvalidSignature = 122`
-* `EncryptionBoxNotRegistered = 123`
-* `InvalidIvSize = 124`
-* `UnsupportedCipherMode = 125`
-* `CannotCreateCipher = 126`
-* `EncryptDataError = 127`
-* `DecryptDataError = 128`
-* `IvRequired = 129`
-* `CryptoBoxNotRegistered = 130`
-* `InvalidCryptoBoxType = 131`
-* `CryptoBoxSecretSerializationError = 132`
-* `CryptoBoxSecretDeserializationError = 133`
-* `InvalidNonceSize = 134`
+- `InvalidPublicKey = 100`
+- `InvalidSecretKey = 101`
+- `InvalidKey = 102`
+- `InvalidFactorizeChallenge = 106`
+- `InvalidBigInt = 107`
+- `ScryptFailed = 108`
+- `InvalidKeySize = 109`
+- `NaclSecretBoxFailed = 110`
+- `NaclBoxFailed = 111`
+- `NaclSignFailed = 112`
+- `Bip39InvalidEntropy = 113`
+- `Bip39InvalidPhrase = 114`
+- `Bip32InvalidKey = 115`
+- `Bip32InvalidDerivePath = 116`
+- `Bip39InvalidDictionary = 117`
+- `Bip39InvalidWordCount = 118`
+- `MnemonicGenerationFailed = 119`
+- `MnemonicFromEntropyFailed = 120`
+- `SigningBoxNotRegistered = 121`
+- `InvalidSignature = 122`
+- `EncryptionBoxNotRegistered = 123`
+- `InvalidIvSize = 124`
+- `UnsupportedCipherMode = 125`
+- `CannotCreateCipher = 126`
+- `EncryptDataError = 127`
+- `DecryptDataError = 128`
+- `IvRequired = 129`
+- `CryptoBoxNotRegistered = 130`
+- `InvalidCryptoBoxType = 131`
+- `CryptoBoxSecretSerializationError = 132`
+- `CryptoBoxSecretDeserializationError = 133`
+- `InvalidNonceSize = 134`
 
-### SigningBoxHandle
 
+## SigningBoxHandle
 ```ts
 type SigningBoxHandle = number
 ```
 
-### EncryptionBoxHandle
 
+## EncryptionBoxHandle
 ```ts
 type EncryptionBoxHandle = number
 ```
 
-### EncryptionBoxInfo
 
+## EncryptionBoxInfo
 Encryption box information.
 
 ```ts
@@ -2213,54 +2181,49 @@ type EncryptionBoxInfo = {
     public?: any
 }
 ```
+- `hdpath`?: _string_ – Derivation path, for instance "m/44'/1331'/0'/0/0"
+- `algorithm`?: _string_ – Cryptographic algorithm, used by this encryption box
+- `options`?: _any_ – Options, depends on algorithm and specific encryption box implementation
+- `public`?: _any_ – Public information, depends on algorithm
 
-* `hdpath`?: _string_ – Derivation path, for instance "m/44'/396'/0'/0/0"
-* `algorithm`?: _string_ – Cryptographic algorithm, used by this encryption box
-* `options`?: _any_ – Options, depends on algorithm and specific encryption box implementation
-* `public`?: _any_ – Public information, depends on algorithm
 
-### EncryptionAlgorithmAESVariant
-
+## EncryptionAlgorithmAESVariant
 ```ts
 type EncryptionAlgorithmAESVariant = {
     value: AesParamsEB
 }
 ```
+- `value`: _[AesParamsEB](mod\_crypto.md#aesparamseb)_
 
-* `value`: [_AesParamsEB_](mod_crypto.md#aesparamseb)
 
-### EncryptionAlgorithmChaCha20Variant
-
+## EncryptionAlgorithmChaCha20Variant
 ```ts
 type EncryptionAlgorithmChaCha20Variant = {
     value: ChaCha20ParamsEB
 }
 ```
+- `value`: _[ChaCha20ParamsEB](mod\_crypto.md#chacha20paramseb)_
 
-* `value`: [_ChaCha20ParamsEB_](mod_crypto.md#chacha20paramseb)
 
-### EncryptionAlgorithmNaclBoxVariant
-
+## EncryptionAlgorithmNaclBoxVariant
 ```ts
 type EncryptionAlgorithmNaclBoxVariant = {
     value: NaclBoxParamsEB
 }
 ```
+- `value`: _[NaclBoxParamsEB](mod\_crypto.md#naclboxparamseb)_
 
-* `value`: [_NaclBoxParamsEB_](mod_crypto.md#naclboxparamseb)
 
-### EncryptionAlgorithmNaclSecretBoxVariant
-
+## EncryptionAlgorithmNaclSecretBoxVariant
 ```ts
 type EncryptionAlgorithmNaclSecretBoxVariant = {
     value: NaclSecretBoxParamsEB
 }
 ```
+- `value`: _[NaclSecretBoxParamsEB](mod\_crypto.md#naclsecretboxparamseb)_
 
-* `value`: [_NaclSecretBoxParamsEB_](mod_crypto.md#naclsecretboxparamseb)
 
-### EncryptionAlgorithm
-
+## EncryptionAlgorithm
 ```ts
 type EncryptionAlgorithm = ({
     type: 'AES'
@@ -2272,24 +2235,24 @@ type EncryptionAlgorithm = ({
     type: 'NaclSecretBox'
 } & EncryptionAlgorithmNaclSecretBoxVariant)
 ```
-
-Depends on value of the `type` field.
+Depends on value of the  `type` field.
 
 When _type_ is _'AES'_
 
-* `value`: [_AesParamsEB_](mod_crypto.md#aesparamseb)
+- `value`: _[AesParamsEB](mod\_crypto.md#aesparamseb)_
 
 When _type_ is _'ChaCha20'_
 
-* `value`: [_ChaCha20ParamsEB_](mod_crypto.md#chacha20paramseb)
+- `value`: _[ChaCha20ParamsEB](mod\_crypto.md#chacha20paramseb)_
 
 When _type_ is _'NaclBox'_
 
-* `value`: [_NaclBoxParamsEB_](mod_crypto.md#naclboxparamseb)
+- `value`: _[NaclBoxParamsEB](mod\_crypto.md#naclboxparamseb)_
 
 When _type_ is _'NaclSecretBox'_
 
-* `value`: [_NaclSecretBoxParamsEB_](mod_crypto.md#naclsecretboxparamseb)
+- `value`: _[NaclSecretBoxParamsEB](mod\_crypto.md#naclsecretboxparamseb)_
+
 
 Variant constructors:
 
@@ -2300,8 +2263,7 @@ function encryptionAlgorithmNaclBox(value: NaclBoxParamsEB): EncryptionAlgorithm
 function encryptionAlgorithmNaclSecretBox(value: NaclSecretBoxParamsEB): EncryptionAlgorithm;
 ```
 
-### CipherMode
-
+## CipherMode
 ```ts
 enum CipherMode {
     CBC = "CBC",
@@ -2311,17 +2273,16 @@ enum CipherMode {
     OFB = "OFB"
 }
 ```
-
 One of the following value:
 
-* `CBC = "CBC"`
-* `CFB = "CFB"`
-* `CTR = "CTR"`
-* `ECB = "ECB"`
-* `OFB = "OFB"`
+- `CBC = "CBC"`
+- `CFB = "CFB"`
+- `CTR = "CTR"`
+- `ECB = "ECB"`
+- `OFB = "OFB"`
 
-### AesParamsEB
 
+## AesParamsEB
 ```ts
 type AesParamsEB = {
     mode: CipherMode,
@@ -2329,39 +2290,36 @@ type AesParamsEB = {
     iv?: string
 }
 ```
+- `mode`: _[CipherMode](mod\_crypto.md#ciphermode)_
+- `key`: _string_
+- `iv`?: _string_
 
-* `mode`: [_CipherMode_](mod_crypto.md#ciphermode)
-* `key`: _string_
-* `iv`?: _string_
 
-### AesInfo
-
+## AesInfo
 ```ts
 type AesInfo = {
     mode: CipherMode,
     iv?: string
 }
 ```
+- `mode`: _[CipherMode](mod\_crypto.md#ciphermode)_
+- `iv`?: _string_
 
-* `mode`: [_CipherMode_](mod_crypto.md#ciphermode)
-* `iv`?: _string_
 
-### ChaCha20ParamsEB
-
+## ChaCha20ParamsEB
 ```ts
 type ChaCha20ParamsEB = {
     key: string,
     nonce: string
 }
 ```
+- `key`: _string_ – 256-bit key.
+<br>Must be encoded with `hex`.
+- `nonce`: _string_ – 96-bit nonce.
+<br>Must be encoded with `hex`.
 
-* `key`: _string_ – 256-bit key.\
-  Must be encoded with `hex`.
-* `nonce`: _string_ – 96-bit nonce.\
-  Must be encoded with `hex`.
 
-### NaclBoxParamsEB
-
+## NaclBoxParamsEB
 ```ts
 type NaclBoxParamsEB = {
     their_public: string,
@@ -2369,33 +2327,33 @@ type NaclBoxParamsEB = {
     nonce: string
 }
 ```
+- `their_public`: _string_ – 256-bit key.
+<br>Must be encoded with `hex`.
+- `secret`: _string_ – 256-bit key.
+<br>Must be encoded with `hex`.
+- `nonce`: _string_ – 96-bit nonce.
+<br>Must be encoded with `hex`.
 
-* `their_public`: _string_ – 256-bit key.\
-  Must be encoded with `hex`.
-* `secret`: _string_ – 256-bit key.\
-  Must be encoded with `hex`.
-* `nonce`: _string_ – 96-bit nonce.\
-  Must be encoded with `hex`.
 
-### NaclSecretBoxParamsEB
-
+## NaclSecretBoxParamsEB
 ```ts
 type NaclSecretBoxParamsEB = {
     key: string,
     nonce: string
 }
 ```
+- `key`: _string_ – Secret key - unprefixed 0-padded to 64 symbols hex string
+- `nonce`: _string_ – Nonce in `hex`
 
-* `key`: _string_ – Secret key - unprefixed 0-padded to 64 symbols hex string
-* `nonce`: _string_ – Nonce in `hex`
 
-### CryptoBoxSecretRandomSeedPhraseVariant
-
+## CryptoBoxSecretRandomSeedPhraseVariant
 Creates Crypto Box from a random seed phrase. This option can be used if a developer doesn't want the seed phrase to leave the core library's memory, where it is stored encrypted.
 
-This type should be used upon the first wallet initialization, all further initializations should use `EncryptedSecret` type instead.
+This type should be used upon the first wallet initialization, all
+further initializations should use `EncryptedSecret` type instead.
 
-Get `encrypted_secret` with `get_crypto_box_info` function and store it on your side.
+Get `encrypted_secret` with `get_crypto_box_info` function and store it
+on your side.
 
 ```ts
 type CryptoBoxSecretRandomSeedPhraseVariant = {
@@ -2403,17 +2361,18 @@ type CryptoBoxSecretRandomSeedPhraseVariant = {
     wordcount: number
 }
 ```
+- `dictionary`: _[MnemonicDictionary](mod\_crypto.md#mnemonicdictionary)_
+- `wordcount`: _number_
 
-* `dictionary`: [_MnemonicDictionary_](mod_crypto.md#mnemonicdictionary)
-* `wordcount`: _number_
 
-### CryptoBoxSecretPredefinedSeedPhraseVariant
-
+## CryptoBoxSecretPredefinedSeedPhraseVariant
 Restores crypto box instance from an existing seed phrase. This type should be used when Crypto Box is initialized from a seed phrase, entered by a user.
 
-This type should be used only upon the first wallet initialization, all further initializations should use `EncryptedSecret` type instead.
+This type should be used only upon the first wallet initialization, all
+further initializations should use `EncryptedSecret` type instead.
 
-Get `encrypted_secret` with `get_crypto_box_info` function and store it on your side.
+Get `encrypted_secret` with `get_crypto_box_info` function and store it
+on your side.
 
 ```ts
 type CryptoBoxSecretPredefinedSeedPhraseVariant = {
@@ -2422,29 +2381,34 @@ type CryptoBoxSecretPredefinedSeedPhraseVariant = {
     wordcount: number
 }
 ```
+- `phrase`: _string_
+- `dictionary`: _[MnemonicDictionary](mod\_crypto.md#mnemonicdictionary)_
+- `wordcount`: _number_
 
-* `phrase`: _string_
-* `dictionary`: [_MnemonicDictionary_](mod_crypto.md#mnemonicdictionary)
-* `wordcount`: _number_
 
-### CryptoBoxSecretEncryptedSecretVariant
+## CryptoBoxSecretEncryptedSecretVariant
+Use this type for wallet reinitializations, when you already have `encrypted_secret` on hands.
 
-Use this type for wallet reinitializations, when you already have `encrypted_secret` on hands. To get `encrypted_secret`, use `get_crypto_box_info` function after you initialized your crypto box for the first time.
+To get `encrypted_secret`, use `get_crypto_box_info` function after you initialized your crypto box
+for the first time.
 
-It is an object, containing seed phrase or private key, encrypted with `secret_encryption_salt` and password from `password_provider`.
+It is an object, containing seed phrase or private key, encrypted with
+`secret_encryption_salt` and password from `password_provider`.
 
-Note that if you want to change salt or password provider, then you need to reinitialize the wallet with `PredefinedSeedPhrase`, then get `EncryptedSecret` via `get_crypto_box_info`, store it somewhere, and only after that initialize the wallet with `EncryptedSecret` type.
+Note that if you want to change salt or password provider, then you need
+to reinitialize the wallet with `PredefinedSeedPhrase`, then get
+`EncryptedSecret` via `get_crypto_box_info`, store it somewhere, and
+only after that initialize the wallet with `EncryptedSecret` type.
 
 ```ts
 type CryptoBoxSecretEncryptedSecretVariant = {
     encrypted_secret: string
 }
 ```
+- `encrypted_secret`: _string_ – It is an object, containing encrypted seed phrase or private key (now we support only seed phrase).
 
-* `encrypted_secret`: _string_ – It is an object, containing encrypted seed phrase or private key (now we support only seed phrase).
 
-### CryptoBoxSecret
-
+## CryptoBoxSecret
 Crypto Box Secret.
 
 ```ts
@@ -2456,41 +2420,52 @@ type CryptoBoxSecret = ({
     type: 'EncryptedSecret'
 } & CryptoBoxSecretEncryptedSecretVariant)
 ```
-
-Depends on value of the `type` field.
+Depends on value of the  `type` field.
 
 When _type_ is _'RandomSeedPhrase'_
 
 Creates Crypto Box from a random seed phrase. This option can be used if a developer doesn't want the seed phrase to leave the core library's memory, where it is stored encrypted.
 
-This type should be used upon the first wallet initialization, all further initializations should use `EncryptedSecret` type instead.
+This type should be used upon the first wallet initialization, all
+further initializations should use `EncryptedSecret` type instead.
 
-Get `encrypted_secret` with `get_crypto_box_info` function and store it on your side.
+Get `encrypted_secret` with `get_crypto_box_info` function and store it
+on your side.
 
-* `dictionary`: [_MnemonicDictionary_](mod_crypto.md#mnemonicdictionary)
-* `wordcount`: _number_
+- `dictionary`: _[MnemonicDictionary](mod\_crypto.md#mnemonicdictionary)_
+- `wordcount`: _number_
 
 When _type_ is _'PredefinedSeedPhrase'_
 
 Restores crypto box instance from an existing seed phrase. This type should be used when Crypto Box is initialized from a seed phrase, entered by a user.
 
-This type should be used only upon the first wallet initialization, all further initializations should use `EncryptedSecret` type instead.
+This type should be used only upon the first wallet initialization, all
+further initializations should use `EncryptedSecret` type instead.
 
-Get `encrypted_secret` with `get_crypto_box_info` function and store it on your side.
+Get `encrypted_secret` with `get_crypto_box_info` function and store it
+on your side.
 
-* `phrase`: _string_
-* `dictionary`: [_MnemonicDictionary_](mod_crypto.md#mnemonicdictionary)
-* `wordcount`: _number_
+- `phrase`: _string_
+- `dictionary`: _[MnemonicDictionary](mod\_crypto.md#mnemonicdictionary)_
+- `wordcount`: _number_
 
 When _type_ is _'EncryptedSecret'_
 
-Use this type for wallet reinitializations, when you already have `encrypted_secret` on hands. To get `encrypted_secret`, use `get_crypto_box_info` function after you initialized your crypto box for the first time.
+Use this type for wallet reinitializations, when you already have `encrypted_secret` on hands.
 
-It is an object, containing seed phrase or private key, encrypted with `secret_encryption_salt` and password from `password_provider`.
+To get `encrypted_secret`, use `get_crypto_box_info` function after you initialized your crypto box
+for the first time.
 
-Note that if you want to change salt or password provider, then you need to reinitialize the wallet with `PredefinedSeedPhrase`, then get `EncryptedSecret` via `get_crypto_box_info`, store it somewhere, and only after that initialize the wallet with `EncryptedSecret` type.
+It is an object, containing seed phrase or private key, encrypted with
+`secret_encryption_salt` and password from `password_provider`.
 
-* `encrypted_secret`: _string_ – It is an object, containing encrypted seed phrase or private key (now we support only seed phrase).
+Note that if you want to change salt or password provider, then you need
+to reinitialize the wallet with `PredefinedSeedPhrase`, then get
+`EncryptedSecret` via `get_crypto_box_info`, store it somewhere, and
+only after that initialize the wallet with `EncryptedSecret` type.
+
+- `encrypted_secret`: _string_ – It is an object, containing encrypted seed phrase or private key (now we support only seed phrase).
+
 
 Variant constructors:
 
@@ -2500,44 +2475,40 @@ function cryptoBoxSecretPredefinedSeedPhrase(phrase: string, dictionary: Mnemoni
 function cryptoBoxSecretEncryptedSecret(encrypted_secret: string): CryptoBoxSecret;
 ```
 
-### CryptoBoxHandle
-
+## CryptoBoxHandle
 ```ts
 type CryptoBoxHandle = number
 ```
 
-### BoxEncryptionAlgorithmChaCha20Variant
 
+## BoxEncryptionAlgorithmChaCha20Variant
 ```ts
 type BoxEncryptionAlgorithmChaCha20Variant = {
     value: ChaCha20ParamsCB
 }
 ```
+- `value`: _[ChaCha20ParamsCB](mod\_crypto.md#chacha20paramscb)_
 
-* `value`: [_ChaCha20ParamsCB_](mod_crypto.md#chacha20paramscb)
 
-### BoxEncryptionAlgorithmNaclBoxVariant
-
+## BoxEncryptionAlgorithmNaclBoxVariant
 ```ts
 type BoxEncryptionAlgorithmNaclBoxVariant = {
     value: NaclBoxParamsCB
 }
 ```
+- `value`: _[NaclBoxParamsCB](mod\_crypto.md#naclboxparamscb)_
 
-* `value`: [_NaclBoxParamsCB_](mod_crypto.md#naclboxparamscb)
 
-### BoxEncryptionAlgorithmNaclSecretBoxVariant
-
+## BoxEncryptionAlgorithmNaclSecretBoxVariant
 ```ts
 type BoxEncryptionAlgorithmNaclSecretBoxVariant = {
     value: NaclSecretBoxParamsCB
 }
 ```
+- `value`: _[NaclSecretBoxParamsCB](mod\_crypto.md#naclsecretboxparamscb)_
 
-* `value`: [_NaclSecretBoxParamsCB_](mod_crypto.md#naclsecretboxparamscb)
 
-### BoxEncryptionAlgorithm
-
+## BoxEncryptionAlgorithm
 ```ts
 type BoxEncryptionAlgorithm = ({
     type: 'ChaCha20'
@@ -2547,20 +2518,20 @@ type BoxEncryptionAlgorithm = ({
     type: 'NaclSecretBox'
 } & BoxEncryptionAlgorithmNaclSecretBoxVariant)
 ```
-
-Depends on value of the `type` field.
+Depends on value of the  `type` field.
 
 When _type_ is _'ChaCha20'_
 
-* `value`: [_ChaCha20ParamsCB_](mod_crypto.md#chacha20paramscb)
+- `value`: _[ChaCha20ParamsCB](mod\_crypto.md#chacha20paramscb)_
 
 When _type_ is _'NaclBox'_
 
-* `value`: [_NaclBoxParamsCB_](mod_crypto.md#naclboxparamscb)
+- `value`: _[NaclBoxParamsCB](mod\_crypto.md#naclboxparamscb)_
 
 When _type_ is _'NaclSecretBox'_
 
-* `value`: [_NaclSecretBoxParamsCB_](mod_crypto.md#naclsecretboxparamscb)
+- `value`: _[NaclSecretBoxParamsCB](mod\_crypto.md#naclsecretboxparamscb)_
+
 
 Variant constructors:
 
@@ -2570,43 +2541,39 @@ function boxEncryptionAlgorithmNaclBox(value: NaclBoxParamsCB): BoxEncryptionAlg
 function boxEncryptionAlgorithmNaclSecretBox(value: NaclSecretBoxParamsCB): BoxEncryptionAlgorithm;
 ```
 
-### ChaCha20ParamsCB
-
+## ChaCha20ParamsCB
 ```ts
 type ChaCha20ParamsCB = {
     nonce: string
 }
 ```
+- `nonce`: _string_ – 96-bit nonce.
+<br>Must be encoded with `hex`.
 
-* `nonce`: _string_ – 96-bit nonce.\
-  Must be encoded with `hex`.
 
-### NaclBoxParamsCB
-
+## NaclBoxParamsCB
 ```ts
 type NaclBoxParamsCB = {
     their_public: string,
     nonce: string
 }
 ```
+- `their_public`: _string_ – 256-bit key.
+<br>Must be encoded with `hex`.
+- `nonce`: _string_ – 96-bit nonce.
+<br>Must be encoded with `hex`.
 
-* `their_public`: _string_ – 256-bit key.\
-  Must be encoded with `hex`.
-* `nonce`: _string_ – 96-bit nonce.\
-  Must be encoded with `hex`.
 
-### NaclSecretBoxParamsCB
-
+## NaclSecretBoxParamsCB
 ```ts
 type NaclSecretBoxParamsCB = {
     nonce: string
 }
 ```
+- `nonce`: _string_ – Nonce in `hex`
 
-* `nonce`: _string_ – Nonce in `hex`
 
-### MnemonicDictionary
-
+## MnemonicDictionary
 ```ts
 enum MnemonicDictionary {
     Ton = 0,
@@ -2620,41 +2587,38 @@ enum MnemonicDictionary {
     Spanish = 8
 }
 ```
-
 One of the following value:
 
-* `Ton = 0` – TON compatible dictionary
-* `English = 1` – English BIP-39 dictionary
-* `ChineseSimplified = 2` – Chinese simplified BIP-39 dictionary
-* `ChineseTraditional = 3` – Chinese traditional BIP-39 dictionary
-* `French = 4` – French BIP-39 dictionary
-* `Italian = 5` – Italian BIP-39 dictionary
-* `Japanese = 6` – Japanese BIP-39 dictionary
-* `Korean = 7` – Korean BIP-39 dictionary
-* `Spanish = 8` – Spanish BIP-39 dictionary
+- `Ton = 0` – TON compatible dictionary
+- `English = 1` – English BIP-39 dictionary
+- `ChineseSimplified = 2` – Chinese simplified BIP-39 dictionary
+- `ChineseTraditional = 3` – Chinese traditional BIP-39 dictionary
+- `French = 4` – French BIP-39 dictionary
+- `Italian = 5` – Italian BIP-39 dictionary
+- `Japanese = 6` – Japanese BIP-39 dictionary
+- `Korean = 7` – Korean BIP-39 dictionary
+- `Spanish = 8` – Spanish BIP-39 dictionary
 
-### ParamsOfFactorize
 
+## ParamsOfFactorize
 ```ts
 type ParamsOfFactorize = {
     composite: string
 }
 ```
+- `composite`: _string_ – Hexadecimal representation of u64 composite number.
 
-* `composite`: _string_ – Hexadecimal representation of u64 composite number.
 
-### ResultOfFactorize
-
+## ResultOfFactorize
 ```ts
 type ResultOfFactorize = {
     factors: string[]
 }
 ```
+- `factors`: _string[]_ – Two factors of composite or empty if composite can't be factorized.
 
-* `factors`: _string\[]_ – Two factors of composite or empty if composite can't be factorized.
 
-### ParamsOfModularPower
-
+## ParamsOfModularPower
 ```ts
 type ParamsOfModularPower = {
     base: string,
@@ -2662,83 +2626,79 @@ type ParamsOfModularPower = {
     modulus: string
 }
 ```
+- `base`: _string_ – `base` argument of calculation.
+- `exponent`: _string_ – `exponent` argument of calculation.
+- `modulus`: _string_ – `modulus` argument of calculation.
 
-* `base`: _string_ – `base` argument of calculation.
-* `exponent`: _string_ – `exponent` argument of calculation.
-* `modulus`: _string_ – `modulus` argument of calculation.
 
-### ResultOfModularPower
-
+## ResultOfModularPower
 ```ts
 type ResultOfModularPower = {
     modular_power: string
 }
 ```
+- `modular_power`: _string_ – Result of modular exponentiation
 
-* `modular_power`: _string_ – Result of modular exponentiation
 
-### ParamsOfTonCrc16
-
+## ParamsOfTonCrc16
 ```ts
 type ParamsOfTonCrc16 = {
     data: string
 }
 ```
+- `data`: _string_ – Input data for CRC calculation.
+<br>Encoded with `base64`.
 
-* `data`: _string_ – Input data for CRC calculation.\
-  Encoded with `base64`.
 
-### ResultOfTonCrc16
-
+## ResultOfTonCrc16
 ```ts
 type ResultOfTonCrc16 = {
     crc: number
 }
 ```
+- `crc`: _number_ – Calculated CRC for input data.
 
-* `crc`: _number_ – Calculated CRC for input data.
 
-### ParamsOfGenerateRandomBytes
-
+## ParamsOfGenerateRandomBytes
 ```ts
 type ParamsOfGenerateRandomBytes = {
     length: number
 }
 ```
+- `length`: _number_ – Size of random byte array.
 
-* `length`: _number_ – Size of random byte array.
 
-### ResultOfGenerateRandomBytes
-
+## ResultOfGenerateRandomBytes
 ```ts
 type ResultOfGenerateRandomBytes = {
     bytes: string
 }
 ```
+- `bytes`: _string_ – Generated bytes encoded in `base64`.
 
-* `bytes`: _string_ – Generated bytes encoded in `base64`.
 
-### ParamsOfConvertPublicKeyToTonSafeFormat
+## ParamsOfConvertPublicKeyToTonSafeFormat
+ParamsOfConvertPublicKeyToTonSafeFormat
 
 ```ts
 type ParamsOfConvertPublicKeyToTonSafeFormat = {
     public_key: string
 }
 ```
+- `public_key`: _string_ – Public key - 64 symbols hex string
 
-* `public_key`: _string_ – Public key - 64 symbols hex string
 
-### ResultOfConvertPublicKeyToTonSafeFormat
-
+## ResultOfConvertPublicKeyToTonSafeFormat
 ```ts
 type ResultOfConvertPublicKeyToTonSafeFormat = {
-    ton_public_key: string
+    tvm_public_key: string
 }
 ```
+- `tvm_public_key`: _string_ – Public key represented in TON safe format.
 
-* `ton_public_key`: _string_ – Public key represented in TON safe format.
 
-### KeyPair
+## KeyPair
+KeyPair
 
 ```ts
 type KeyPair = {
@@ -2746,11 +2706,12 @@ type KeyPair = {
     secret: string
 }
 ```
+- `public`: _string_ – Public key - 64 symbols hex string
+- `secret`: _string_ – Private key - u64 symbols hex string
 
-* `public`: _string_ – Public key - 64 symbols hex string
-* `secret`: _string_ – Private key - u64 symbols hex string
 
-### ParamsOfSign
+## ParamsOfSign
+ParamsOfSign
 
 ```ts
 type ParamsOfSign = {
@@ -2758,23 +2719,23 @@ type ParamsOfSign = {
     keys: KeyPair
 }
 ```
+- `unsigned`: _string_ – Data that must be signed encoded in `base64`.
+- `keys`: _[KeyPair](mod\_crypto.md#keypair)_ – Sign keys.
 
-* `unsigned`: _string_ – Data that must be signed encoded in `base64`.
-* `keys`: [_KeyPair_](mod_crypto.md#keypair) – Sign keys.
 
-### ResultOfSign
-
+## ResultOfSign
 ```ts
 type ResultOfSign = {
     signed: string,
     signature: string
 }
 ```
+- `signed`: _string_ – Signed data combined with signature encoded in `base64`.
+- `signature`: _string_ – Signature encoded in `hex`.
 
-* `signed`: _string_ – Signed data combined with signature encoded in `base64`.
-* `signature`: _string_ – Signature encoded in `hex`.
 
-### ParamsOfVerifySignature
+## ParamsOfVerifySignature
+ParamsOfVerifySignature
 
 ```ts
 type ParamsOfVerifySignature = {
@@ -2782,44 +2743,40 @@ type ParamsOfVerifySignature = {
     public: string
 }
 ```
+- `signed`: _string_ – Signed data that must be verified encoded in `base64`.
+- `public`: _string_ – Signer's public key - 64 symbols hex string
 
-* `signed`: _string_ – Signed data that must be verified encoded in `base64`.
-* `public`: _string_ – Signer's public key - 64 symbols hex string
 
-### ResultOfVerifySignature
-
+## ResultOfVerifySignature
 ```ts
 type ResultOfVerifySignature = {
     unsigned: string
 }
 ```
+- `unsigned`: _string_ – Unsigned data encoded in `base64`.
 
-* `unsigned`: _string_ – Unsigned data encoded in `base64`.
 
-### ParamsOfHash
-
+## ParamsOfHash
 ```ts
 type ParamsOfHash = {
     data: string
 }
 ```
+- `data`: _string_ – Input data for hash calculation.
+<br>Encoded with `base64`.
 
-* `data`: _string_ – Input data for hash calculation.\
-  Encoded with `base64`.
 
-### ResultOfHash
-
+## ResultOfHash
 ```ts
 type ResultOfHash = {
     hash: string
 }
 ```
+- `hash`: _string_ – Hash of input `data`.
+<br>Encoded with 'hex'.
 
-* `hash`: _string_ – Hash of input `data`.\
-  Encoded with 'hex'.
 
-### ParamsOfScrypt
-
+## ParamsOfScrypt
 ```ts
 type ParamsOfScrypt = {
     password: string,
@@ -2830,36 +2787,38 @@ type ParamsOfScrypt = {
     dk_len: number
 }
 ```
+- `password`: _string_ – The password bytes to be hashed. Must be encoded with `base64`.
+- `salt`: _string_ – Salt bytes that modify the hash to protect against Rainbow table attacks.
+<br>Must be encoded with `base64`.
+- `log_n`: _number_ – CPU/memory cost parameter
+- `r`: _number_ – The block size parameter, which fine-tunes sequential memory read size and performance.
+- `p`: _number_ – Parallelization parameter.
+- `dk_len`: _number_ – Intended output length in octets of the derived key.
 
-* `password`: _string_ – The password bytes to be hashed. Must be encoded with `base64`.
-* `salt`: _string_ – Salt bytes that modify the hash to protect against Rainbow table attacks. Must be encoded with `base64`.
-* `log_n`: _number_ – CPU/memory cost parameter
-* `r`: _number_ – The block size parameter, which fine-tunes sequential memory read size and performance.
-* `p`: _number_ – Parallelization parameter.
-* `dk_len`: _number_ – Intended output length in octets of the derived key.
 
-### ResultOfScrypt
-
+## ResultOfScrypt
 ```ts
 type ResultOfScrypt = {
     key: string
 }
 ```
+- `key`: _string_ – Derived key.
+<br>Encoded with `hex`.
 
-* `key`: _string_ – Derived key.\
-  Encoded with `hex`.
 
-### ParamsOfNaclSignKeyPairFromSecret
+## ParamsOfNaclSignKeyPairFromSecret
+ParamsOfNaclSignKeyPairFromSecret
 
 ```ts
 type ParamsOfNaclSignKeyPairFromSecret = {
     secret: string
 }
 ```
+- `secret`: _string_ – Secret key - unprefixed 0-padded to 64 symbols hex string
 
-* `secret`: _string_ – Secret key - unprefixed 0-padded to 64 symbols hex string
 
-### ParamsOfNaclSign
+## ParamsOfNaclSign
+ParamsOfNaclSign
 
 ```ts
 type ParamsOfNaclSign = {
@@ -2867,21 +2826,21 @@ type ParamsOfNaclSign = {
     secret: string
 }
 ```
+- `unsigned`: _string_ – Data that must be signed encoded in `base64`.
+- `secret`: _string_ – Signer's secret key - unprefixed 0-padded to 128 symbols hex string (concatenation of 64 symbols secret and 64 symbols public keys). See `nacl_sign_keypair_from_secret_key`.
 
-* `unsigned`: _string_ – Data that must be signed encoded in `base64`.
-* `secret`: _string_ – Signer's secret key - unprefixed 0-padded to 128 symbols hex string (concatenation of 64 symbols secret and 64 symbols public keys). See `nacl_sign_keypair_from_secret_key`.
 
-### ResultOfNaclSign
-
+## ResultOfNaclSign
 ```ts
 type ResultOfNaclSign = {
     signed: string
 }
 ```
+- `signed`: _string_ – Signed data, encoded in `base64`.
 
-* `signed`: _string_ – Signed data, encoded in `base64`.
 
-### ParamsOfNaclSignOpen
+## ParamsOfNaclSignOpen
+ParamsOfNaclSignOpen
 
 ```ts
 type ParamsOfNaclSignOpen = {
@@ -2889,32 +2848,31 @@ type ParamsOfNaclSignOpen = {
     public: string
 }
 ```
+- `signed`: _string_ – Signed data that must be unsigned.
+<br>Encoded with `base64`.
+- `public`: _string_ – Signer's public key - unprefixed 0-padded to 64 symbols hex string
 
-* `signed`: _string_ – Signed data that must be unsigned.\
-  Encoded with `base64`.
-* `public`: _string_ – Signer's public key - unprefixed 0-padded to 64 symbols hex string
 
-### ResultOfNaclSignOpen
-
+## ResultOfNaclSignOpen
 ```ts
 type ResultOfNaclSignOpen = {
     unsigned: string
 }
 ```
+- `unsigned`: _string_ – Unsigned data, encoded in `base64`.
 
-* `unsigned`: _string_ – Unsigned data, encoded in `base64`.
 
-### ResultOfNaclSignDetached
-
+## ResultOfNaclSignDetached
 ```ts
 type ResultOfNaclSignDetached = {
     signature: string
 }
 ```
+- `signature`: _string_ – Signature encoded in `hex`.
 
-* `signature`: _string_ – Signature encoded in `hex`.
 
-### ParamsOfNaclSignDetachedVerify
+## ParamsOfNaclSignDetachedVerify
+ParamsOfNaclSignDetachedVerify
 
 ```ts
 type ParamsOfNaclSignDetachedVerify = {
@@ -2923,34 +2881,35 @@ type ParamsOfNaclSignDetachedVerify = {
     public: string
 }
 ```
+- `unsigned`: _string_ – Unsigned data that must be verified.
+<br>Encoded with `base64`.
+- `signature`: _string_ – Signature that must be verified.
+<br>Encoded with `hex`.
+- `public`: _string_ – Signer's public key - unprefixed 0-padded to 64 symbols hex string.
 
-* `unsigned`: _string_ – Unsigned data that must be verified.\
-  Encoded with `base64`.
-* `signature`: _string_ – Signature that must be verified.\
-  Encoded with `hex`.
-* `public`: _string_ – Signer's public key - unprefixed 0-padded to 64 symbols hex string.
 
-### ResultOfNaclSignDetachedVerify
-
+## ResultOfNaclSignDetachedVerify
 ```ts
 type ResultOfNaclSignDetachedVerify = {
     succeeded: boolean
 }
 ```
+- `succeeded`: _boolean_ – `true` if verification succeeded or `false` if it failed
 
-* `succeeded`: _boolean_ – `true` if verification succeeded or `false` if it failed
 
-### ParamsOfNaclBoxKeyPairFromSecret
+## ParamsOfNaclBoxKeyPairFromSecret
+ParamsOfNaclBoxKeyPairFromSecret
 
 ```ts
 type ParamsOfNaclBoxKeyPairFromSecret = {
     secret: string
 }
 ```
+- `secret`: _string_ – Secret key - unprefixed 0-padded to 64 symbols hex string
 
-* `secret`: _string_ – Secret key - unprefixed 0-padded to 64 symbols hex string
 
-### ParamsOfNaclBox
+## ParamsOfNaclBox
+ParamsOfNaclBox
 
 ```ts
 type ParamsOfNaclBox = {
@@ -2960,23 +2919,23 @@ type ParamsOfNaclBox = {
     secret: string
 }
 ```
+- `decrypted`: _string_ – Data that must be encrypted encoded in `base64`.
+- `nonce`: _string_ – Nonce, encoded in `hex`
+- `their_public`: _string_ – Receiver's public key - unprefixed 0-padded to 64 symbols hex string
+- `secret`: _string_ – Sender's private key - unprefixed 0-padded to 64 symbols hex string
 
-* `decrypted`: _string_ – Data that must be encrypted encoded in `base64`.
-* `nonce`: _string_ – Nonce, encoded in `hex`
-* `their_public`: _string_ – Receiver's public key - unprefixed 0-padded to 64 symbols hex string
-* `secret`: _string_ – Sender's private key - unprefixed 0-padded to 64 symbols hex string
 
-### ResultOfNaclBox
-
+## ResultOfNaclBox
 ```ts
 type ResultOfNaclBox = {
     encrypted: string
 }
 ```
+- `encrypted`: _string_ – Encrypted data encoded in `base64`.
 
-* `encrypted`: _string_ – Encrypted data encoded in `base64`.
 
-### ParamsOfNaclBoxOpen
+## ParamsOfNaclBoxOpen
+ParamsOfNaclBoxOpen
 
 ```ts
 type ParamsOfNaclBoxOpen = {
@@ -2986,24 +2945,24 @@ type ParamsOfNaclBoxOpen = {
     secret: string
 }
 ```
+- `encrypted`: _string_ – Data that must be decrypted.
+<br>Encoded with `base64`.
+- `nonce`: _string_ – Nonce
+- `their_public`: _string_ – Sender's public key - unprefixed 0-padded to 64 symbols hex string
+- `secret`: _string_ – Receiver's private key - unprefixed 0-padded to 64 symbols hex string
 
-* `encrypted`: _string_ – Data that must be decrypted.\
-  Encoded with `base64`.
-* `nonce`: _string_ – Nonce
-* `their_public`: _string_ – Sender's public key - unprefixed 0-padded to 64 symbols hex string
-* `secret`: _string_ – Receiver's private key - unprefixed 0-padded to 64 symbols hex string
 
-### ResultOfNaclBoxOpen
-
+## ResultOfNaclBoxOpen
 ```ts
 type ResultOfNaclBoxOpen = {
     decrypted: string
 }
 ```
+- `decrypted`: _string_ – Decrypted data encoded in `base64`.
 
-* `decrypted`: _string_ – Decrypted data encoded in `base64`.
 
-### ParamsOfNaclSecretBox
+## ParamsOfNaclSecretBox
+ParamsOfNaclSecretBox
 
 ```ts
 type ParamsOfNaclSecretBox = {
@@ -3012,13 +2971,14 @@ type ParamsOfNaclSecretBox = {
     key: string
 }
 ```
+- `decrypted`: _string_ – Data that must be encrypted.
+<br>Encoded with `base64`.
+- `nonce`: _string_ – Nonce in `hex`
+- `key`: _string_ – Secret key - unprefixed 0-padded to 64 symbols hex string
 
-* `decrypted`: _string_ – Data that must be encrypted.\
-  Encoded with `base64`.
-* `nonce`: _string_ – Nonce in `hex`
-* `key`: _string_ – Secret key - unprefixed 0-padded to 64 symbols hex string
 
-### ParamsOfNaclSecretBoxOpen
+## ParamsOfNaclSecretBoxOpen
+ParamsOfNaclSecretBoxOpen
 
 ```ts
 type ParamsOfNaclSecretBoxOpen = {
@@ -3027,56 +2987,51 @@ type ParamsOfNaclSecretBoxOpen = {
     key: string
 }
 ```
+- `encrypted`: _string_ – Data that must be decrypted.
+<br>Encoded with `base64`.
+- `nonce`: _string_ – Nonce in `hex`
+- `key`: _string_ – Secret key - unprefixed 0-padded to 64 symbols hex string
 
-* `encrypted`: _string_ – Data that must be decrypted.\
-  Encoded with `base64`.
-* `nonce`: _string_ – Nonce in `hex`
-* `key`: _string_ – Secret key - unprefixed 0-padded to 64 symbols hex string
 
-### ParamsOfMnemonicWords
-
+## ParamsOfMnemonicWords
 ```ts
 type ParamsOfMnemonicWords = {
     dictionary?: MnemonicDictionary
 }
 ```
+- `dictionary`?: _[MnemonicDictionary](mod\_crypto.md#mnemonicdictionary)_ – Dictionary identifier
 
-* `dictionary`?: [_MnemonicDictionary_](mod_crypto.md#mnemonicdictionary) – Dictionary identifier
 
-### ResultOfMnemonicWords
-
+## ResultOfMnemonicWords
 ```ts
 type ResultOfMnemonicWords = {
     words: string
 }
 ```
+- `words`: _string_ – The list of mnemonic words
 
-* `words`: _string_ – The list of mnemonic words
 
-### ParamsOfMnemonicFromRandom
-
+## ParamsOfMnemonicFromRandom
 ```ts
 type ParamsOfMnemonicFromRandom = {
     dictionary?: MnemonicDictionary,
     word_count?: number
 }
 ```
+- `dictionary`?: _[MnemonicDictionary](mod\_crypto.md#mnemonicdictionary)_ – Dictionary identifier
+- `word_count`?: _number_ – Mnemonic word count
 
-* `dictionary`?: [_MnemonicDictionary_](mod_crypto.md#mnemonicdictionary) – Dictionary identifier
-* `word_count`?: _number_ – Mnemonic word count
 
-### ResultOfMnemonicFromRandom
-
+## ResultOfMnemonicFromRandom
 ```ts
 type ResultOfMnemonicFromRandom = {
     phrase: string
 }
 ```
+- `phrase`: _string_ – String of mnemonic words
 
-* `phrase`: _string_ – String of mnemonic words
 
-### ParamsOfMnemonicFromEntropy
-
+## ParamsOfMnemonicFromEntropy
 ```ts
 type ParamsOfMnemonicFromEntropy = {
     entropy: string,
@@ -3084,24 +3039,22 @@ type ParamsOfMnemonicFromEntropy = {
     word_count?: number
 }
 ```
+- `entropy`: _string_ – Entropy bytes.
+<br>Hex encoded.
+- `dictionary`?: _[MnemonicDictionary](mod\_crypto.md#mnemonicdictionary)_ – Dictionary identifier
+- `word_count`?: _number_ – Mnemonic word count
 
-* `entropy`: _string_ – Entropy bytes.\
-  Hex encoded.
-* `dictionary`?: [_MnemonicDictionary_](mod_crypto.md#mnemonicdictionary) – Dictionary identifier
-* `word_count`?: _number_ – Mnemonic word count
 
-### ResultOfMnemonicFromEntropy
-
+## ResultOfMnemonicFromEntropy
 ```ts
 type ResultOfMnemonicFromEntropy = {
     phrase: string
 }
 ```
+- `phrase`: _string_ – Phrase
 
-* `phrase`: _string_ – Phrase
 
-### ParamsOfMnemonicVerify
-
+## ParamsOfMnemonicVerify
 ```ts
 type ParamsOfMnemonicVerify = {
     phrase: string,
@@ -3109,23 +3062,21 @@ type ParamsOfMnemonicVerify = {
     word_count?: number
 }
 ```
+- `phrase`: _string_ – Phrase
+- `dictionary`?: _[MnemonicDictionary](mod\_crypto.md#mnemonicdictionary)_ – Dictionary identifier
+- `word_count`?: _number_ – Word count
 
-* `phrase`: _string_ – Phrase
-* `dictionary`?: [_MnemonicDictionary_](mod_crypto.md#mnemonicdictionary) – Dictionary identifier
-* `word_count`?: _number_ – Word count
 
-### ResultOfMnemonicVerify
-
+## ResultOfMnemonicVerify
 ```ts
 type ResultOfMnemonicVerify = {
     valid: boolean
 }
 ```
+- `valid`: _boolean_ – Flag indicating if the mnemonic is valid or not
 
-* `valid`: _boolean_ – Flag indicating if the mnemonic is valid or not
 
-### ParamsOfMnemonicDeriveSignKeys
-
+## ParamsOfMnemonicDeriveSignKeys
 ```ts
 type ParamsOfMnemonicDeriveSignKeys = {
     phrase: string,
@@ -3134,14 +3085,13 @@ type ParamsOfMnemonicDeriveSignKeys = {
     word_count?: number
 }
 ```
+- `phrase`: _string_ – Phrase
+- `path`?: _string_ – Derivation path, for instance "m/44'/1331'/0'/0/0"
+- `dictionary`?: _[MnemonicDictionary](mod\_crypto.md#mnemonicdictionary)_ – Dictionary identifier
+- `word_count`?: _number_ – Word count
 
-* `phrase`: _string_ – Phrase
-* `path`?: _string_ – Derivation path, for instance "m/44'/396'/0'/0/0"
-* `dictionary`?: [_MnemonicDictionary_](mod_crypto.md#mnemonicdictionary) – Dictionary identifier
-* `word_count`?: _number_ – Word count
 
-### ParamsOfHDKeyXPrvFromMnemonic
-
+## ParamsOfHDKeyXPrvFromMnemonic
 ```ts
 type ParamsOfHDKeyXPrvFromMnemonic = {
     phrase: string,
@@ -3149,23 +3099,21 @@ type ParamsOfHDKeyXPrvFromMnemonic = {
     word_count?: number
 }
 ```
+- `phrase`: _string_ – String with seed phrase
+- `dictionary`?: _[MnemonicDictionary](mod\_crypto.md#mnemonicdictionary)_ – Dictionary identifier
+- `word_count`?: _number_ – Mnemonic word count
 
-* `phrase`: _string_ – String with seed phrase
-* `dictionary`?: [_MnemonicDictionary_](mod_crypto.md#mnemonicdictionary) – Dictionary identifier
-* `word_count`?: _number_ – Mnemonic word count
 
-### ResultOfHDKeyXPrvFromMnemonic
-
+## ResultOfHDKeyXPrvFromMnemonic
 ```ts
 type ResultOfHDKeyXPrvFromMnemonic = {
     xprv: string
 }
 ```
+- `xprv`: _string_ – Serialized extended master private key
 
-* `xprv`: _string_ – Serialized extended master private key
 
-### ParamsOfHDKeyDeriveFromXPrv
-
+## ParamsOfHDKeyDeriveFromXPrv
 ```ts
 type ParamsOfHDKeyDeriveFromXPrv = {
     xprv: string,
@@ -3173,85 +3121,77 @@ type ParamsOfHDKeyDeriveFromXPrv = {
     hardened: boolean
 }
 ```
+- `xprv`: _string_ – Serialized extended private key
+- `child_index`: _number_ – Child index (see BIP-0032)
+- `hardened`: _boolean_ – Indicates the derivation of hardened/not-hardened key (see BIP-0032)
 
-* `xprv`: _string_ – Serialized extended private key
-* `child_index`: _number_ – Child index (see BIP-0032)
-* `hardened`: _boolean_ – Indicates the derivation of hardened/not-hardened key (see BIP-0032)
 
-### ResultOfHDKeyDeriveFromXPrv
-
+## ResultOfHDKeyDeriveFromXPrv
 ```ts
 type ResultOfHDKeyDeriveFromXPrv = {
     xprv: string
 }
 ```
+- `xprv`: _string_ – Serialized extended private key
 
-* `xprv`: _string_ – Serialized extended private key
 
-### ParamsOfHDKeyDeriveFromXPrvPath
-
+## ParamsOfHDKeyDeriveFromXPrvPath
 ```ts
 type ParamsOfHDKeyDeriveFromXPrvPath = {
     xprv: string,
     path: string
 }
 ```
+- `xprv`: _string_ – Serialized extended private key
+- `path`: _string_ – Derivation path, for instance "m/44'/1331'/0'/0/0"
 
-* `xprv`: _string_ – Serialized extended private key
-* `path`: _string_ – Derivation path, for instance "m/44'/396'/0'/0/0"
 
-### ResultOfHDKeyDeriveFromXPrvPath
-
+## ResultOfHDKeyDeriveFromXPrvPath
 ```ts
 type ResultOfHDKeyDeriveFromXPrvPath = {
     xprv: string
 }
 ```
+- `xprv`: _string_ – Derived serialized extended private key
 
-* `xprv`: _string_ – Derived serialized extended private key
 
-### ParamsOfHDKeySecretFromXPrv
-
+## ParamsOfHDKeySecretFromXPrv
 ```ts
 type ParamsOfHDKeySecretFromXPrv = {
     xprv: string
 }
 ```
+- `xprv`: _string_ – Serialized extended private key
 
-* `xprv`: _string_ – Serialized extended private key
 
-### ResultOfHDKeySecretFromXPrv
-
+## ResultOfHDKeySecretFromXPrv
 ```ts
 type ResultOfHDKeySecretFromXPrv = {
     secret: string
 }
 ```
+- `secret`: _string_ – Private key - 64 symbols hex string
 
-* `secret`: _string_ – Private key - 64 symbols hex string
 
-### ParamsOfHDKeyPublicFromXPrv
-
+## ParamsOfHDKeyPublicFromXPrv
 ```ts
 type ParamsOfHDKeyPublicFromXPrv = {
     xprv: string
 }
 ```
+- `xprv`: _string_ – Serialized extended private key
 
-* `xprv`: _string_ – Serialized extended private key
 
-### ResultOfHDKeyPublicFromXPrv
-
+## ResultOfHDKeyPublicFromXPrv
 ```ts
 type ResultOfHDKeyPublicFromXPrv = {
     public: string
 }
 ```
+- `public`: _string_ – Public key - 64 symbols hex string
 
-* `public`: _string_ – Public key - 64 symbols hex string
 
-### ParamsOfChaCha20
-
+## ParamsOfChaCha20
 ```ts
 type ParamsOfChaCha20 = {
     data: string,
@@ -3259,76 +3199,79 @@ type ParamsOfChaCha20 = {
     nonce: string
 }
 ```
+- `data`: _string_ – Source data to be encrypted or decrypted.
+<br>Must be encoded with `base64`.
+- `key`: _string_ – 256-bit key.
+<br>Must be encoded with `hex`.
+- `nonce`: _string_ – 96-bit nonce.
+<br>Must be encoded with `hex`.
 
-* `data`: _string_ – Source data to be encrypted or decrypted.\
-  Must be encoded with `base64`.
-* `key`: _string_ – 256-bit key.\
-  Must be encoded with `hex`.
-* `nonce`: _string_ – 96-bit nonce.\
-  Must be encoded with `hex`.
 
-### ResultOfChaCha20
-
+## ResultOfChaCha20
 ```ts
 type ResultOfChaCha20 = {
     data: string
 }
 ```
+- `data`: _string_ – Encrypted/decrypted data.
+<br>Encoded with `base64`.
 
-* `data`: _string_ – Encrypted/decrypted data.\
-  Encoded with `base64`.
 
-### ParamsOfCreateCryptoBox
-
+## ParamsOfCreateCryptoBox
 ```ts
 type ParamsOfCreateCryptoBox = {
     secret_encryption_salt: string,
     secret: CryptoBoxSecret
 }
 ```
+- `secret_encryption_salt`: _string_ – Salt used for secret encryption. For example, a mobile device can use device ID as salt.
+- `secret`: _[CryptoBoxSecret](mod\_crypto.md#cryptoboxsecret)_ – Cryptobox secret
 
-* `secret_encryption_salt`: _string_ – Salt used for secret encryption. For example, a mobile device can use device ID as salt.
-* `secret`: [_CryptoBoxSecret_](mod_crypto.md#cryptoboxsecret) – Cryptobox secret
 
-### RegisteredCryptoBox
-
+## RegisteredCryptoBox
 ```ts
 type RegisteredCryptoBox = {
     handle: CryptoBoxHandle
 }
 ```
+- `handle`: _[CryptoBoxHandle](mod\_crypto.md#cryptoboxhandle)_
 
-* `handle`: [_CryptoBoxHandle_](mod_crypto.md#cryptoboxhandle)
 
-### ParamsOfAppPasswordProviderGetPasswordVariant
-
+## ParamsOfAppPasswordProviderGetPasswordVariant
 ```ts
 type ParamsOfAppPasswordProviderGetPasswordVariant = {
     encryption_public_key: string
 }
 ```
+- `encryption_public_key`: _string_ – Temporary library pubkey, that is used on application side for password encryption, along with application temporary private key and nonce.
+<br>Used for password decryption on library side.
 
-* `encryption_public_key`: _string_ – Temporary library pubkey, that is used on application side for password encryption, along with application temporary private key and nonce. Used for password decryption on library side.
 
-### ParamsOfAppPasswordProvider
-
+## ParamsOfAppPasswordProvider
 Interface that provides a callback that returns an encrypted password, used for cryptobox secret encryption
 
-To secure the password while passing it from application to the library, the library generates a temporary key pair, passes the pubkey to the passwordProvider, decrypts the received password with private key, and deletes the key pair right away.
+To secure the password while passing it from application to the library,
+the library generates a temporary key pair, passes the pubkey
+to the passwordProvider, decrypts the received password with private key,
+and deletes the key pair right away.
 
-Application should generate a temporary nacl\_box\_keypair and encrypt the password with naclbox function using nacl\_box\_keypair.secret and encryption\_public\_key keys + nonce = 24-byte prefix of encryption\_public\_key.
+Application should generate a temporary nacl_box_keypair
+and encrypt the password with naclbox function using nacl_box_keypair.secret
+and encryption_public_key keys + nonce = 24-byte prefix of
+encryption_public_key.
 
 ```ts
 type ParamsOfAppPasswordProvider = ({
     type: 'GetPassword'
 } & ParamsOfAppPasswordProviderGetPasswordVariant)
 ```
-
-Depends on value of the `type` field.
+Depends on value of the  `type` field.
 
 When _type_ is _'GetPassword'_
 
-* `encryption_public_key`: _string_ – Temporary library pubkey, that is used on application side for password encryption, along with application temporary private key and nonce. Used for password decryption on library side.
+- `encryption_public_key`: _string_ – Temporary library pubkey, that is used on application side for password encryption, along with application temporary private key and nonce.
+<br>Used for password decryption on library side.
+
 
 Variant constructors:
 
@@ -3336,34 +3279,32 @@ Variant constructors:
 function paramsOfAppPasswordProviderGetPassword(encryption_public_key: string): ParamsOfAppPasswordProvider;
 ```
 
-### ResultOfAppPasswordProviderGetPasswordVariant
-
+## ResultOfAppPasswordProviderGetPasswordVariant
 ```ts
 type ResultOfAppPasswordProviderGetPasswordVariant = {
     encrypted_password: string,
     app_encryption_pubkey: string
 }
 ```
+- `encrypted_password`: _string_ – Password, encrypted and encoded to base64. Crypto box uses this password to decrypt its secret (seed phrase).
+- `app_encryption_pubkey`: _string_ – Hex encoded public key of a temporary key pair, used for password encryption on application side.
+<br>Used together with `encryption_public_key` to decode `encrypted_password`.
 
-* `encrypted_password`: _string_ – Password, encrypted and encoded to base64. Crypto box uses this password to decrypt its secret (seed phrase).
-* `app_encryption_pubkey`: _string_ – Hex encoded public key of a temporary key pair, used for password encryption on application side.\
-  Used together with `encryption_public_key` to decode `encrypted_password`.
 
-### ResultOfAppPasswordProvider
-
+## ResultOfAppPasswordProvider
 ```ts
 type ResultOfAppPasswordProvider = ({
     type: 'GetPassword'
 } & ResultOfAppPasswordProviderGetPasswordVariant)
 ```
-
-Depends on value of the `type` field.
+Depends on value of the  `type` field.
 
 When _type_ is _'GetPassword'_
 
-* `encrypted_password`: _string_ – Password, encrypted and encoded to base64. Crypto box uses this password to decrypt its secret (seed phrase).
-* `app_encryption_pubkey`: _string_ – Hex encoded public key of a temporary key pair, used for password encryption on application side.\
-  Used together with `encryption_public_key` to decode `encrypted_password`.
+- `encrypted_password`: _string_ – Password, encrypted and encoded to base64. Crypto box uses this password to decrypt its secret (seed phrase).
+- `app_encryption_pubkey`: _string_ – Hex encoded public key of a temporary key pair, used for password encryption on application side.
+<br>Used together with `encryption_public_key` to decode `encrypted_password`.
+
 
 Variant constructors:
 
@@ -3371,18 +3312,16 @@ Variant constructors:
 function resultOfAppPasswordProviderGetPassword(encrypted_password: string, app_encryption_pubkey: string): ResultOfAppPasswordProvider;
 ```
 
-### ResultOfGetCryptoBoxInfo
-
+## ResultOfGetCryptoBoxInfo
 ```ts
 type ResultOfGetCryptoBoxInfo = {
     encrypted_secret: string
 }
 ```
+- `encrypted_secret`: _string_ – Secret (seed phrase) encrypted with salt and password.
 
-* `encrypted_secret`: _string_ – Secret (seed phrase) encrypted with salt and password.
 
-### ResultOfGetCryptoBoxSeedPhrase
-
+## ResultOfGetCryptoBoxSeedPhrase
 ```ts
 type ResultOfGetCryptoBoxSeedPhrase = {
     phrase: string,
@@ -3390,13 +3329,12 @@ type ResultOfGetCryptoBoxSeedPhrase = {
     wordcount: number
 }
 ```
+- `phrase`: _string_
+- `dictionary`: _[MnemonicDictionary](mod\_crypto.md#mnemonicdictionary)_
+- `wordcount`: _number_
 
-* `phrase`: _string_
-* `dictionary`: [_MnemonicDictionary_](mod_crypto.md#mnemonicdictionary)
-* `wordcount`: _number_
 
-### ParamsOfGetSigningBoxFromCryptoBox
-
+## ParamsOfGetSigningBoxFromCryptoBox
 ```ts
 type ParamsOfGetSigningBoxFromCryptoBox = {
     handle: number,
@@ -3404,24 +3342,22 @@ type ParamsOfGetSigningBoxFromCryptoBox = {
     secret_lifetime?: number
 }
 ```
+- `handle`: _number_ – Crypto Box Handle.
+- `hdpath`?: _string_ – HD key derivation path.
+<br>By default, Acki Nacki HD path is used.
+- `secret_lifetime`?: _number_ – Store derived secret for this lifetime (in ms). The timer starts after each signing box operation. Secrets will be deleted immediately after each signing box operation, if this value is not set.
 
-* `handle`: _number_ – Crypto Box Handle.
-* `hdpath`?: _string_ – HD key derivation path.\
-  By default, Acki Nacki HD path is used.
-* `secret_lifetime`?: _number_ – Store derived secret for this lifetime (in ms). The timer starts after each signing box operation. Secrets will be deleted immediately after each signing box operation, if this value is not set.
 
-### RegisteredSigningBox
-
+## RegisteredSigningBox
 ```ts
 type RegisteredSigningBox = {
     handle: SigningBoxHandle
 }
 ```
+- `handle`: _[SigningBoxHandle](mod\_crypto.md#signingboxhandle)_ – Handle of the signing box.
 
-* `handle`: [_SigningBoxHandle_](mod_crypto.md#signingboxhandle) – Handle of the signing box.
 
-### ParamsOfGetEncryptionBoxFromCryptoBox
-
+## ParamsOfGetEncryptionBoxFromCryptoBox
 ```ts
 type ParamsOfGetEncryptionBoxFromCryptoBox = {
     handle: number,
@@ -3430,25 +3366,23 @@ type ParamsOfGetEncryptionBoxFromCryptoBox = {
     secret_lifetime?: number
 }
 ```
+- `handle`: _number_ – Crypto Box Handle.
+- `hdpath`?: _string_ – HD key derivation path.
+<br>By default, Acki Nacki HD path is used.
+- `algorithm`: _[BoxEncryptionAlgorithm](mod\_crypto.md#boxencryptionalgorithm)_ – Encryption algorithm.
+- `secret_lifetime`?: _number_ – Store derived secret for encryption algorithm for this lifetime (in ms). The timer starts after each encryption box operation. Secrets will be deleted (overwritten with zeroes) after each encryption operation, if this value is not set.
 
-* `handle`: _number_ – Crypto Box Handle.
-* `hdpath`?: _string_ – HD key derivation path.\
-  By default, Acki Nacki HD path is used.
-* `algorithm`: [_BoxEncryptionAlgorithm_](mod_crypto.md#boxencryptionalgorithm) – Encryption algorithm.
-* `secret_lifetime`?: _number_ – Store derived secret for encryption algorithm for this lifetime (in ms). The timer starts after each encryption box operation. Secrets will be deleted (overwritten with zeroes) after each encryption operation, if this value is not set.
 
-### RegisteredEncryptionBox
-
+## RegisteredEncryptionBox
 ```ts
 type RegisteredEncryptionBox = {
     handle: EncryptionBoxHandle
 }
 ```
+- `handle`: _[EncryptionBoxHandle](mod\_crypto.md#encryptionboxhandle)_ – Handle of the encryption box.
 
-* `handle`: [_EncryptionBoxHandle_](mod_crypto.md#encryptionboxhandle) – Handle of the encryption box.
 
-### ParamsOfAppSigningBoxGetPublicKeyVariant
-
+## ParamsOfAppSigningBoxGetPublicKeyVariant
 Get signing box public key
 
 ```ts
@@ -3457,8 +3391,8 @@ type ParamsOfAppSigningBoxGetPublicKeyVariant = {
 }
 ```
 
-### ParamsOfAppSigningBoxSignVariant
 
+## ParamsOfAppSigningBoxSignVariant
 Sign data
 
 ```ts
@@ -3466,11 +3400,10 @@ type ParamsOfAppSigningBoxSignVariant = {
     unsigned: string
 }
 ```
+- `unsigned`: _string_ – Data to sign encoded as base64
 
-* `unsigned`: _string_ – Data to sign encoded as base64
 
-### ParamsOfAppSigningBox
-
+## ParamsOfAppSigningBox
 Signing box callbacks.
 
 ```ts
@@ -3480,18 +3413,19 @@ type ParamsOfAppSigningBox = ({
     type: 'Sign'
 } & ParamsOfAppSigningBoxSignVariant)
 ```
-
-Depends on value of the `type` field.
+Depends on value of the  `type` field.
 
 When _type_ is _'GetPublicKey'_
 
 Get signing box public key
 
+
 When _type_ is _'Sign'_
 
 Sign data
 
-* `unsigned`: _string_ – Data to sign encoded as base64
+- `unsigned`: _string_ – Data to sign encoded as base64
+
 
 Variant constructors:
 
@@ -3500,8 +3434,7 @@ function paramsOfAppSigningBoxGetPublicKey(): ParamsOfAppSigningBox;
 function paramsOfAppSigningBoxSign(unsigned: string): ParamsOfAppSigningBox;
 ```
 
-### ResultOfAppSigningBoxGetPublicKeyVariant
-
+## ResultOfAppSigningBoxGetPublicKeyVariant
 Result of getting public key
 
 ```ts
@@ -3509,11 +3442,10 @@ type ResultOfAppSigningBoxGetPublicKeyVariant = {
     public_key: string
 }
 ```
+- `public_key`: _string_ – Signing box public key
 
-* `public_key`: _string_ – Signing box public key
 
-### ResultOfAppSigningBoxSignVariant
-
+## ResultOfAppSigningBoxSignVariant
 Result of signing data
 
 ```ts
@@ -3521,11 +3453,10 @@ type ResultOfAppSigningBoxSignVariant = {
     signature: string
 }
 ```
+- `signature`: _string_ – Data signature encoded as hex
 
-* `signature`: _string_ – Data signature encoded as hex
 
-### ResultOfAppSigningBox
-
+## ResultOfAppSigningBox
 Returning values from signing box callbacks.
 
 ```ts
@@ -3535,20 +3466,20 @@ type ResultOfAppSigningBox = ({
     type: 'Sign'
 } & ResultOfAppSigningBoxSignVariant)
 ```
-
-Depends on value of the `type` field.
+Depends on value of the  `type` field.
 
 When _type_ is _'GetPublicKey'_
 
 Result of getting public key
 
-* `public_key`: _string_ – Signing box public key
+- `public_key`: _string_ – Signing box public key
 
 When _type_ is _'Sign'_
 
 Result of signing data
 
-* `signature`: _string_ – Data signature encoded as hex
+- `signature`: _string_ – Data signature encoded as hex
+
 
 Variant constructors:
 
@@ -3557,43 +3488,39 @@ function resultOfAppSigningBoxGetPublicKey(public_key: string): ResultOfAppSigni
 function resultOfAppSigningBoxSign(signature: string): ResultOfAppSigningBox;
 ```
 
-### ResultOfSigningBoxGetPublicKey
-
+## ResultOfSigningBoxGetPublicKey
 ```ts
 type ResultOfSigningBoxGetPublicKey = {
     pubkey: string
 }
 ```
+- `pubkey`: _string_ – Public key of signing box.
+<br>Encoded with hex
 
-* `pubkey`: _string_ – Public key of signing box.\
-  Encoded with hex
 
-### ParamsOfSigningBoxSign
-
+## ParamsOfSigningBoxSign
 ```ts
 type ParamsOfSigningBoxSign = {
     signing_box: SigningBoxHandle,
     unsigned: string
 }
 ```
+- `signing_box`: _[SigningBoxHandle](mod\_crypto.md#signingboxhandle)_ – Signing Box handle.
+- `unsigned`: _string_ – Unsigned user data.
+<br>Must be encoded with `base64`.
 
-* `signing_box`: [_SigningBoxHandle_](mod_crypto.md#signingboxhandle) – Signing Box handle.
-* `unsigned`: _string_ – Unsigned user data.\
-  Must be encoded with `base64`.
 
-### ResultOfSigningBoxSign
-
+## ResultOfSigningBoxSign
 ```ts
 type ResultOfSigningBoxSign = {
     signature: string
 }
 ```
+- `signature`: _string_ – Data signature.
+<br>Encoded with `hex`.
 
-* `signature`: _string_ – Data signature.\
-  Encoded with `hex`.
 
-### ParamsOfAppEncryptionBoxGetInfoVariant
-
+## ParamsOfAppEncryptionBoxGetInfoVariant
 Get encryption box info
 
 ```ts
@@ -3602,8 +3529,8 @@ type ParamsOfAppEncryptionBoxGetInfoVariant = {
 }
 ```
 
-### ParamsOfAppEncryptionBoxEncryptVariant
 
+## ParamsOfAppEncryptionBoxEncryptVariant
 Encrypt data
 
 ```ts
@@ -3611,11 +3538,10 @@ type ParamsOfAppEncryptionBoxEncryptVariant = {
     data: string
 }
 ```
+- `data`: _string_ – Data, encoded in Base64
 
-* `data`: _string_ – Data, encoded in Base64
 
-### ParamsOfAppEncryptionBoxDecryptVariant
-
+## ParamsOfAppEncryptionBoxDecryptVariant
 Decrypt data
 
 ```ts
@@ -3623,11 +3549,10 @@ type ParamsOfAppEncryptionBoxDecryptVariant = {
     data: string
 }
 ```
+- `data`: _string_ – Data, encoded in Base64
 
-* `data`: _string_ – Data, encoded in Base64
 
-### ParamsOfAppEncryptionBox
-
+## ParamsOfAppEncryptionBox
 Interface for data encryption/decryption
 
 ```ts
@@ -3639,24 +3564,25 @@ type ParamsOfAppEncryptionBox = ({
     type: 'Decrypt'
 } & ParamsOfAppEncryptionBoxDecryptVariant)
 ```
-
-Depends on value of the `type` field.
+Depends on value of the  `type` field.
 
 When _type_ is _'GetInfo'_
 
 Get encryption box info
 
+
 When _type_ is _'Encrypt'_
 
 Encrypt data
 
-* `data`: _string_ – Data, encoded in Base64
+- `data`: _string_ – Data, encoded in Base64
 
 When _type_ is _'Decrypt'_
 
 Decrypt data
 
-* `data`: _string_ – Data, encoded in Base64
+- `data`: _string_ – Data, encoded in Base64
+
 
 Variant constructors:
 
@@ -3666,8 +3592,7 @@ function paramsOfAppEncryptionBoxEncrypt(data: string): ParamsOfAppEncryptionBox
 function paramsOfAppEncryptionBoxDecrypt(data: string): ParamsOfAppEncryptionBox;
 ```
 
-### ResultOfAppEncryptionBoxGetInfoVariant
-
+## ResultOfAppEncryptionBoxGetInfoVariant
 Result of getting encryption box info
 
 ```ts
@@ -3675,11 +3600,10 @@ type ResultOfAppEncryptionBoxGetInfoVariant = {
     info: EncryptionBoxInfo
 }
 ```
+- `info`: _[EncryptionBoxInfo](mod\_crypto.md#encryptionboxinfo)_
 
-* `info`: [_EncryptionBoxInfo_](mod_crypto.md#encryptionboxinfo)
 
-### ResultOfAppEncryptionBoxEncryptVariant
-
+## ResultOfAppEncryptionBoxEncryptVariant
 Result of encrypting data
 
 ```ts
@@ -3687,11 +3611,10 @@ type ResultOfAppEncryptionBoxEncryptVariant = {
     data: string
 }
 ```
+- `data`: _string_ – Encrypted data, encoded in Base64
 
-* `data`: _string_ – Encrypted data, encoded in Base64
 
-### ResultOfAppEncryptionBoxDecryptVariant
-
+## ResultOfAppEncryptionBoxDecryptVariant
 Result of decrypting data
 
 ```ts
@@ -3699,11 +3622,10 @@ type ResultOfAppEncryptionBoxDecryptVariant = {
     data: string
 }
 ```
+- `data`: _string_ – Decrypted data, encoded in Base64
 
-* `data`: _string_ – Decrypted data, encoded in Base64
 
-### ResultOfAppEncryptionBox
-
+## ResultOfAppEncryptionBox
 Returning values from signing box callbacks.
 
 ```ts
@@ -3715,26 +3637,26 @@ type ResultOfAppEncryptionBox = ({
     type: 'Decrypt'
 } & ResultOfAppEncryptionBoxDecryptVariant)
 ```
-
-Depends on value of the `type` field.
+Depends on value of the  `type` field.
 
 When _type_ is _'GetInfo'_
 
 Result of getting encryption box info
 
-* `info`: [_EncryptionBoxInfo_](mod_crypto.md#encryptionboxinfo)
+- `info`: _[EncryptionBoxInfo](mod\_crypto.md#encryptionboxinfo)_
 
 When _type_ is _'Encrypt'_
 
 Result of encrypting data
 
-* `data`: _string_ – Encrypted data, encoded in Base64
+- `data`: _string_ – Encrypted data, encoded in Base64
 
 When _type_ is _'Decrypt'_
 
 Result of decrypting data
 
-* `data`: _string_ – Decrypted data, encoded in Base64
+- `data`: _string_ – Decrypted data, encoded in Base64
+
 
 Variant constructors:
 
@@ -3744,88 +3666,87 @@ function resultOfAppEncryptionBoxEncrypt(data: string): ResultOfAppEncryptionBox
 function resultOfAppEncryptionBoxDecrypt(data: string): ResultOfAppEncryptionBox;
 ```
 
-### ParamsOfEncryptionBoxGetInfo
-
+## ParamsOfEncryptionBoxGetInfo
 ```ts
 type ParamsOfEncryptionBoxGetInfo = {
     encryption_box: EncryptionBoxHandle
 }
 ```
+- `encryption_box`: _[EncryptionBoxHandle](mod\_crypto.md#encryptionboxhandle)_ – Encryption box handle
 
-* `encryption_box`: [_EncryptionBoxHandle_](mod_crypto.md#encryptionboxhandle) – Encryption box handle
 
-### ResultOfEncryptionBoxGetInfo
-
+## ResultOfEncryptionBoxGetInfo
 ```ts
 type ResultOfEncryptionBoxGetInfo = {
     info: EncryptionBoxInfo
 }
 ```
+- `info`: _[EncryptionBoxInfo](mod\_crypto.md#encryptionboxinfo)_ – Encryption box information
 
-* `info`: [_EncryptionBoxInfo_](mod_crypto.md#encryptionboxinfo) – Encryption box information
 
-### ParamsOfEncryptionBoxEncrypt
-
+## ParamsOfEncryptionBoxEncrypt
 ```ts
 type ParamsOfEncryptionBoxEncrypt = {
     encryption_box: EncryptionBoxHandle,
     data: string
 }
 ```
+- `encryption_box`: _[EncryptionBoxHandle](mod\_crypto.md#encryptionboxhandle)_ – Encryption box handle
+- `data`: _string_ – Data to be encrypted, encoded in Base64
 
-* `encryption_box`: [_EncryptionBoxHandle_](mod_crypto.md#encryptionboxhandle) – Encryption box handle
-* `data`: _string_ – Data to be encrypted, encoded in Base64
 
-### ResultOfEncryptionBoxEncrypt
-
+## ResultOfEncryptionBoxEncrypt
 ```ts
 type ResultOfEncryptionBoxEncrypt = {
     data: string
 }
 ```
+- `data`: _string_ – Encrypted data, encoded in Base64.
+<br>Padded to cipher block size
 
-* `data`: _string_ – Encrypted data, encoded in Base64.\
-  Padded to cipher block size
 
-### ParamsOfEncryptionBoxDecrypt
-
+## ParamsOfEncryptionBoxDecrypt
 ```ts
 type ParamsOfEncryptionBoxDecrypt = {
     encryption_box: EncryptionBoxHandle,
     data: string
 }
 ```
+- `encryption_box`: _[EncryptionBoxHandle](mod\_crypto.md#encryptionboxhandle)_ – Encryption box handle
+- `data`: _string_ – Data to be decrypted, encoded in Base64
 
-* `encryption_box`: [_EncryptionBoxHandle_](mod_crypto.md#encryptionboxhandle) – Encryption box handle
-* `data`: _string_ – Data to be decrypted, encoded in Base64
 
-### ResultOfEncryptionBoxDecrypt
-
+## ResultOfEncryptionBoxDecrypt
 ```ts
 type ResultOfEncryptionBoxDecrypt = {
     data: string
 }
 ```
+- `data`: _string_ – Decrypted data, encoded in Base64.
 
-* `data`: _string_ – Decrypted data, encoded in Base64.
 
-### ParamsOfCreateEncryptionBox
-
+## ParamsOfCreateEncryptionBox
 ```ts
 type ParamsOfCreateEncryptionBox = {
     algorithm: EncryptionAlgorithm
 }
 ```
+- `algorithm`: _[EncryptionAlgorithm](mod\_crypto.md#encryptionalgorithm)_ – Encryption algorithm specifier including cipher parameters (key, IV, etc)
 
-* `algorithm`: [_EncryptionAlgorithm_](mod_crypto.md#encryptionalgorithm) – Encryption algorithm specifier including cipher parameters (key, IV, etc)
 
-### AppPasswordProvider
-
+## AppPasswordProvider
 Interface that provides a callback that returns an encrypted password, used for cryptobox secret encryption
 
-To secure the password while passing it from application to the library, the library generates a temporary key pair, passes the pubkey to the passwordProvider, decrypts the received password with private key, and deletes the key pair right away.
+To secure the password while passing it from application to the library,
+the library generates a temporary key pair, passes the pubkey
+to the passwordProvider, decrypts the received password with private key,
+and deletes the key pair right away.
 
-Application should generate a temporary nacl\_box\_keypair and encrypt the password with naclbox function using nacl\_box\_keypair.secret and encryption\_public\_key keys + nonce = 24-byte prefix of encryption\_public\_key.
+Application should generate a temporary nacl_box_keypair
+and encrypt the password with naclbox function using nacl_box_keypair.secret
+and encryption_public_key keys + nonce = 24-byte prefix of
+encryption_public_key.
+
 
 ```ts
 
@@ -3834,7 +3755,7 @@ export interface AppPasswordProvider {
 }
 ```
 
-### get\_password
+## get_password
 
 ```ts
 type ParamsOfAppPasswordProviderGetPasswordVariant = ParamsOfAppPasswordProviderGetPasswordVariant
@@ -3849,22 +3770,22 @@ function get_password_sync(
     params: ParamsOfAppPasswordProviderGetPasswordVariant,
 ): ResultOfAppPasswordProviderGetPasswordVariant;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `encryption_public_key`: _string_ – Temporary library pubkey, that is used on application side for password encryption, along with application temporary private key and nonce.
+<br>Used for password decryption on library side.
 
-#### Parameters
 
-* `encryption_public_key`: _string_ – Temporary library pubkey, that is used on application side for password encryption, along with application temporary private key and nonce. Used for password decryption on library side.
+### Result
 
-#### Result
+- `encrypted_password`: _string_ – Password, encrypted and encoded to base64. Crypto box uses this password to decrypt its secret (seed phrase).
+- `app_encryption_pubkey`: _string_ – Hex encoded public key of a temporary key pair, used for password encryption on application side.
+<br>Used together with `encryption_public_key` to decode `encrypted_password`.
 
-* `encrypted_password`: _string_ – Password, encrypted and encoded to base64. Crypto box uses this password to decrypt its secret (seed phrase).
-* `app_encryption_pubkey`: _string_ – Hex encoded public key of a temporary key pair, used for password encryption on application side.\
-  Used together with `encryption_public_key` to decode `encrypted_password`.
 
-### AppSigningBox
-
+## AppSigningBox
 Signing box callbacks.
+
 
 ```ts
 
@@ -3874,7 +3795,7 @@ export interface AppSigningBox {
 }
 ```
 
-### get\_public\_key
+## get_public_key
 
 Get signing box public key
 
@@ -3885,14 +3806,15 @@ function get_public_key(): Promise<ResultOfAppSigningBoxGetPublicKeyVariant>;
 
 function get_public_key_sync(): ResultOfAppSigningBoxGetPublicKeyVariant;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
 
-#### Result
 
-* `public_key`: _string_ – Signing box public key
+### Result
 
-### sign
+- `public_key`: _string_ – Signing box public key
+
+
+## sign
 
 Sign data
 
@@ -3909,20 +3831,19 @@ function sign_sync(
     params: ParamsOfAppSigningBoxSignVariant,
 ): ResultOfAppSigningBoxSignVariant;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `unsigned`: _string_ – Data to sign encoded as base64
 
-#### Parameters
 
-* `unsigned`: _string_ – Data to sign encoded as base64
+### Result
 
-#### Result
+- `signature`: _string_ – Data signature encoded as hex
 
-* `signature`: _string_ – Data signature encoded as hex
 
-### AppEncryptionBox
-
+## AppEncryptionBox
 Interface for data encryption/decryption
+
 
 ```ts
 
@@ -3933,7 +3854,7 @@ export interface AppEncryptionBox {
 }
 ```
 
-### get\_info
+## get_info
 
 Get encryption box info
 
@@ -3944,14 +3865,15 @@ function get_info(): Promise<ResultOfAppEncryptionBoxGetInfoVariant>;
 
 function get_info_sync(): ResultOfAppEncryptionBoxGetInfoVariant;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
 
-#### Result
 
-* `info`: [_EncryptionBoxInfo_](mod_crypto.md#encryptionboxinfo)
+### Result
 
-### encrypt
+- `info`: _[EncryptionBoxInfo](mod\_crypto.md#encryptionboxinfo)_
+
+
+## encrypt
 
 Encrypt data
 
@@ -3968,18 +3890,17 @@ function encrypt_sync(
     params: ParamsOfAppEncryptionBoxEncryptVariant,
 ): ResultOfAppEncryptionBoxEncryptVariant;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `data`: _string_ – Data, encoded in Base64
 
-#### Parameters
 
-* `data`: _string_ – Data, encoded in Base64
+### Result
 
-#### Result
+- `data`: _string_ – Encrypted data, encoded in Base64
 
-* `data`: _string_ – Encrypted data, encoded in Base64
 
-### decrypt
+## decrypt
 
 Decrypt data
 
@@ -3996,13 +3917,13 @@ function decrypt_sync(
     params: ParamsOfAppEncryptionBoxDecryptVariant,
 ): ResultOfAppEncryptionBoxDecryptVariant;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `data`: _string_ – Data, encoded in Base64
 
-#### Parameters
 
-* `data`: _string_ – Data, encoded in Base64
+### Result
 
-#### Result
+- `data`: _string_ – Decrypted data, encoded in Base64
 
-* `data`: _string_ – Decrypted data, encoded in Base64
+

--- a/docs/acki-nacki-sdk/types-and-methods/mod_debot.md
+++ b/docs/acki-nacki-sdk/types-and-methods/mod_debot.md
@@ -1,97 +1,94 @@
 # Module debot
 
-## Module debot
+[UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Module for working with debot.
 
-[UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Module for working with debot.
-
-### Functions
-
-[init](mod_debot.md#init) – [UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Creates and instance of DeBot.
-
-[start](mod_debot.md#start) – [UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Starts the DeBot.
-
-[fetch](mod_debot.md#fetch) – [UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Fetches DeBot metadata from blockchain.
-
-[execute](mod_debot.md#execute) – [UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Executes debot action.
-
-[send](mod_debot.md#send) – [UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Sends message to Debot.
-
-[remove](mod_debot.md#remove) – [UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Destroys debot handle.
-
-### Types
-
-[DebotErrorCode](mod_debot.md#deboterrorcode)
-
-[DebotHandle](mod_debot.md#debothandle) – [UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Handle of registered in SDK debot
-
-[DebotAction](mod_debot.md#debotaction) – [UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Describes a debot action in a Debot Context.
-
-[DebotInfo](mod_debot.md#debotinfo) – [UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Describes DeBot metadata.
-
-[DebotActivityTransactionVariant](mod_debot.md#debotactivitytransactionvariant) – DeBot wants to create new transaction in blockchain.
-
-[DebotActivity](mod_debot.md#debotactivity) – [UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Describes the operation that the DeBot wants to perform.
-
-[Spending](mod_debot.md#spending) – [UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Describes how much funds will be debited from the target contract balance as a result of the transaction.
-
-[ParamsOfInit](mod_debot.md#paramsofinit) – [UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Parameters to init DeBot.
-
-[RegisteredDebot](mod_debot.md#registereddebot) – [UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Structure for storing debot handle returned from `init` function.
-
-[ParamsOfAppDebotBrowserLogVariant](mod_debot.md#paramsofappdebotbrowserlogvariant) – Print message to user.
-
-[ParamsOfAppDebotBrowserSwitchVariant](mod_debot.md#paramsofappdebotbrowserswitchvariant) – Switch debot to another context (menu).
-
-[ParamsOfAppDebotBrowserSwitchCompletedVariant](mod_debot.md#paramsofappdebotbrowserswitchcompletedvariant) – Notify browser that all context actions are shown.
-
-[ParamsOfAppDebotBrowserShowActionVariant](mod_debot.md#paramsofappdebotbrowsershowactionvariant) – Show action to the user. Called after `switch` for each action in context.
-
-[ParamsOfAppDebotBrowserInputVariant](mod_debot.md#paramsofappdebotbrowserinputvariant) – Request user input.
-
-[ParamsOfAppDebotBrowserGetSigningBoxVariant](mod_debot.md#paramsofappdebotbrowsergetsigningboxvariant) – Get signing box to sign data.
-
-[ParamsOfAppDebotBrowserInvokeDebotVariant](mod_debot.md#paramsofappdebotbrowserinvokedebotvariant) – Execute action of another debot.
-
-[ParamsOfAppDebotBrowserSendVariant](mod_debot.md#paramsofappdebotbrowsersendvariant) – Used by Debot to call DInterface implemented by Debot Browser.
-
-[ParamsOfAppDebotBrowserApproveVariant](mod_debot.md#paramsofappdebotbrowserapprovevariant) – Requests permission from DeBot Browser to execute DeBot operation.
-
-[ParamsOfAppDebotBrowser](mod_debot.md#paramsofappdebotbrowser) – [UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Debot Browser callbacks
-
-[ResultOfAppDebotBrowserInputVariant](mod_debot.md#resultofappdebotbrowserinputvariant) – Result of user input.
-
-[ResultOfAppDebotBrowserGetSigningBoxVariant](mod_debot.md#resultofappdebotbrowsergetsigningboxvariant) – Result of getting signing box.
-
-[ResultOfAppDebotBrowserInvokeDebotVariant](mod_debot.md#resultofappdebotbrowserinvokedebotvariant) – Result of debot invoking.
-
-[ResultOfAppDebotBrowserApproveVariant](mod_debot.md#resultofappdebotbrowserapprovevariant) – Result of `approve` callback.
-
-[ResultOfAppDebotBrowser](mod_debot.md#resultofappdebotbrowser) – [UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Returning values from Debot Browser callbacks.
-
-[ParamsOfStart](mod_debot.md#paramsofstart) – [UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Parameters to start DeBot. DeBot must be already initialized with init() function.
-
-[ParamsOfFetch](mod_debot.md#paramsoffetch) – [UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Parameters to fetch DeBot metadata.
-
-[ResultOfFetch](mod_debot.md#resultoffetch) – [UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md)
-
-[ParamsOfExecute](mod_debot.md#paramsofexecute) – [UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Parameters for executing debot action.
-
-[ParamsOfSend](mod_debot.md#paramsofsend) – [UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Parameters of `send` function.
-
-[ParamsOfRemove](mod_debot.md#paramsofremove) – [UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md)
-
-[AppDebotBrowser](mod_debot.md#appdebotbrowser) – [UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Debot Browser callbacks
 
 ## Functions
+[init](mod\_debot.md#init) – [UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Creates and instance of DeBot.
 
-### init
+[start](mod\_debot.md#start) – [UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Starts the DeBot.
 
-[UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Creates and instance of DeBot.
+[fetch](mod\_debot.md#fetch) – [UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Fetches DeBot metadata from blockchain.
 
-Downloads debot smart contract (code and data) from blockchain and creates an instance of Debot Engine for it.
+[execute](mod\_debot.md#execute) – [UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Executes debot action.
 
-## Remarks
+[send](mod\_debot.md#send) – [UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Sends message to Debot.
 
+[remove](mod\_debot.md#remove) – [UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Destroys debot handle.
+
+## Types
+[DebotErrorCode](mod\_debot.md#deboterrorcode)
+
+[DebotHandle](mod\_debot.md#debothandle) – [UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Handle of registered in SDK debot
+
+[DebotAction](mod\_debot.md#debotaction) – [UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Describes a debot action in a Debot Context.
+
+[DebotInfo](mod\_debot.md#debotinfo) – [UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Describes DeBot metadata.
+
+[DebotActivityTransactionVariant](mod\_debot.md#debotactivitytransactionvariant) – DeBot wants to create new transaction in blockchain.
+
+[DebotActivity](mod\_debot.md#debotactivity) – [UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Describes the operation that the DeBot wants to perform.
+
+[Spending](mod\_debot.md#spending) – [UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Describes how much funds will be debited from the target  contract balance as a result of the transaction.
+
+[ParamsOfInit](mod\_debot.md#paramsofinit) – [UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Parameters to init DeBot.
+
+[RegisteredDebot](mod\_debot.md#registereddebot) – [UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Structure for storing debot handle returned from `init` function.
+
+[ParamsOfAppDebotBrowserLogVariant](mod\_debot.md#paramsofappdebotbrowserlogvariant) – Print message to user.
+
+[ParamsOfAppDebotBrowserSwitchVariant](mod\_debot.md#paramsofappdebotbrowserswitchvariant) – Switch debot to another context (menu).
+
+[ParamsOfAppDebotBrowserSwitchCompletedVariant](mod\_debot.md#paramsofappdebotbrowserswitchcompletedvariant) – Notify browser that all context actions are shown.
+
+[ParamsOfAppDebotBrowserShowActionVariant](mod\_debot.md#paramsofappdebotbrowsershowactionvariant) – Show action to the user. Called after `switch` for each action in context.
+
+[ParamsOfAppDebotBrowserInputVariant](mod\_debot.md#paramsofappdebotbrowserinputvariant) – Request user input.
+
+[ParamsOfAppDebotBrowserGetSigningBoxVariant](mod\_debot.md#paramsofappdebotbrowsergetsigningboxvariant) – Get signing box to sign data.
+
+[ParamsOfAppDebotBrowserInvokeDebotVariant](mod\_debot.md#paramsofappdebotbrowserinvokedebotvariant) – Execute action of another debot.
+
+[ParamsOfAppDebotBrowserSendVariant](mod\_debot.md#paramsofappdebotbrowsersendvariant) – Used by Debot to call DInterface implemented by Debot Browser.
+
+[ParamsOfAppDebotBrowserApproveVariant](mod\_debot.md#paramsofappdebotbrowserapprovevariant) – Requests permission from DeBot Browser to execute DeBot operation.
+
+[ParamsOfAppDebotBrowser](mod\_debot.md#paramsofappdebotbrowser) – [UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Debot Browser callbacks
+
+[ResultOfAppDebotBrowserInputVariant](mod\_debot.md#resultofappdebotbrowserinputvariant) – Result of user input.
+
+[ResultOfAppDebotBrowserGetSigningBoxVariant](mod\_debot.md#resultofappdebotbrowsergetsigningboxvariant) – Result of getting signing box.
+
+[ResultOfAppDebotBrowserInvokeDebotVariant](mod\_debot.md#resultofappdebotbrowserinvokedebotvariant) – Result of debot invoking.
+
+[ResultOfAppDebotBrowserApproveVariant](mod\_debot.md#resultofappdebotbrowserapprovevariant) – Result of `approve` callback.
+
+[ResultOfAppDebotBrowser](mod\_debot.md#resultofappdebotbrowser) – [UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Returning values from Debot Browser callbacks.
+
+[ParamsOfStart](mod\_debot.md#paramsofstart) – [UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Parameters to start DeBot.
+
+[ParamsOfFetch](mod\_debot.md#paramsoffetch) – [UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Parameters to fetch DeBot metadata.
+
+[ResultOfFetch](mod\_debot.md#resultoffetch) – [UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md)
+
+[ParamsOfExecute](mod\_debot.md#paramsofexecute) – [UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Parameters for executing debot action.
+
+[ParamsOfSend](mod\_debot.md#paramsofsend) – [UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Parameters of `send` function.
+
+[ParamsOfRemove](mod\_debot.md#paramsofremove) – [UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md)
+
+[AppDebotBrowser](mod\_debot.md#appdebotbrowser) – [UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Debot Browser callbacks
+
+
+# Functions
+## init
+
+[UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Creates and instance of DeBot.
+
+Downloads debot smart contract (code and data) from blockchain and creates
+an instance of Debot Engine for it.
+
+# Remarks
 It does not switch debot to context 0. Browser Callbacks are not called.
 
 ```ts
@@ -114,29 +111,35 @@ function init_sync(
     params: ParamsOfInit,
 ): RegisteredDebot;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `address`: _string_ – Debot smart contract address
+- `obj`: [AppDebotBrowser](mod\_AppDebotBrowser.md#appdebotbrowser) – [UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Debot Browser callbacks
 
-#### Parameters
 
-* `address`: _string_ – Debot smart contract address
-* `obj`: [AppDebotBrowser](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/mod_AppDebotBrowser.md#appdebotbrowser) – [UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Debot Browser callbacks
 
-#### Result
+### Result
 
-* `debot_handle`: [_DebotHandle_](mod_debot.md#debothandle) – Debot handle which references an instance of debot engine.
-* `debot_abi`: _string_ – Debot abi as json string.
-* `info`: [_DebotInfo_](mod_debot.md#debotinfo) – Debot metadata.
+- `debot_handle`: _[DebotHandle](mod\_debot.md#debothandle)_ – Debot handle which references an instance of debot engine.
+- `debot_abi`: _string_ – Debot abi as json string.
+- `info`: _[DebotInfo](mod\_debot.md#debotinfo)_ – Debot metadata.
 
-### start
 
-[UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Starts the DeBot.
+## start
 
-Downloads debot smart contract from blockchain and switches it to context zero.
+[UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Starts the DeBot.
 
-This function must be used by Debot Browser to start a dialog with debot. While the function is executing, several Browser Callbacks can be called, since the debot tries to display all actions from the context 0 to the user.
+Downloads debot smart contract from blockchain and switches it to
+context zero.
 
-When the debot starts SDK registers `BrowserCallbacks` AppObject. Therefore when `debote.remove` is called the debot is being deleted and the callback is called with `finish`=`true` which indicates that it will never be used again.
+This function must be used by Debot Browser to start a dialog with debot.
+While the function is executing, several Browser Callbacks can be called,
+since the debot tries to display all actions from the context 0 to the user.
+
+When the debot starts SDK registers `BrowserCallbacks` AppObject.
+Therefore when `debote.remove` is called the debot is being deleted and the
+callback is called with `finish`=`true` which indicates that it will never
+be used again.
 
 ```ts
 type ParamsOfStart = {
@@ -151,16 +154,14 @@ function start_sync(
     params: ParamsOfStart,
 ): void;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `debot_handle`: _[DebotHandle](mod\_debot.md#debothandle)_ – Debot handle which references an instance of debot engine.
 
-#### Parameters
 
-* `debot_handle`: [_DebotHandle_](mod_debot.md#debothandle) – Debot handle which references an instance of debot engine.
+## fetch
 
-### fetch
-
-[UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Fetches DeBot metadata from blockchain.
+[UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Fetches DeBot metadata from blockchain.
 
 Downloads DeBot from blockchain and creates and fetches its metadata.
 
@@ -181,26 +182,26 @@ function fetch_sync(
     params: ParamsOfFetch,
 ): ResultOfFetch;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `address`: _string_ – Debot smart contract address.
 
-#### Parameters
 
-* `address`: _string_ – Debot smart contract address.
+### Result
 
-#### Result
+- `info`: _[DebotInfo](mod\_debot.md#debotinfo)_ – Debot metadata.
 
-* `info`: [_DebotInfo_](mod_debot.md#debotinfo) – Debot metadata.
 
-### execute
+## execute
 
-[UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Executes debot action.
+[UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Executes debot action.
 
-Calls debot engine referenced by debot handle to execute input action. Calls Debot Browser Callbacks if needed.
+Calls debot engine referenced by debot handle to execute input action.
+Calls Debot Browser Callbacks if needed.
 
-## Remarks
-
-Chain of actions can be executed if input action generates a list of subactions.
+# Remarks
+Chain of actions can be executed if input action generates a list of
+subactions.
 
 ```ts
 type ParamsOfExecute = {
@@ -216,19 +217,18 @@ function execute_sync(
     params: ParamsOfExecute,
 ): void;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `debot_handle`: _[DebotHandle](mod\_debot.md#debothandle)_ – Debot handle which references an instance of debot engine.
+- `action`: _[DebotAction](mod\_debot.md#debotaction)_ – Debot Action that must be executed.
 
-#### Parameters
 
-* `debot_handle`: [_DebotHandle_](mod_debot.md#debothandle) – Debot handle which references an instance of debot engine.
-* `action`: [_DebotAction_](mod_debot.md#debotaction) – Debot Action that must be executed.
+## send
 
-### send
+[UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Sends message to Debot.
 
-[UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Sends message to Debot.
-
-Used by Debot Browser to send response on Dinterface call or from other Debots.
+Used by Debot Browser to send response on Dinterface call or from other
+Debots.
 
 ```ts
 type ParamsOfSend = {
@@ -244,19 +244,18 @@ function send_sync(
     params: ParamsOfSend,
 ): void;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `debot_handle`: _[DebotHandle](mod\_debot.md#debothandle)_ – Debot handle which references an instance of debot engine.
+- `message`: _string_ – BOC of internal message to debot encoded in base64 format.
 
-#### Parameters
 
-* `debot_handle`: [_DebotHandle_](mod_debot.md#debothandle) – Debot handle which references an instance of debot engine.
-* `message`: _string_ – BOC of internal message to debot encoded in base64 format.
+## remove
 
-### remove
+[UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Destroys debot handle.
 
-[UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Destroys debot handle.
-
-Removes handle from Client Context and drops debot engine referenced by that handle.
+Removes handle from Client Context and drops debot engine referenced by that
+handle.
 
 ```ts
 type ParamsOfRemove = {
@@ -271,17 +270,13 @@ function remove_sync(
     params: ParamsOfRemove,
 ): void;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `debot_handle`: _[DebotHandle](mod\_debot.md#debothandle)_ – Debot handle which references an instance of debot engine.
 
-#### Parameters
 
-* `debot_handle`: [_DebotHandle_](mod_debot.md#debothandle) – Debot handle which references an instance of debot engine.
-
-## Types
-
-### DebotErrorCode
-
+# Types
+## DebotErrorCode
 ```ts
 enum DebotErrorCode {
     DebotStartFailed = 801,
@@ -299,34 +294,33 @@ enum DebotErrorCode {
     DebotNoCode = 813
 }
 ```
-
 One of the following value:
 
-* `DebotStartFailed = 801`
-* `DebotFetchFailed = 802`
-* `DebotExecutionFailed = 803`
-* `DebotInvalidHandle = 804`
-* `DebotInvalidJsonParams = 805`
-* `DebotInvalidFunctionId = 806`
-* `DebotInvalidAbi = 807`
-* `DebotGetMethodFailed = 808`
-* `DebotInvalidMsg = 809`
-* `DebotExternalCallFailed = 810`
-* `DebotBrowserCallbackFailed = 811`
-* `DebotOperationRejected = 812`
-* `DebotNoCode = 813`
+- `DebotStartFailed = 801`
+- `DebotFetchFailed = 802`
+- `DebotExecutionFailed = 803`
+- `DebotInvalidHandle = 804`
+- `DebotInvalidJsonParams = 805`
+- `DebotInvalidFunctionId = 806`
+- `DebotInvalidAbi = 807`
+- `DebotGetMethodFailed = 808`
+- `DebotInvalidMsg = 809`
+- `DebotExternalCallFailed = 810`
+- `DebotBrowserCallbackFailed = 811`
+- `DebotOperationRejected = 812`
+- `DebotNoCode = 813`
 
-### DebotHandle
 
-[UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Handle of registered in SDK debot
+## DebotHandle
+[UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Handle of registered in SDK debot
 
 ```ts
 type DebotHandle = number
 ```
 
-### DebotAction
 
-[UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Describes a debot action in a Debot Context.
+## DebotAction
+[UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Describes a debot action in a Debot Context.
 
 ```ts
 type DebotAction = {
@@ -338,21 +332,20 @@ type DebotAction = {
     misc: string
 }
 ```
+- `description`: _string_ – A short action description.
+<br>Should be used by Debot Browser as name of menu item.
+- `name`: _string_ – Depends on action type.
+<br>Can be a debot function name or a print string (for Print Action).
+- `action_type`: _number_ – Action type.
+- `to`: _number_ – ID of debot context to switch after action execution.
+- `attributes`: _string_ – Action attributes.
+<br>In the form of "param=value,flag". attribute example: instant, args, fargs, sign.
+- `misc`: _string_ – Some internal action data.
+<br>Used by debot only.
 
-* `description`: _string_ – A short action description.\
-  Should be used by Debot Browser as name of menu item.
-* `name`: _string_ – Depends on action type.\
-  Can be a debot function name or a print string (for Print Action).
-* `action_type`: _number_ – Action type.
-* `to`: _number_ – ID of debot context to switch after action execution.
-* `attributes`: _string_ – Action attributes.\
-  In the form of "param=value,flag". attribute example: instant, args, fargs, sign.
-* `misc`: _string_ – Some internal action data.\
-  Used by debot only.
 
-### DebotInfo
-
-[UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Describes DeBot metadata.
+## DebotInfo
+[UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Describes DeBot metadata.
 
 ```ts
 type DebotInfo = {
@@ -370,22 +363,21 @@ type DebotInfo = {
     dabiVersion: string
 }
 ```
+- `name`?: _string_ – DeBot short name.
+- `version`?: _string_ – DeBot semantic version.
+- `publisher`?: _string_ – The name of DeBot deployer.
+- `caption`?: _string_ – Short info about DeBot.
+- `author`?: _string_ – The name of DeBot developer.
+- `support`?: _string_ – TON address of author for questions and donations.
+- `hello`?: _string_ – String with the first messsage from DeBot.
+- `language`?: _string_ – String with DeBot interface language (ISO-639).
+- `dabi`?: _string_ – String with DeBot ABI.
+- `icon`?: _string_ – DeBot icon.
+- `interfaces`: _string[]_ – Vector with IDs of DInterfaces used by DeBot.
+- `dabiVersion`: _string_ – ABI version ("x.y") supported by DeBot
 
-* `name`?: _string_ – DeBot short name.
-* `version`?: _string_ – DeBot semantic version.
-* `publisher`?: _string_ – The name of DeBot deployer.
-* `caption`?: _string_ – Short info about DeBot.
-* `author`?: _string_ – The name of DeBot developer.
-* `support`?: _string_ – Acki Nacki address of author for questions and donations.
-* `hello`?: _string_ – String with the first messsage from DeBot.
-* `language`?: _string_ – String with DeBot interface language (ISO-639).
-* `dabi`?: _string_ – String with DeBot ABI.
-* `icon`?: _string_ – DeBot icon.
-* `interfaces`: _string\[]_ – Vector with IDs of DInterfaces used by DeBot.
-* `dabiVersion`: _string_ – ABI version ("x.y") supported by DeBot
 
-### DebotActivityTransactionVariant
-
+## DebotActivityTransactionVariant
 DeBot wants to create new transaction in blockchain.
 
 ```ts
@@ -399,38 +391,37 @@ type DebotActivityTransactionVariant = {
     signing_box_handle: number
 }
 ```
+- `msg`: _string_ – External inbound message BOC.
+- `dst`: _string_ – Target smart contract address.
+- `out`: _[Spending](mod\_debot.md#spending)[]_ – List of spendings as a result of transaction.
+- `fee`: _bigint_ – Transaction total fee.
+- `setcode`: _boolean_ – Indicates if target smart contract updates its code.
+- `signkey`: _string_ – Public key from keypair that was used to sign external message.
+- `signing_box_handle`: _number_ – Signing box handle used to sign external message.
 
-* `msg`: _string_ – External inbound message BOC.
-* `dst`: _string_ – Target smart contract address.
-* `out`: [_Spending_](mod_debot.md#spending)_\[]_ – List of spendings as a result of transaction.
-* `fee`: _bigint_ – Transaction total fee.
-* `setcode`: _boolean_ – Indicates if target smart contract updates its code.
-* `signkey`: _string_ – Public key from keypair that was used to sign external message.
-* `signing_box_handle`: _number_ – Signing box handle used to sign external message.
 
-### DebotActivity
-
-[UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Describes the operation that the DeBot wants to perform.
+## DebotActivity
+[UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Describes the operation that the DeBot wants to perform.
 
 ```ts
 type DebotActivity = ({
     type: 'Transaction'
 } & DebotActivityTransactionVariant)
 ```
-
-Depends on value of the `type` field.
+Depends on value of the  `type` field.
 
 When _type_ is _'Transaction'_
 
 DeBot wants to create new transaction in blockchain.
 
-* `msg`: _string_ – External inbound message BOC.
-* `dst`: _string_ – Target smart contract address.
-* `out`: [_Spending_](mod_debot.md#spending)_\[]_ – List of spendings as a result of transaction.
-* `fee`: _bigint_ – Transaction total fee.
-* `setcode`: _boolean_ – Indicates if target smart contract updates its code.
-* `signkey`: _string_ – Public key from keypair that was used to sign external message.
-* `signing_box_handle`: _number_ – Signing box handle used to sign external message.
+- `msg`: _string_ – External inbound message BOC.
+- `dst`: _string_ – Target smart contract address.
+- `out`: _[Spending](mod\_debot.md#spending)[]_ – List of spendings as a result of transaction.
+- `fee`: _bigint_ – Transaction total fee.
+- `setcode`: _boolean_ – Indicates if target smart contract updates its code.
+- `signkey`: _string_ – Public key from keypair that was used to sign external message.
+- `signing_box_handle`: _number_ – Signing box handle used to sign external message.
+
 
 Variant constructors:
 
@@ -438,9 +429,8 @@ Variant constructors:
 function debotActivityTransaction(msg: string, dst: string, out: Spending[], fee: bigint, setcode: boolean, signkey: string, signing_box_handle: number): DebotActivity;
 ```
 
-### Spending
-
-[UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Describes how much funds will be debited from the target contract balance as a result of the transaction.
+## Spending
+[UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Describes how much funds will be debited from the target  contract balance as a result of the transaction.
 
 ```ts
 type Spending = {
@@ -448,25 +438,23 @@ type Spending = {
     dst: string
 }
 ```
+- `amount`: _bigint_ – Amount of nanotokens that will be sent to `dst` address.
+- `dst`: _string_ – Destination address of recipient of funds.
 
-* `amount`: _bigint_ – Amount of nanotokens that will be sent to `dst` address.
-* `dst`: _string_ – Destination address of recipient of funds.
 
-### ParamsOfInit
-
-[UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Parameters to init DeBot.
+## ParamsOfInit
+[UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Parameters to init DeBot.
 
 ```ts
 type ParamsOfInit = {
     address: string
 }
 ```
+- `address`: _string_ – Debot smart contract address
 
-* `address`: _string_ – Debot smart contract address
 
-### RegisteredDebot
-
-[UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Structure for storing debot handle returned from `init` function.
+## RegisteredDebot
+[UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Structure for storing debot handle returned from `init` function.
 
 ```ts
 type RegisteredDebot = {
@@ -475,13 +463,12 @@ type RegisteredDebot = {
     info: DebotInfo
 }
 ```
+- `debot_handle`: _[DebotHandle](mod\_debot.md#debothandle)_ – Debot handle which references an instance of debot engine.
+- `debot_abi`: _string_ – Debot abi as json string.
+- `info`: _[DebotInfo](mod\_debot.md#debotinfo)_ – Debot metadata.
 
-* `debot_handle`: [_DebotHandle_](mod_debot.md#debothandle) – Debot handle which references an instance of debot engine.
-* `debot_abi`: _string_ – Debot abi as json string.
-* `info`: [_DebotInfo_](mod_debot.md#debotinfo) – Debot metadata.
 
-### ParamsOfAppDebotBrowserLogVariant
-
+## ParamsOfAppDebotBrowserLogVariant
 Print message to user.
 
 ```ts
@@ -489,11 +476,10 @@ type ParamsOfAppDebotBrowserLogVariant = {
     msg: string
 }
 ```
+- `msg`: _string_ – A string that must be printed to user.
 
-* `msg`: _string_ – A string that must be printed to user.
 
-### ParamsOfAppDebotBrowserSwitchVariant
-
+## ParamsOfAppDebotBrowserSwitchVariant
 Switch debot to another context (menu).
 
 ```ts
@@ -501,11 +487,10 @@ type ParamsOfAppDebotBrowserSwitchVariant = {
     context_id: number
 }
 ```
+- `context_id`: _number_ – Debot context ID to which debot is switched.
 
-* `context_id`: _number_ – Debot context ID to which debot is switched.
 
-### ParamsOfAppDebotBrowserSwitchCompletedVariant
-
+## ParamsOfAppDebotBrowserSwitchCompletedVariant
 Notify browser that all context actions are shown.
 
 ```ts
@@ -514,8 +499,8 @@ type ParamsOfAppDebotBrowserSwitchCompletedVariant = {
 }
 ```
 
-### ParamsOfAppDebotBrowserShowActionVariant
 
+## ParamsOfAppDebotBrowserShowActionVariant
 Show action to the user. Called after `switch` for each action in context.
 
 ```ts
@@ -523,11 +508,10 @@ type ParamsOfAppDebotBrowserShowActionVariant = {
     action: DebotAction
 }
 ```
+- `action`: _[DebotAction](mod\_debot.md#debotaction)_ – Debot action that must be shown to user as menu item. At least `description` property must be shown from [DebotAction] structure.
 
-* `action`: [_DebotAction_](mod_debot.md#debotaction) – Debot action that must be shown to user as menu item. At least `description` property must be shown from \[DebotAction] structure.
 
-### ParamsOfAppDebotBrowserInputVariant
-
+## ParamsOfAppDebotBrowserInputVariant
 Request user input.
 
 ```ts
@@ -535,11 +519,10 @@ type ParamsOfAppDebotBrowserInputVariant = {
     prompt: string
 }
 ```
+- `prompt`: _string_ – A prompt string that must be printed to user before input request.
 
-* `prompt`: _string_ – A prompt string that must be printed to user before input request.
 
-### ParamsOfAppDebotBrowserGetSigningBoxVariant
-
+## ParamsOfAppDebotBrowserGetSigningBoxVariant
 Get signing box to sign data.
 
 Signing box returned is owned and disposed by debot engine
@@ -550,8 +533,8 @@ type ParamsOfAppDebotBrowserGetSigningBoxVariant = {
 }
 ```
 
-### ParamsOfAppDebotBrowserInvokeDebotVariant
 
+## ParamsOfAppDebotBrowserInvokeDebotVariant
 Execute action of another debot.
 
 ```ts
@@ -560,12 +543,11 @@ type ParamsOfAppDebotBrowserInvokeDebotVariant = {
     action: DebotAction
 }
 ```
+- `debot_addr`: _string_ – Address of debot in blockchain.
+- `action`: _[DebotAction](mod\_debot.md#debotaction)_ – Debot action to execute.
 
-* `debot_addr`: _string_ – Address of debot in blockchain.
-* `action`: [_DebotAction_](mod_debot.md#debotaction) – Debot action to execute.
 
-### ParamsOfAppDebotBrowserSendVariant
-
+## ParamsOfAppDebotBrowserSendVariant
 Used by Debot to call DInterface implemented by Debot Browser.
 
 ```ts
@@ -573,12 +555,11 @@ type ParamsOfAppDebotBrowserSendVariant = {
     message: string
 }
 ```
+- `message`: _string_ – Internal message to DInterface address.
+<br>Message body contains interface function and parameters.
 
-* `message`: _string_ – Internal message to DInterface address.\
-  Message body contains interface function and parameters.
 
-### ParamsOfAppDebotBrowserApproveVariant
-
+## ParamsOfAppDebotBrowserApproveVariant
 Requests permission from DeBot Browser to execute DeBot operation.
 
 ```ts
@@ -586,12 +567,11 @@ type ParamsOfAppDebotBrowserApproveVariant = {
     activity: DebotActivity
 }
 ```
+- `activity`: _[DebotActivity](mod\_debot.md#debotactivity)_ – DeBot activity details.
 
-* `activity`: [_DebotActivity_](mod_debot.md#debotactivity) – DeBot activity details.
 
-### ParamsOfAppDebotBrowser
-
-[UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Debot Browser callbacks
+## ParamsOfAppDebotBrowser
+[UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Debot Browser callbacks
 
 Called by debot engine to communicate with debot browser.
 
@@ -616,36 +596,36 @@ type ParamsOfAppDebotBrowser = ({
     type: 'Approve'
 } & ParamsOfAppDebotBrowserApproveVariant)
 ```
-
-Depends on value of the `type` field.
+Depends on value of the  `type` field.
 
 When _type_ is _'Log'_
 
 Print message to user.
 
-* `msg`: _string_ – A string that must be printed to user.
+- `msg`: _string_ – A string that must be printed to user.
 
 When _type_ is _'Switch'_
 
 Switch debot to another context (menu).
 
-* `context_id`: _number_ – Debot context ID to which debot is switched.
+- `context_id`: _number_ – Debot context ID to which debot is switched.
 
 When _type_ is _'SwitchCompleted'_
 
 Notify browser that all context actions are shown.
 
+
 When _type_ is _'ShowAction'_
 
 Show action to the user. Called after `switch` for each action in context.
 
-* `action`: [_DebotAction_](mod_debot.md#debotaction) – Debot action that must be shown to user as menu item. At least `description` property must be shown from \[DebotAction] structure.
+- `action`: _[DebotAction](mod\_debot.md#debotaction)_ – Debot action that must be shown to user as menu item. At least `description` property must be shown from [DebotAction] structure.
 
 When _type_ is _'Input'_
 
 Request user input.
 
-* `prompt`: _string_ – A prompt string that must be printed to user before input request.
+- `prompt`: _string_ – A prompt string that must be printed to user before input request.
 
 When _type_ is _'GetSigningBox'_
 
@@ -653,25 +633,27 @@ Get signing box to sign data.
 
 Signing box returned is owned and disposed by debot engine
 
+
 When _type_ is _'InvokeDebot'_
 
 Execute action of another debot.
 
-* `debot_addr`: _string_ – Address of debot in blockchain.
-* `action`: [_DebotAction_](mod_debot.md#debotaction) – Debot action to execute.
+- `debot_addr`: _string_ – Address of debot in blockchain.
+- `action`: _[DebotAction](mod\_debot.md#debotaction)_ – Debot action to execute.
 
 When _type_ is _'Send'_
 
 Used by Debot to call DInterface implemented by Debot Browser.
 
-* `message`: _string_ – Internal message to DInterface address.\
-  Message body contains interface function and parameters.
+- `message`: _string_ – Internal message to DInterface address.
+<br>Message body contains interface function and parameters.
 
 When _type_ is _'Approve'_
 
 Requests permission from DeBot Browser to execute DeBot operation.
 
-* `activity`: [_DebotActivity_](mod_debot.md#debotactivity) – DeBot activity details.
+- `activity`: _[DebotActivity](mod\_debot.md#debotactivity)_ – DeBot activity details.
+
 
 Variant constructors:
 
@@ -687,8 +669,7 @@ function paramsOfAppDebotBrowserSend(message: string): ParamsOfAppDebotBrowser;
 function paramsOfAppDebotBrowserApprove(activity: DebotActivity): ParamsOfAppDebotBrowser;
 ```
 
-### ResultOfAppDebotBrowserInputVariant
-
+## ResultOfAppDebotBrowserInputVariant
 Result of user input.
 
 ```ts
@@ -696,11 +677,10 @@ type ResultOfAppDebotBrowserInputVariant = {
     value: string
 }
 ```
+- `value`: _string_ – String entered by user.
 
-* `value`: _string_ – String entered by user.
 
-### ResultOfAppDebotBrowserGetSigningBoxVariant
-
+## ResultOfAppDebotBrowserGetSigningBoxVariant
 Result of getting signing box.
 
 ```ts
@@ -708,12 +688,11 @@ type ResultOfAppDebotBrowserGetSigningBoxVariant = {
     signing_box: SigningBoxHandle
 }
 ```
+- `signing_box`: _[SigningBoxHandle](mod\_crypto.md#signingboxhandle)_ – Signing box for signing data requested by debot engine.
+<br>Signing box is owned and disposed by debot engine
 
-* `signing_box`: [_SigningBoxHandle_](/broken/pages/b7U0dxs59ESc6rtN09mV#signingboxhandle) – Signing box for signing data requested by debot engine.\
-  Signing box is owned and disposed by debot engine
 
-### ResultOfAppDebotBrowserInvokeDebotVariant
-
+## ResultOfAppDebotBrowserInvokeDebotVariant
 Result of debot invoking.
 
 ```ts
@@ -722,8 +701,8 @@ type ResultOfAppDebotBrowserInvokeDebotVariant = {
 }
 ```
 
-### ResultOfAppDebotBrowserApproveVariant
 
+## ResultOfAppDebotBrowserApproveVariant
 Result of `approve` callback.
 
 ```ts
@@ -731,12 +710,11 @@ type ResultOfAppDebotBrowserApproveVariant = {
     approved: boolean
 }
 ```
+- `approved`: _boolean_ – Indicates whether the DeBot is allowed to perform the specified operation.
 
-* `approved`: _boolean_ – Indicates whether the DeBot is allowed to perform the specified operation.
 
-### ResultOfAppDebotBrowser
-
-[UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Returning values from Debot Browser callbacks.
+## ResultOfAppDebotBrowser
+[UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Returning values from Debot Browser callbacks.
 
 ```ts
 type ResultOfAppDebotBrowser = ({
@@ -749,31 +727,32 @@ type ResultOfAppDebotBrowser = ({
     type: 'Approve'
 } & ResultOfAppDebotBrowserApproveVariant)
 ```
-
-Depends on value of the `type` field.
+Depends on value of the  `type` field.
 
 When _type_ is _'Input'_
 
 Result of user input.
 
-* `value`: _string_ – String entered by user.
+- `value`: _string_ – String entered by user.
 
 When _type_ is _'GetSigningBox'_
 
 Result of getting signing box.
 
-* `signing_box`: [_SigningBoxHandle_](/broken/pages/b7U0dxs59ESc6rtN09mV#signingboxhandle) – Signing box for signing data requested by debot engine.\
-  Signing box is owned and disposed by debot engine
+- `signing_box`: _[SigningBoxHandle](mod\_crypto.md#signingboxhandle)_ – Signing box for signing data requested by debot engine.
+<br>Signing box is owned and disposed by debot engine
 
 When _type_ is _'InvokeDebot'_
 
 Result of debot invoking.
 
+
 When _type_ is _'Approve'_
 
 Result of `approve` callback.
 
-* `approved`: _boolean_ – Indicates whether the DeBot is allowed to perform the specified operation.
+- `approved`: _boolean_ – Indicates whether the DeBot is allowed to perform the specified operation.
+
 
 Variant constructors:
 
@@ -784,45 +763,43 @@ function resultOfAppDebotBrowserInvokeDebot(): ResultOfAppDebotBrowser;
 function resultOfAppDebotBrowserApprove(approved: boolean): ResultOfAppDebotBrowser;
 ```
 
-### ParamsOfStart
+## ParamsOfStart
+[UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Parameters to start DeBot.
 
-[UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Parameters to start DeBot. DeBot must be already initialized with init() function.
+DeBot must be already initialized with init() function.
 
 ```ts
 type ParamsOfStart = {
     debot_handle: DebotHandle
 }
 ```
+- `debot_handle`: _[DebotHandle](mod\_debot.md#debothandle)_ – Debot handle which references an instance of debot engine.
 
-* `debot_handle`: [_DebotHandle_](mod_debot.md#debothandle) – Debot handle which references an instance of debot engine.
 
-### ParamsOfFetch
-
-[UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Parameters to fetch DeBot metadata.
+## ParamsOfFetch
+[UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Parameters to fetch DeBot metadata.
 
 ```ts
 type ParamsOfFetch = {
     address: string
 }
 ```
+- `address`: _string_ – Debot smart contract address.
 
-* `address`: _string_ – Debot smart contract address.
 
-### ResultOfFetch
-
-[UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md)
+## ResultOfFetch
+[UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md)
 
 ```ts
 type ResultOfFetch = {
     info: DebotInfo
 }
 ```
+- `info`: _[DebotInfo](mod\_debot.md#debotinfo)_ – Debot metadata.
 
-* `info`: [_DebotInfo_](mod_debot.md#debotinfo) – Debot metadata.
 
-### ParamsOfExecute
-
-[UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Parameters for executing debot action.
+## ParamsOfExecute
+[UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Parameters for executing debot action.
 
 ```ts
 type ParamsOfExecute = {
@@ -830,13 +807,12 @@ type ParamsOfExecute = {
     action: DebotAction
 }
 ```
+- `debot_handle`: _[DebotHandle](mod\_debot.md#debothandle)_ – Debot handle which references an instance of debot engine.
+- `action`: _[DebotAction](mod\_debot.md#debotaction)_ – Debot Action that must be executed.
 
-* `debot_handle`: [_DebotHandle_](mod_debot.md#debothandle) – Debot handle which references an instance of debot engine.
-* `action`: [_DebotAction_](mod_debot.md#debotaction) – Debot Action that must be executed.
 
-### ParamsOfSend
-
-[UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Parameters of `send` function.
+## ParamsOfSend
+[UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Parameters of `send` function.
 
 ```ts
 type ParamsOfSend = {
@@ -844,27 +820,26 @@ type ParamsOfSend = {
     message: string
 }
 ```
+- `debot_handle`: _[DebotHandle](mod\_debot.md#debothandle)_ – Debot handle which references an instance of debot engine.
+- `message`: _string_ – BOC of internal message to debot encoded in base64 format.
 
-* `debot_handle`: [_DebotHandle_](mod_debot.md#debothandle) – Debot handle which references an instance of debot engine.
-* `message`: _string_ – BOC of internal message to debot encoded in base64 format.
 
-### ParamsOfRemove
-
-[UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md)
+## ParamsOfRemove
+[UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md)
 
 ```ts
 type ParamsOfRemove = {
     debot_handle: DebotHandle
 }
 ```
+- `debot_handle`: _[DebotHandle](mod\_debot.md#debothandle)_ – Debot handle which references an instance of debot engine.
 
-* `debot_handle`: [_DebotHandle_](mod_debot.md#debothandle) – Debot handle which references an instance of debot engine.
 
-### AppDebotBrowser
-
-[UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Debot Browser callbacks
+## AppDebotBrowser
+[UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Debot Browser callbacks
 
 Called by debot engine to communicate with debot browser.
+
 
 ```ts
 
@@ -881,7 +856,7 @@ export interface AppDebotBrowser {
 }
 ```
 
-### log
+## log
 
 Print message to user.
 
@@ -896,14 +871,12 @@ function log_sync(
     params: ParamsOfAppDebotBrowserLogVariant,
 ): ;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `msg`: _string_ – A string that must be printed to user.
 
-#### Parameters
 
-* `msg`: _string_ – A string that must be printed to user.
-
-### switch
+## switch
 
 Switch debot to another context (menu).
 
@@ -918,14 +891,12 @@ function switch_sync(
     params: ParamsOfAppDebotBrowserSwitchVariant,
 ): ;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `context_id`: _number_ – Debot context ID to which debot is switched.
 
-#### Parameters
 
-* `context_id`: _number_ – Debot context ID to which debot is switched.
-
-### switch\_completed
+## switch_completed
 
 Notify browser that all context actions are shown.
 
@@ -934,10 +905,10 @@ function switch_completed(): Promise<>;
 
 function switch_completed_sync(): ;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
 
-### show\_action
+
+## show_action
 
 Show action to the user. Called after `switch` for each action in context.
 
@@ -952,14 +923,12 @@ function show_action_sync(
     params: ParamsOfAppDebotBrowserShowActionVariant,
 ): ;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `action`: _[DebotAction](mod\_debot.md#debotaction)_ – Debot action that must be shown to user as menu item. At least `description` property must be shown from [DebotAction] structure.
 
-#### Parameters
 
-* `action`: [_DebotAction_](mod_debot.md#debotaction) – Debot action that must be shown to user as menu item. At least `description` property must be shown from \[DebotAction] structure.
-
-### input
+## input
 
 Request user input.
 
@@ -976,18 +945,17 @@ function input_sync(
     params: ParamsOfAppDebotBrowserInputVariant,
 ): ResultOfAppDebotBrowserInputVariant;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `prompt`: _string_ – A prompt string that must be printed to user before input request.
 
-#### Parameters
 
-* `prompt`: _string_ – A prompt string that must be printed to user before input request.
+### Result
 
-#### Result
+- `value`: _string_ – String entered by user.
 
-* `value`: _string_ – String entered by user.
 
-### get\_signing\_box
+## get_signing_box
 
 Get signing box to sign data.
 
@@ -1000,15 +968,16 @@ function get_signing_box(): Promise<ResultOfAppDebotBrowserGetSigningBoxVariant>
 
 function get_signing_box_sync(): ResultOfAppDebotBrowserGetSigningBoxVariant;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
 
-#### Result
 
-* `signing_box`: [_SigningBoxHandle_](/broken/pages/b7U0dxs59ESc6rtN09mV#signingboxhandle) – Signing box for signing data requested by debot engine.\
-  Signing box is owned and disposed by debot engine
+### Result
 
-### invoke\_debot
+- `signing_box`: _[SigningBoxHandle](mod\_crypto.md#signingboxhandle)_ – Signing box for signing data requested by debot engine.
+<br>Signing box is owned and disposed by debot engine
+
+
+## invoke_debot
 
 Execute action of another debot.
 
@@ -1023,15 +992,13 @@ function invoke_debot_sync(
     params: ParamsOfAppDebotBrowserInvokeDebotVariant,
 ): void;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `debot_addr`: _string_ – Address of debot in blockchain.
+- `action`: _[DebotAction](mod\_debot.md#debotaction)_ – Debot action to execute.
 
-#### Parameters
 
-* `debot_addr`: _string_ – Address of debot in blockchain.
-* `action`: [_DebotAction_](mod_debot.md#debotaction) – Debot action to execute.
-
-### send
+## send
 
 Used by Debot to call DInterface implemented by Debot Browser.
 
@@ -1046,15 +1013,13 @@ function send_sync(
     params: ParamsOfAppDebotBrowserSendVariant,
 ): ;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `message`: _string_ – Internal message to DInterface address.
+<br>Message body contains interface function and parameters.
 
-#### Parameters
 
-* `message`: _string_ – Internal message to DInterface address.\
-  Message body contains interface function and parameters.
-
-### approve
+## approve
 
 Requests permission from DeBot Browser to execute DeBot operation.
 
@@ -1071,13 +1036,13 @@ function approve_sync(
     params: ParamsOfAppDebotBrowserApproveVariant,
 ): ResultOfAppDebotBrowserApproveVariant;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `activity`: _[DebotActivity](mod\_debot.md#debotactivity)_ – DeBot activity details.
 
-#### Parameters
 
-* `activity`: [_DebotActivity_](mod_debot.md#debotactivity) – DeBot activity details.
+### Result
 
-#### Result
+- `approved`: _boolean_ – Indicates whether the DeBot is allowed to perform the specified operation.
 
-* `approved`: _boolean_ – Indicates whether the DeBot is allowed to perform the specified operation.
+

--- a/docs/acki-nacki-sdk/types-and-methods/mod_net.md
+++ b/docs/acki-nacki-sdk/types-and-methods/mod_net.md
@@ -1,134 +1,131 @@
 # Module net
 
-## Module net
-
 Network access.
 
-### Functions
-
-[query](mod_net.md#query) – Performs DAppServer GraphQL query.
-
-[batch\_query](mod_net.md#batch_query) – Performs multiple queries per single fetch.
-
-[query\_collection](mod_net.md#query_collection) – Queries collection data
-
-[aggregate\_collection](mod_net.md#aggregate_collection) – Aggregates collection data.
-
-[wait\_for\_collection](mod_net.md#wait_for_collection) – Returns an object that fulfills the conditions or waits for its appearance
-
-[unsubscribe](mod_net.md#unsubscribe) – Cancels a subscription
-
-[subscribe\_collection](mod_net.md#subscribe_collection) – Creates a collection subscription
-
-[subscribe](mod_net.md#subscribe) – Creates a subscription
-
-[suspend](mod_net.md#suspend) – Suspends network module to stop any network activity
-
-[resume](mod_net.md#resume) – Resumes network module to enable network activity
-
-[find\_last\_shard\_block](mod_net.md#find_last_shard_block) – Returns ID of the last block in a specified account shard
-
-[fetch\_endpoints](mod_net.md#fetch_endpoints) – Requests the list of alternative endpoints from server
-
-[set\_endpoints](mod_net.md#set_endpoints) – Sets the list of endpoints to use on reinit
-
-[get\_endpoints](mod_net.md#get_endpoints) – Requests the list of alternative endpoints from server
-
-[query\_counterparties](mod_net.md#query_counterparties) – Allows to query and paginate through the list of accounts that the specified account has interacted with, sorted by the time of the last internal message between accounts
-
-[query\_transaction\_tree](mod_net.md#query_transaction_tree) – Returns a tree of transactions triggered by a specific message.
-
-[create\_block\_iterator](mod_net.md#create_block_iterator) – Creates block iterator.
-
-[resume\_block\_iterator](mod_net.md#resume_block_iterator) – Resumes block iterator.
-
-[create\_transaction\_iterator](mod_net.md#create_transaction_iterator) – Creates transaction iterator.
-
-[resume\_transaction\_iterator](mod_net.md#resume_transaction_iterator) – Resumes transaction iterator.
-
-[iterator\_next](mod_net.md#iterator_next) – Returns next available items.
-
-[remove\_iterator](mod_net.md#remove_iterator) – Removes an iterator
-
-[get\_signature\_id](mod_net.md#get_signature_id) – Returns signature ID for configured network if it should be used in messages signature
-
-### Types
-
-[NetErrorCode](mod_net.md#neterrorcode)
-
-[OrderBy](mod_net.md#orderby)
-
-[SortDirection](mod_net.md#sortdirection)
-
-[ParamsOfQueryOperation](mod_net.md#paramsofqueryoperation)
-
-[FieldAggregation](mod_net.md#fieldaggregation)
-
-[AggregationFn](mod_net.md#aggregationfn)
-
-[TransactionNode](mod_net.md#transactionnode)
-
-[MessageNode](mod_net.md#messagenode)
-
-[ParamsOfQuery](mod_net.md#paramsofquery)
-
-[ResultOfQuery](mod_net.md#resultofquery)
-
-[ParamsOfBatchQuery](mod_net.md#paramsofbatchquery)
-
-[ResultOfBatchQuery](mod_net.md#resultofbatchquery)
-
-[ParamsOfQueryCollection](mod_net.md#paramsofquerycollection)
-
-[ResultOfQueryCollection](mod_net.md#resultofquerycollection)
-
-[ParamsOfAggregateCollection](mod_net.md#paramsofaggregatecollection)
-
-[ResultOfAggregateCollection](mod_net.md#resultofaggregatecollection)
-
-[ParamsOfWaitForCollection](mod_net.md#paramsofwaitforcollection)
-
-[ResultOfWaitForCollection](mod_net.md#resultofwaitforcollection)
-
-[ResultOfSubscribeCollection](mod_net.md#resultofsubscribecollection)
-
-[ParamsOfSubscribeCollection](mod_net.md#paramsofsubscribecollection)
-
-[ParamsOfSubscribe](mod_net.md#paramsofsubscribe)
-
-[ParamsOfFindLastShardBlock](mod_net.md#paramsoffindlastshardblock)
-
-[ResultOfFindLastShardBlock](mod_net.md#resultoffindlastshardblock)
-
-[EndpointsSet](mod_net.md#endpointsset)
-
-[ResultOfGetEndpoints](mod_net.md#resultofgetendpoints)
-
-[ParamsOfQueryCounterparties](mod_net.md#paramsofquerycounterparties)
-
-[ParamsOfQueryTransactionTree](mod_net.md#paramsofquerytransactiontree)
-
-[ResultOfQueryTransactionTree](mod_net.md#resultofquerytransactiontree)
-
-[ParamsOfCreateBlockIterator](mod_net.md#paramsofcreateblockiterator)
-
-[RegisteredIterator](mod_net.md#registerediterator)
-
-[ParamsOfResumeBlockIterator](mod_net.md#paramsofresumeblockiterator)
-
-[ParamsOfCreateTransactionIterator](mod_net.md#paramsofcreatetransactioniterator)
-
-[ParamsOfResumeTransactionIterator](mod_net.md#paramsofresumetransactioniterator)
-
-[ParamsOfIteratorNext](mod_net.md#paramsofiteratornext)
-
-[ResultOfIteratorNext](mod_net.md#resultofiteratornext)
-
-[ResultOfGetSignatureId](mod_net.md#resultofgetsignatureid)
 
 ## Functions
+[query](mod\_net.md#query) – Performs DAppServer GraphQL query.
 
-### query
+[batch_query](mod\_net.md#batch_query) – Performs multiple queries per single fetch.
+
+[query_collection](mod\_net.md#query_collection) – Queries collection data
+
+[aggregate_collection](mod\_net.md#aggregate_collection) – Aggregates collection data.
+
+[wait_for_collection](mod\_net.md#wait_for_collection) – Returns an object that fulfills the conditions or waits for its appearance
+
+[unsubscribe](mod\_net.md#unsubscribe) – Cancels a subscription
+
+[subscribe_collection](mod\_net.md#subscribe_collection) – Creates a collection subscription
+
+[subscribe](mod\_net.md#subscribe) – Creates a subscription (Deprecated)
+
+[suspend](mod\_net.md#suspend) – Suspends network module to stop any network activity
+
+[resume](mod\_net.md#resume) – Resumes network module to enable network activity
+
+[find_last_shard_block](mod\_net.md#find_last_shard_block) – Returns ID of the last block in a specified account shard
+
+[fetch_endpoints](mod\_net.md#fetch_endpoints) – Requests the list of alternative endpoints from server
+
+[set_endpoints](mod\_net.md#set_endpoints) – Sets the list of endpoints to use on reinit
+
+[get_endpoints](mod\_net.md#get_endpoints) – Requests the list of alternative endpoints from server
+
+[query_counterparties](mod\_net.md#query_counterparties) – Allows to query and paginate through the list of accounts that the specified account has interacted with, sorted by the time of the last internal message between accounts
+
+[query_transaction_tree](mod\_net.md#query_transaction_tree) – Returns a tree of transactions triggered by a specific message.
+
+[create_block_iterator](mod\_net.md#create_block_iterator) – Creates block iterator.
+
+[resume_block_iterator](mod\_net.md#resume_block_iterator) – Resumes block iterator.
+
+[create_transaction_iterator](mod\_net.md#create_transaction_iterator) – Creates transaction iterator.
+
+[resume_transaction_iterator](mod\_net.md#resume_transaction_iterator) – Resumes transaction iterator.
+
+[iterator_next](mod\_net.md#iterator_next) – Returns next available items.
+
+[remove_iterator](mod\_net.md#remove_iterator) – Removes an iterator
+
+[get_signature_id](mod\_net.md#get_signature_id) – Returns signature ID for configured network if it should be used in messages signature
+
+## Types
+[NetErrorCode](mod\_net.md#neterrorcode)
+
+[OrderBy](mod\_net.md#orderby)
+
+[SortDirection](mod\_net.md#sortdirection)
+
+[ParamsOfQueryOperation](mod\_net.md#paramsofqueryoperation)
+
+[FieldAggregation](mod\_net.md#fieldaggregation)
+
+[AggregationFn](mod\_net.md#aggregationfn)
+
+[TransactionNode](mod\_net.md#transactionnode)
+
+[MessageNode](mod\_net.md#messagenode)
+
+[ParamsOfQuery](mod\_net.md#paramsofquery)
+
+[ResultOfQuery](mod\_net.md#resultofquery)
+
+[ParamsOfBatchQuery](mod\_net.md#paramsofbatchquery)
+
+[ResultOfBatchQuery](mod\_net.md#resultofbatchquery)
+
+[ParamsOfQueryCollection](mod\_net.md#paramsofquerycollection)
+
+[ResultOfQueryCollection](mod\_net.md#resultofquerycollection)
+
+[ParamsOfAggregateCollection](mod\_net.md#paramsofaggregatecollection)
+
+[ResultOfAggregateCollection](mod\_net.md#resultofaggregatecollection)
+
+[ParamsOfWaitForCollection](mod\_net.md#paramsofwaitforcollection)
+
+[ResultOfWaitForCollection](mod\_net.md#resultofwaitforcollection)
+
+[ResultOfSubscribeCollection](mod\_net.md#resultofsubscribecollection)
+
+[ParamsOfSubscribeCollection](mod\_net.md#paramsofsubscribecollection)
+
+[ParamsOfSubscribe](mod\_net.md#paramsofsubscribe)
+
+[ParamsOfFindLastShardBlock](mod\_net.md#paramsoffindlastshardblock)
+
+[ResultOfFindLastShardBlock](mod\_net.md#resultoffindlastshardblock)
+
+[EndpointsSet](mod\_net.md#endpointsset)
+
+[ResultOfGetEndpoints](mod\_net.md#resultofgetendpoints)
+
+[ParamsOfQueryCounterparties](mod\_net.md#paramsofquerycounterparties)
+
+[ParamsOfQueryTransactionTree](mod\_net.md#paramsofquerytransactiontree)
+
+[ResultOfQueryTransactionTree](mod\_net.md#resultofquerytransactiontree)
+
+[ParamsOfCreateBlockIterator](mod\_net.md#paramsofcreateblockiterator)
+
+[RegisteredIterator](mod\_net.md#registerediterator)
+
+[ParamsOfResumeBlockIterator](mod\_net.md#paramsofresumeblockiterator)
+
+[ParamsOfCreateTransactionIterator](mod\_net.md#paramsofcreatetransactioniterator)
+
+[ParamsOfResumeTransactionIterator](mod\_net.md#paramsofresumetransactioniterator)
+
+[ParamsOfIteratorNext](mod\_net.md#paramsofiteratornext)
+
+[ResultOfIteratorNext](mod\_net.md#resultofiteratornext)
+
+[ResultOfGetSignatureId](mod\_net.md#resultofgetsignatureid)
+
+
+# Functions
+## query
 
 Performs DAppServer GraphQL query.
 
@@ -150,20 +147,19 @@ function query_sync(
     params: ParamsOfQuery,
 ): ResultOfQuery;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `query`: _string_ – GraphQL query text.
+- `variables`?: _any_ – Variables used in query.
+<br>Must be a map with named values that can be used in query.
 
-#### Parameters
 
-* `query`: _string_ – GraphQL query text.
-* `variables`?: _any_ – Variables used in query.\
-  Must be a map with named values that can be used in query.
+### Result
 
-#### Result
+- `result`: _any_ – Result provided by DAppServer.
 
-* `result`: _any_ – Result provided by DAppServer.
 
-### batch\_query
+## batch_query
 
 Performs multiple queries per single fetch.
 
@@ -184,23 +180,24 @@ function batch_query_sync(
     params: ParamsOfBatchQuery,
 ): ResultOfBatchQuery;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `operations`: _[ParamsOfQueryOperation](mod\_net.md#paramsofqueryoperation)[]_ – List of query operations that must be performed per single fetch.
 
-#### Parameters
 
-* `operations`: [_ParamsOfQueryOperation_](mod_net.md#paramsofqueryoperation)_\[]_ – List of query operations that must be performed per single fetch.
+### Result
 
-#### Result
+- `results`: _any[]_ – Result values for batched queries.
+<br>Returns an array of values. Each value corresponds to `queries` item.
 
-* `results`: _any\[]_ – Result values for batched queries.\
-  Returns an array of values. Each value corresponds to `queries` item.
 
-### query\_collection
+## query_collection
 
 Queries collection data
 
-Queries data that satisfies the `filter` conditions, limits the number of returned records and orders them. The projection fields are limited to `result` fields
+Queries data that satisfies the `filter` conditions,
+limits the number of returned records and orders them.
+The projection fields are limited to `result` fields
 
 ```ts
 type ParamsOfQueryCollection = {
@@ -223,26 +220,26 @@ function query_collection_sync(
     params: ParamsOfQueryCollection,
 ): ResultOfQueryCollection;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `collection`: _string_ – Collection name (accounts, blocks, transactions, messages, block_signatures)
+- `filter`?: _any_ – Collection filter
+- `result`: _string_ – Projection (result) string
+- `order`?: _[OrderBy](mod\_net.md#orderby)[]_ – Sorting order
+- `limit`?: _number_ – Number of documents to return
 
-#### Parameters
 
-* `collection`: _string_ – Collection name (accounts, blocks, transactions, messages, block\_signatures)
-* `filter`?: _any_ – Collection filter
-* `result`: _string_ – Projection (result) string
-* `order`?: [_OrderBy_](mod_net.md#orderby)_\[]_ – Sorting order
-* `limit`?: _number_ – Number of documents to return
+### Result
 
-#### Result
+- `result`: _any[]_ – Objects that match the provided criteria
 
-* `result`: _any\[]_ – Objects that match the provided criteria
 
-### aggregate\_collection
+## aggregate_collection
 
 Aggregates collection data.
 
-Aggregates values from the specified `fields` for records that satisfies the `filter` conditions,
+Aggregates values from the specified `fields` for records
+that satisfies the `filter` conditions,
 
 ```ts
 type ParamsOfAggregateCollection = {
@@ -263,26 +260,29 @@ function aggregate_collection_sync(
     params: ParamsOfAggregateCollection,
 ): ResultOfAggregateCollection;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `collection`: _string_ – Collection name (accounts, blocks, transactions, messages, block_signatures)
+- `filter`?: _any_ – Collection filter
+- `fields`?: _[FieldAggregation](mod\_net.md#fieldaggregation)[]_ – Projection (result) string
 
-#### Parameters
 
-* `collection`: _string_ – Collection name (accounts, blocks, transactions, messages, block\_signatures)
-* `filter`?: _any_ – Collection filter
-* `fields`?: [_FieldAggregation_](mod_net.md#fieldaggregation)_\[]_ – Projection (result) string
+### Result
 
-#### Result
+- `values`: _any_ – Values for requested fields.
+<br>Returns an array of strings. Each string refers to the corresponding<br>`fields` item. Numeric value is returned as a decimal string<br>representations.
 
-* `values`: _any_ – Values for requested fields.\
-  Returns an array of strings. Each string refers to the corresponding `fields` item.\
-  Numeric value is returned as a decimal string representations.
 
-### wait\_for\_collection
+## wait_for_collection
 
 Returns an object that fulfills the conditions or waits for its appearance
 
-Triggers only once. If object that satisfies the `filter` conditions already exists - returns it immediately. If not - waits for insert/update of data within the specified `timeout`, and returns it. The projection fields are limited to `result` fields
+Triggers only once.
+If object that satisfies the `filter` conditions
+already exists - returns it immediately.
+If not - waits for insert/update of data within the specified `timeout`,
+and returns it.
+The projection fields are limited to `result` fields
 
 ```ts
 type ParamsOfWaitForCollection = {
@@ -304,21 +304,20 @@ function wait_for_collection_sync(
     params: ParamsOfWaitForCollection,
 ): ResultOfWaitForCollection;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `collection`: _string_ – Collection name (accounts, blocks, transactions, messages, block_signatures)
+- `filter`?: _any_ – Collection filter
+- `result`: _string_ – Projection (result) string
+- `timeout`?: _number_ – Query timeout
 
-#### Parameters
 
-* `collection`: _string_ – Collection name (accounts, blocks, transactions, messages, block\_signatures)
-* `filter`?: _any_ – Collection filter
-* `result`: _string_ – Projection (result) string
-* `timeout`?: _number_ – Query timeout
+### Result
 
-#### Result
+- `result`: _any_ – First found object that matches the provided criteria
 
-* `result`: _any_ – First found object that matches the provided criteria
 
-### unsubscribe
+## unsubscribe
 
 Cancels a subscription
 
@@ -337,40 +336,56 @@ function unsubscribe_sync(
     params: ResultOfSubscribeCollection,
 ): void;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `handle`: _number_ – Subscription handle.
+<br>Must be closed with `unsubscribe`
 
-#### Parameters
 
-* `handle`: _number_ – Subscription handle.\
-  Must be closed with `unsubscribe`
-
-### subscribe\_collection
+## subscribe_collection
 
 Creates a collection subscription
 
-Triggers for each insert/update of data that satisfies the `filter` conditions. The projection fields are limited to `result` fields.
+Triggers for each insert/update of data that satisfies
+the `filter` conditions.
+The projection fields are limited to `result` fields.
 
-The subscription is a persistent communication channel between client and Acki Nacki Network. All changes in the blockchain will be reflected in realtime. Changes means inserts and updates of the blockchain entities.
+The subscription is a persistent communication channel between
+client and Free TON Network.
+All changes in the blockchain will be reflected in realtime.
+Changes means inserts and updates of the blockchain entities.
 
-#### Important Notes on Subscriptions
+### Important Notes on Subscriptions
 
-Unfortunately sometimes the connection with the network brakes down. In this situation the library attempts to reconnect to the network. This reconnection sequence can take significant time. All of this time the client is disconnected from the network.
+Unfortunately sometimes the connection with the network brakes down.
+In this situation the library attempts to reconnect to the network.
+This reconnection sequence can take significant time.
+All of this time the client is disconnected from the network.
 
-Bad news is that all blockchain changes that happened while the client was disconnected are lost.
+Bad news is that all blockchain changes that happened while
+the client was disconnected are lost.
 
-Good news is that the client report errors to the callback when it loses and resumes connection.
+Good news is that the client report errors to the callback when
+it loses and resumes connection.
 
-So, if the lost changes are important to the application then the application must handle these error reports.
+So, if the lost changes are important to the application then
+the application must handle these error reports.
 
-Library reports errors with `responseType` == 101 and the error object passed via `params`.
+Library reports errors with `responseType` == 101
+and the error object passed via `params`.
 
-When the library has successfully reconnected the application receives callback with `responseType` == 101 and `params.code` == 614 (NetworkModuleResumed).
+When the library has successfully reconnected
+the application receives callback with
+`responseType` == 101 and `params.code` == 614 (NetworkModuleResumed).
 
 Application can use several ways to handle this situation:
-
-* If application monitors changes for the single blockchain object (for example specific account): application can perform a query for this object and handle actual data as a regular data from the subscription.
-* If application monitors sequence of some blockchain objects (for example transactions of the specific account): application must refresh all cached (or visible to user) lists where this sequences presents.
+- If application monitors changes for the single blockchain
+object (for example specific account):  application
+can perform a query for this object and handle actual data as a
+regular data from the subscription.
+- If application monitors sequence of some blockchain objects
+(for example transactions of the specific account): application must
+refresh all cached (or visible to user) lists where this sequences presents.
 
 ```ts
 type ParamsOfSubscribeCollection = {
@@ -392,45 +407,57 @@ function subscribe_collection_sync(
     params: ParamsOfSubscribeCollection,
 ): ResultOfSubscribeCollection;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `collection`: _string_ – Collection name (accounts, blocks, transactions, messages, block_signatures)
+- `filter`?: _any_ – Collection filter
+- `result`: _string_ – Projection (result) string
+- `responseHandler`?: _[ResponseHandler](modules.md#responsehandler)_ – additional responses handler.
 
-#### Parameters
+### Result
 
-* `collection`: _string_ – Collection name (accounts, blocks, transactions, messages, block\_signatures)
-* `filter`?: _any_ – Collection filter
-* `result`: _string_ – Projection (result) string
-* `responseHandler`?: [_ResponseHandler_](modules.md#responsehandler) – additional responses handler.
+- `handle`: _number_ – Subscription handle.
+<br>Must be closed with `unsubscribe`
 
-#### Result
 
-* `handle`: _number_ – Subscription handle.\
-  Must be closed with `unsubscribe`
+## subscribe
 
-### subscribe
+Creates a subscription (Deprecated)
 
-Creates a subscription
+The subscription is a persistent communication channel between
+client and Acki Nacki Network.
 
-The subscription is a persistent communication channel between client and Acki Nacki Network.
+### Important Notes on Subscriptions
 
-#### Important Notes on Subscriptions
+Unfortunately sometimes the connection with the network breaks down.
+In this situation the library attempts to reconnect to the network.
+This reconnection sequence can take significant time.
+All of this time the client is disconnected from the network.
 
-Unfortunately sometimes the connection with the network breaks down. In this situation the library attempts to reconnect to the network. This reconnection sequence can take significant time. All of this time the client is disconnected from the network.
+Bad news is that all changes that happened while
+the client was disconnected are lost.
 
-Bad news is that all changes that happened while the client was disconnected are lost.
+Good news is that the client report errors to the callback when
+it loses and resumes connection.
 
-Good news is that the client report errors to the callback when it loses and resumes connection.
+So, if the lost changes are important to the application then
+the application must handle these error reports.
 
-So, if the lost changes are important to the application then the application must handle these error reports.
+Library reports errors with `responseType` == 101
+and the error object passed via `params`.
 
-Library reports errors with `responseType` == 101 and the error object passed via `params`.
-
-When the library has successfully reconnected the application receives callback with `responseType` == 101 and `params.code` == 614 (NetworkModuleResumed).
+When the library has successfully reconnected
+the application receives callback with
+`responseType` == 101 and `params.code` == 614 (NetworkModuleResumed).
 
 Application can use several ways to handle this situation:
-
-* If application monitors changes for the single object (for example specific account): application can perform a query for this object and handle actual data as a regular data from the subscription.
-* If application monitors sequence of some objects (for example transactions of the specific account): application must refresh all cached (or visible to user) lists where this sequences presents.
+- If application monitors changes for the single
+object (for example specific account):  application
+can perform a query for this object and handle actual data as a
+regular data from the subscription.
+- If application monitors sequence of some objects
+(for example transactions of the specific account): application must
+refresh all cached (or visible to user) lists where this sequences presents.
 
 ```ts
 type ParamsOfSubscribe = {
@@ -451,22 +478,20 @@ function subscribe_sync(
     params: ParamsOfSubscribe,
 ): ResultOfSubscribeCollection;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `subscription`: _string_ – GraphQL subscription text.
+- `variables`?: _any_ – Variables used in subscription.
+<br>Must be a map with named values that can be used in query.
+- `responseHandler`?: _[ResponseHandler](modules.md#responsehandler)_ – additional responses handler.
 
-#### Parameters
+### Result
 
-* `subscription`: _string_ – GraphQL subscription text.
-* `variables`?: _any_ – Variables used in subscription.\
-  Must be a map with named values that can be used in query.
-* `responseHandler`?: [_ResponseHandler_](modules.md#responsehandler) – additional responses handler.
+- `handle`: _number_ – Subscription handle.
+<br>Must be closed with `unsubscribe`
 
-#### Result
 
-* `handle`: _number_ – Subscription handle.\
-  Must be closed with `unsubscribe`
-
-### suspend
+## suspend
 
 Suspends network module to stop any network activity
 
@@ -475,10 +500,10 @@ function suspend(): Promise<void>;
 
 function suspend_sync(): void;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
 
-### resume
+
+## resume
 
 Resumes network module to enable network activity
 
@@ -487,10 +512,10 @@ function resume(): Promise<void>;
 
 function resume_sync(): void;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
 
-### find\_last\_shard\_block
+
+## find_last_shard_block
 
 Returns ID of the last block in a specified account shard
 
@@ -511,18 +536,17 @@ function find_last_shard_block_sync(
     params: ParamsOfFindLastShardBlock,
 ): ResultOfFindLastShardBlock;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `address`: _string_ – Account address
 
-#### Parameters
 
-* `address`: _string_ – Account address
+### Result
 
-#### Result
+- `block_id`: _string_ – Account shard last block ID
 
-* `block_id`: _string_ – Account shard last block ID
 
-### fetch\_endpoints
+## fetch_endpoints
 
 Requests the list of alternative endpoints from server
 
@@ -535,14 +559,15 @@ function fetch_endpoints(): Promise<EndpointsSet>;
 
 function fetch_endpoints_sync(): EndpointsSet;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
 
-#### Result
 
-* `endpoints`: _string\[]_ – List of endpoints provided by server
+### Result
 
-### set\_endpoints
+- `endpoints`: _string[]_ – List of endpoints provided by server
+
+
+## set_endpoints
 
 Sets the list of endpoints to use on reinit
 
@@ -559,14 +584,12 @@ function set_endpoints_sync(
     params: EndpointsSet,
 ): void;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `endpoints`: _string[]_ – List of endpoints provided by server
 
-#### Parameters
 
-* `endpoints`: _string\[]_ – List of endpoints provided by server
-
-### get\_endpoints
+## get_endpoints
 
 Requests the list of alternative endpoints from server
 
@@ -580,19 +603,23 @@ function get_endpoints(): Promise<ResultOfGetEndpoints>;
 
 function get_endpoints_sync(): ResultOfGetEndpoints;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
 
-#### Result
 
-* `query`: _string_ – Current query endpoint
-* `endpoints`: _string\[]_ – List of all endpoints used by client
+### Result
 
-### query\_counterparties
+- `query`: _string_ – Current query endpoint
+- `endpoints`: _string[]_ – List of all endpoints used by client
+
+
+## query_counterparties
 
 Allows to query and paginate through the list of accounts that the specified account has interacted with, sorted by the time of the last internal message between accounts
 
-_Attention_ this query retrieves data from 'Counterparties' service which is not supported in the opensource version of DApp Server (and will not be supported)
+*Attention* this query retrieves data from 'Counterparties' service which is
+not supported in the opensource version of DApp Server (and will not be
+supported) as well as in Evernode SE (will be supported in SE in future),
+but is always accessible via [EVER OS Clouds](../ton-os-api/networks.md)
 
 ```ts
 type ParamsOfQueryCounterparties = {
@@ -614,43 +641,64 @@ function query_counterparties_sync(
     params: ParamsOfQueryCounterparties,
 ): ResultOfQueryCollection;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `account`: _string_ – Account address
+- `result`: _string_ – Projection (result) string
+- `first`?: _number_ – Number of counterparties to return
+- `after`?: _string_ – `cursor` field of the last received result
 
-#### Parameters
 
-* `account`: _string_ – Account address
-* `result`: _string_ – Projection (result) string
-* `first`?: _number_ – Number of counterparties to return
-* `after`?: _string_ – `cursor` field of the last received result
+### Result
 
-#### Result
+- `result`: _any[]_ – Objects that match the provided criteria
 
-* `result`: _any\[]_ – Objects that match the provided criteria
 
-### query\_transaction\_tree
+## query_transaction_tree
 
 Returns a tree of transactions triggered by a specific message.
 
-Performs recursive retrieval of a transactions tree produced by a specific message: in\_msg -> dst\_transaction -> out\_messages -> dst\_transaction -> ... If the chain of transactions execution is in progress while the function is running, it will wait for the next transactions to appear until the full tree or more than 50 transactions are received.
+Performs recursive retrieval of a transactions tree produced by a specific
+message: in_msg -> dst_transaction -> out_messages -> dst_transaction -> ...
+If the chain of transactions execution is in progress while the function is
+running, it will wait for the next transactions to appear until the full
+tree or more than 50 transactions are received.
 
-All the retrieved messages and transactions are included into `result.messages` and `result.transactions` respectively.
+All the retrieved messages and transactions are included
+into `result.messages` and `result.transactions` respectively.
 
 Function reads transactions layer by layer, by pages of 20 transactions.
 
-The retrieval process goes like this: Let's assume we have an infinite chain of transactions and each transaction generates 5 messages.
+The retrieval process goes like this:
+Let's assume we have an infinite chain of transactions and each transaction
+generates 5 messages.
+1. Retrieve 1st message (input parameter) and corresponding transaction -
+   put it into result.
+It is the first level of the tree of transactions - its root.
+Retrieve 5 out message ids from the transaction for next steps.
+2. Retrieve 5 messages and corresponding transactions on the 2nd layer. Put
+   them into result.
+Retrieve 5*5 out message ids from these transactions for next steps
+3. Retrieve 20 (size of the page) messages and transactions (3rd layer) and
+   20*5=100 message ids (4th layer).
+4. Retrieve the last 5 messages and 5 transactions on the 3rd layer + 15
+   messages and transactions (of 100) from the 4th layer
++ 25 message ids of the 4th layer + 75 message ids of the 5th layer.
+5. Retrieve 20 more messages and 20 more transactions of the 4th layer + 100
+   more message ids of the 5th layer.
+6. Now we have 1+5+20+20+20 = 66 transactions, which is more than 50.
+   Function exits with the tree of
+1m->1t->5m->5t->25m->25t->35m->35t. If we see any message ids in the last
+transactions out_msgs, which don't have corresponding messages in the
+function result, it means that the full tree was not received and we need to
+continue iteration.
 
-1. Retrieve 1st message (input parameter) and corresponding transaction - put it into result. It is the first level of the tree of transactions - its root. Retrieve 5 out message ids from the transaction for next steps.
-2. Retrieve 5 messages and corresponding transactions on the 2nd layer. Put them into result. Retrieve 5\*5 out message ids from these transactions for next steps
-3. Retrieve 20 (size of the page) messages and transactions (3rd layer) and 20\*5=100 message ids (4th layer).
-4. Retrieve the last 5 messages and 5 transactions on the 3rd layer + 15 messages and transactions (of 100) from the 4th layer
-
-* 25 message ids of the 4th layer + 75 message ids of the 5th layer.
-
-5. Retrieve 20 more messages and 20 more transactions of the 4th layer + 100 more message ids of the 5th layer.
-6. Now we have 1+5+20+20+20 = 66 transactions, which is more than 50. Function exits with the tree of 1m->1t->5m->5t->25m->25t->35m->35t. If we see any message ids in the last transactions out\_msgs, which don't have corresponding messages in the function result, it means that the full tree was not received and we need to continue iteration.
-
-To summarize, it is guaranteed that each message in `result.messages` has the corresponding transaction in the `result.transactions`. But there is no guarantee that all messages from transactions `out_msgs` are presented in `result.messages`. So the application has to continue retrieval for missing messages if it requires.
+To summarize, it is guaranteed that each message in `result.messages` has
+the corresponding transaction in the `result.transactions`.
+But there is no guarantee that all messages from transactions `out_msgs` are
+presented in `result.messages`.
+So the application has to continue retrieval for missing messages if it
+requires.
 
 ```ts
 type ParamsOfQueryTransactionTree = {
@@ -673,45 +721,45 @@ function query_transaction_tree_sync(
     params: ParamsOfQueryTransactionTree,
 ): ResultOfQueryTransactionTree;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `in_msg`: _string_ – Input message id.
+- `abi_registry`?: _[Abi](mod\_abi.md#abi)[]_ – List of contract ABIs that will be used to decode message bodies. Library will try to decode each returned message body using any ABI from the registry.
+- `timeout`?: _number_ – Timeout used to limit waiting time for the missing messages and transaction.
+<br>If some of the following messages and transactions are missing yet<br>The maximum waiting time is regulated by this option.<br><br>Default value is 60000 (1 min). If `timeout` is set to 0 then function<br>will wait infinitely until the whole transaction tree is executed
+- `transaction_max_count`?: _number_ – Maximum transaction count to wait.
+<br>If transaction tree contains more transaction then this parameter then only first<br>`transaction_max_count` transaction are awaited and returned.<br><br>Default value is 50. If `transaction_max_count` is set to 0 then no<br>limitation on transaction count is used and all transaction are<br>returned.
 
-#### Parameters
 
-* `in_msg`: _string_ – Input message id.
-* `abi_registry`?: [_Abi_](mod_abi.md#abi)_\[]_ – List of contract ABIs that will be used to decode message bodies. Library will try to decode each returned message body using any ABI from the registry.
-* `timeout`?: _number_ – Timeout used to limit waiting time for the missing messages and transaction.\
-  If some of the following messages and transactions are missing yet\
-  The maximum waiting time is regulated by this option.\
-  \
-  Default value is 60000 (1 min). If `timeout` is set to 0 then function will wait infinitely\
-  until the whole transaction tree is executed
-* `transaction_max_count`?: _number_ – Maximum transaction count to wait.\
-  If transaction tree contains more transaction then this parameter then only first `transaction_max_count` transaction are awaited and returned.\
-  \
-  Default value is 50. If `transaction_max_count` is set to 0 then no limitation on\
-  transaction count is used and all transaction are returned.
+### Result
 
-#### Result
+- `messages`: _[MessageNode](mod\_net.md#messagenode)[]_ – Messages.
+- `transactions`: _[TransactionNode](mod\_net.md#transactionnode)[]_ – Transactions.
 
-* `messages`: [_MessageNode_](mod_net.md#messagenode)_\[]_ – Messages.
-* `transactions`: [_TransactionNode_](mod_net.md#transactionnode)_\[]_ – Transactions.
 
-### create\_block\_iterator
+## create_block_iterator
 
 Creates block iterator.
 
-Block iterator uses robust iteration methods that guaranties that every block in the specified range isn't missed or iterated twice.
+Block iterator uses robust iteration methods that guaranties that every
+block in the specified range isn't missed or iterated twice.
 
 Iterated range can be reduced with some filters:
+- `start_time` – the bottom time range. Only blocks with `gen_utime`
+more or equal to this value is iterated. If this parameter is omitted then
+there is no bottom time edge, so all blocks since zero state is iterated.
+- `end_time` – the upper time range. Only blocks with `gen_utime`
+less then this value is iterated. If this parameter is omitted then there is
+no upper time edge, so iterator never finishes.
+- `shard_filter` – workchains and shard prefixes that reduce the set of
+  interesting
+blocks. Block conforms to the shard filter if it belongs to the filter
+workchain and the first bits of block's `shard` fields matches to the shard
+prefix. Only blocks with suitable shard are iterated.
 
-* `start_time` – the bottom time range. Only blocks with `gen_utime` more or equal to this value is iterated. If this parameter is omitted then there is no bottom time edge, so all blocks since zero state is iterated.
-* `end_time` – the upper time range. Only blocks with `gen_utime` less then this value is iterated. If this parameter is omitted then there is no upper time edge, so iterator never finishes.
-* `shard_filter` – workchains and shard prefixes that reduce the set of interesting blocks. Block conforms to the shard filter if it belongs to the filter workchain and the first bits of block's `shard` fields matches to the shard prefix. Only blocks with suitable shard are iterated.
-
-Items iterated is a JSON objects with block data. The minimal set of returned fields is:
-
-```
+Items iterated is a JSON objects with block data. The minimal set of
+returned fields is:
+```text
 id
 gen_utime
 workchain_id
@@ -725,10 +773,10 @@ prev_alt_ref {
     root_hash
 }
 ```
-
 Application can request additional fields in the `result` parameter.
 
-Application should call the `remove_iterator` when iterator is no longer required.
+Application should call the `remove_iterator` when iterator is no longer
+required.
 
 ```ts
 type ParamsOfCreateBlockIterator = {
@@ -750,51 +798,33 @@ function create_block_iterator_sync(
     params: ParamsOfCreateBlockIterator,
 ): RegisteredIterator;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `start_time`?: _number_ – Starting time to iterate from.
+<br>If the application specifies this parameter then the iteration<br>includes blocks with `gen_utime` >= `start_time`.<br>Otherwise the iteration starts from zero state.<br><br>Must be specified in seconds.
+- `end_time`?: _number_ – Optional end time to iterate for.
+<br>If the application specifies this parameter then the iteration<br>includes blocks with `gen_utime` < `end_time`.<br>Otherwise the iteration never stops.<br><br>Must be specified in seconds.
+- `shard_filter`?: _string[]_ – Shard prefix filter.
+<br>If the application specifies this parameter and it is not the empty<br>array then the iteration will include items related to accounts that<br>belongs to the specified shard prefixes.<br>Shard prefix must be represented as a string "workchain:prefix".<br>Where `workchain` is a signed integer and the `prefix` if a hexadecimal<br>representation if the 64-bit unsigned integer with tagged shard prefix.<br>For example: "0:3800000000000000".
+- `result`?: _string_ – Projection (result) string.
+<br>List of the fields that must be returned for iterated items.<br>This field is the same as the `result` parameter of<br>the `query_collection` function.<br>Note that iterated items can contains additional fields that are<br>not requested in the `result`.
 
-#### Parameters
 
-* `start_time`?: _number_ – Starting time to iterate from.\
-  If the application specifies this parameter then the iteration\
-  includes blocks with `gen_utime` >= `start_time`.\
-  Otherwise the iteration starts from zero state.\
-  \
-  Must be specified in seconds.
-* `end_time`?: _number_ – Optional end time to iterate for.\
-  If the application specifies this parameter then the iteration\
-  includes blocks with `gen_utime` < `end_time`.\
-  Otherwise the iteration never stops.\
-  \
-  Must be specified in seconds.
-* `shard_filter`?: _string\[]_ – Shard prefix filter.\
-  If the application specifies this parameter and it is not the empty array\
-  then the iteration will include items related to accounts that belongs to\
-  the specified shard prefixes.\
-  Shard prefix must be represented as a string "workchain:prefix".\
-  Where `workchain` is a signed integer and the `prefix` if a hexadecimal\
-  representation if the 64-bit unsigned integer with tagged shard prefix.\
-  For example: "0:3800000000000000".
-* `result`?: _string_ – Projection (result) string.\
-  List of the fields that must be returned for iterated items.\
-  This field is the same as the `result` parameter of\
-  the `query_collection` function.\
-  Note that iterated items can contains additional fields that are\
-  not requested in the `result`.
+### Result
 
-#### Result
+- `handle`: _number_ – Iterator handle.
+<br>Must be removed using `remove_iterator`<br>when it is no more needed for the application.
 
-* `handle`: _number_ – Iterator handle.\
-  Must be removed using `remove_iterator`\
-  when it is no more needed for the application.
 
-### resume\_block\_iterator
+## resume_block_iterator
 
 Resumes block iterator.
 
-The iterator stays exactly at the same position where the `resume_state` was caught.
+The iterator stays exactly at the same position where the `resume_state` was
+caught.
 
-Application should call the `remove_iterator` when iterator is no longer required.
+Application should call the `remove_iterator` when iterator is no longer
+required.
 
 ```ts
 type ParamsOfResumeBlockIterator = {
@@ -813,36 +843,47 @@ function resume_block_iterator_sync(
     params: ParamsOfResumeBlockIterator,
 ): RegisteredIterator;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `resume_state`: _any_ – Iterator state from which to resume.
+<br>Same as value returned from `iterator_next`.
 
-#### Parameters
 
-* `resume_state`: _any_ – Iterator state from which to resume.\
-  Same as value returned from `iterator_next`.
+### Result
 
-#### Result
+- `handle`: _number_ – Iterator handle.
+<br>Must be removed using `remove_iterator`<br>when it is no more needed for the application.
 
-* `handle`: _number_ – Iterator handle.\
-  Must be removed using `remove_iterator`\
-  when it is no more needed for the application.
 
-### create\_transaction\_iterator
+## create_transaction_iterator
 
 Creates transaction iterator.
 
-Transaction iterator uses robust iteration methods that guaranty that every transaction in the specified range isn't missed or iterated twice.
+Transaction iterator uses robust iteration methods that guaranty that every
+transaction in the specified range isn't missed or iterated twice.
 
 Iterated range can be reduced with some filters:
+- `start_time` – the bottom time range. Only transactions with `now`
+more or equal to this value are iterated. If this parameter is omitted then
+there is no bottom time edge, so all the transactions since zero state are
+iterated.
+- `end_time` – the upper time range. Only transactions with `now`
+less then this value are iterated. If this parameter is omitted then there
+is no upper time edge, so iterator never finishes.
+- `shard_filter` – workchains and shard prefixes that reduce the set of
+  interesting
+accounts. Account address conforms to the shard filter if
+it belongs to the filter workchain and the first bits of address match to
+the shard prefix. Only transactions with suitable account addresses are
+iterated.
+- `accounts_filter` – set of account addresses whose transactions must be
+  iterated.
+Note that accounts filter can conflict with shard filter so application must
+combine these filters carefully.
 
-* `start_time` – the bottom time range. Only transactions with `now` more or equal to this value are iterated. If this parameter is omitted then there is no bottom time edge, so all the transactions since zero state are iterated.
-* `end_time` – the upper time range. Only transactions with `now` less then this value are iterated. If this parameter is omitted then there is no upper time edge, so iterator never finishes.
-* `shard_filter` – workchains and shard prefixes that reduce the set of interesting accounts. Account address conforms to the shard filter if it belongs to the filter workchain and the first bits of address match to the shard prefix. Only transactions with suitable account addresses are iterated.
-* `accounts_filter` – set of account addresses whose transactions must be iterated. Note that accounts filter can conflict with shard filter so application must combine these filters carefully.
-
-Iterated item is a JSON objects with transaction data. The minimal set of returned fields is:
-
-```
+Iterated item is a JSON objects with transaction data. The minimal set of
+returned fields is:
+```text
 id
 account_addr
 now
@@ -861,18 +902,28 @@ out_messages {
     dst
 }
 ```
-
 Application can request an additional fields in the `result` parameter.
 
-Another parameter that affects on the returned fields is the `include_transfers`. When this parameter is `true` the iterator computes and adds `transfer` field containing list of the useful `TransactionTransfer` objects. Each transfer is calculated from the particular message related to the transaction and has the following structure:
+Another parameter that affects on the returned fields is the
+`include_transfers`. When this parameter is `true` the iterator computes and
+adds `transfer` field containing list of the useful `TransactionTransfer`
+objects. Each transfer is calculated from the particular message related to
+the transaction and has the following structure:
+- message – source message identifier.
+- isBounced – indicates that the transaction is bounced, which means the
+  value will be returned back to the sender.
+- isDeposit – indicates that this transfer is the deposit (true) or withdraw
+  (false).
+- counterparty – account address of the transfer source or destination
+  depending on `isDeposit`.
+- value – amount of nano tokens transferred. The value is represented as a
+  decimal string
+because the actual value can be more precise than the JSON number can
+represent. Application must use this string carefully – conversion to number
+can follow to loose of precision.
 
-* message – source message identifier.
-* isBounced – indicates that the transaction is bounced, which means the value will be returned back to the sender.
-* isDeposit – indicates that this transfer is the deposit (true) or withdraw (false).
-* counterparty – account address of the transfer source or destination depending on `isDeposit`.
-* value – amount of nano tokens transferred. The value is represented as a decimal string because the actual value can be more precise than the JSON number can represent. Application must use this string carefully – conversion to number can follow to loose of precision.
-
-Application should call the `remove_iterator` when iterator is no longer required.
+Application should call the `remove_iterator` when iterator is no longer
+required.
 
 ```ts
 type ParamsOfCreateTransactionIterator = {
@@ -896,67 +947,40 @@ function create_transaction_iterator_sync(
     params: ParamsOfCreateTransactionIterator,
 ): RegisteredIterator;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `start_time`?: _number_ – Starting time to iterate from.
+<br>If the application specifies this parameter then the iteration<br>includes blocks with `gen_utime` >= `start_time`.<br>Otherwise the iteration starts from zero state.<br><br>Must be specified in seconds.
+- `end_time`?: _number_ – Optional end time to iterate for.
+<br>If the application specifies this parameter then the iteration<br>includes blocks with `gen_utime` < `end_time`.<br>Otherwise the iteration never stops.<br><br>Must be specified in seconds.
+- `shard_filter`?: _string[]_ – Shard prefix filters.
+<br>If the application specifies this parameter and it is not an empty array<br>then the iteration will include items related to accounts that belongs<br>to the specified shard prefixes.<br>Shard prefix must be represented as a string "workchain:prefix".<br>Where `workchain` is a signed integer and the `prefix` if a hexadecimal<br>representation if the 64-bit unsigned integer with tagged shard prefix.<br>For example: "0:3800000000000000".<br>Account address conforms to the shard filter if<br>it belongs to the filter workchain and the first bits of address match<br>to the shard prefix. Only transactions with suitable account<br>addresses are iterated.
+- `accounts_filter`?: _string[]_ – Account address filter.
+<br>Application can specify the list of accounts for which<br>it wants to iterate transactions.<br><br>If this parameter is missing or an empty list then the library iterates<br>transactions for all accounts that pass the shard filter.<br><br>Note that the library doesn't detect conflicts between the account<br>filter and the shard filter if both are specified.<br>So it is an application responsibility to specify the correct filter<br>combination.
+- `result`?: _string_ – Projection (result) string.
+<br>List of the fields that must be returned for iterated items.<br>This field is the same as the `result` parameter of<br>the `query_collection` function.<br>Note that iterated items can contain additional fields that are<br>not requested in the `result`.
+- `include_transfers`?: _boolean_ – Include `transfers` field in iterated transactions.
+<br>If this parameter is `true` then each transaction contains field<br>`transfers` with list of transfer. See more about this structure in<br>function description.
 
-#### Parameters
 
-* `start_time`?: _number_ – Starting time to iterate from.\
-  If the application specifies this parameter then the iteration\
-  includes blocks with `gen_utime` >= `start_time`.\
-  Otherwise the iteration starts from zero state.\
-  \
-  Must be specified in seconds.
-* `end_time`?: _number_ – Optional end time to iterate for.\
-  If the application specifies this parameter then the iteration\
-  includes blocks with `gen_utime` < `end_time`.\
-  Otherwise the iteration never stops.\
-  \
-  Must be specified in seconds.
-* `shard_filter`?: _string\[]_ – Shard prefix filters.\
-  If the application specifies this parameter and it is not an empty array\
-  then the iteration will include items related to accounts that belongs to\
-  the specified shard prefixes.\
-  Shard prefix must be represented as a string "workchain:prefix".\
-  Where `workchain` is a signed integer and the `prefix` if a hexadecimal\
-  representation if the 64-bit unsigned integer with tagged shard prefix.\
-  For example: "0:3800000000000000".\
-  Account address conforms to the shard filter if\
-  it belongs to the filter workchain and the first bits of address match to\
-  the shard prefix. Only transactions with suitable account addresses are iterated.
-* `accounts_filter`?: _string\[]_ – Account address filter.\
-  Application can specify the list of accounts for which\
-  it wants to iterate transactions.\
-  \
-  If this parameter is missing or an empty list then the library iterates\
-  transactions for all accounts that pass the shard filter.\
-  \
-  Note that the library doesn't detect conflicts between the account filter and the shard filter\
-  if both are specified.\
-  So it is an application responsibility to specify the correct filter combination.
-* `result`?: _string_ – Projection (result) string.\
-  List of the fields that must be returned for iterated items.\
-  This field is the same as the `result` parameter of\
-  the `query_collection` function.\
-  Note that iterated items can contain additional fields that are\
-  not requested in the `result`.
-* `include_transfers`?: _boolean_ – Include `transfers` field in iterated transactions.\
-  If this parameter is `true` then each transaction contains field\
-  `transfers` with list of transfer. See more about this structure in function description.
+### Result
 
-#### Result
+- `handle`: _number_ – Iterator handle.
+<br>Must be removed using `remove_iterator`<br>when it is no more needed for the application.
 
-* `handle`: _number_ – Iterator handle.\
-  Must be removed using `remove_iterator`\
-  when it is no more needed for the application.
 
-### resume\_transaction\_iterator
+## resume_transaction_iterator
 
 Resumes transaction iterator.
 
-The iterator stays exactly at the same position where the `resume_state` was caught. Note that `resume_state` doesn't store the account filter. If the application requires to use the same account filter as it was when the iterator was created then the application must pass the account filter again in `accounts_filter` parameter.
+The iterator stays exactly at the same position where the `resume_state` was
+caught. Note that `resume_state` doesn't store the account filter. If the
+application requires to use the same account filter as it was when the
+iterator was created then the application must pass the account filter again
+in `accounts_filter` parameter.
 
-Application should call the `remove_iterator` when iterator is no longer required.
+Application should call the `remove_iterator` when iterator is no longer
+required.
 
 ```ts
 type ParamsOfResumeTransactionIterator = {
@@ -976,41 +1000,38 @@ function resume_transaction_iterator_sync(
     params: ParamsOfResumeTransactionIterator,
 ): RegisteredIterator;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `resume_state`: _any_ – Iterator state from which to resume.
+<br>Same as value returned from `iterator_next`.
+- `accounts_filter`?: _string[]_ – Account address filter.
+<br>Application can specify the list of accounts for which<br>it wants to iterate transactions.<br><br>If this parameter is missing or an empty list then the library iterates<br>transactions for all accounts that passes the shard filter.<br><br>Note that the library doesn't detect conflicts between the account<br>filter and the shard filter if both are specified.<br>So it is the application's responsibility to specify the correct filter<br>combination.
 
-#### Parameters
 
-* `resume_state`: _any_ – Iterator state from which to resume.\
-  Same as value returned from `iterator_next`.
-* `accounts_filter`?: _string\[]_ – Account address filter.\
-  Application can specify the list of accounts for which\
-  it wants to iterate transactions.\
-  \
-  If this parameter is missing or an empty list then the library iterates\
-  transactions for all accounts that passes the shard filter.\
-  \
-  Note that the library doesn't detect conflicts between the account filter and the shard filter\
-  if both are specified.\
-  So it is the application's responsibility to specify the correct filter combination.
+### Result
 
-#### Result
+- `handle`: _number_ – Iterator handle.
+<br>Must be removed using `remove_iterator`<br>when it is no more needed for the application.
 
-* `handle`: _number_ – Iterator handle.\
-  Must be removed using `remove_iterator`\
-  when it is no more needed for the application.
 
-### iterator\_next
+## iterator_next
 
 Returns next available items.
 
-In addition to available items this function returns the `has_more` flag indicating that the iterator isn't reach the end of the iterated range yet.
+In addition to available items this function returns the `has_more` flag
+indicating that the iterator isn't reach the end of the iterated range yet.
 
-This function can return the empty list of available items but indicates that there are more items is available. This situation appears when the iterator doesn't reach iterated range but database doesn't contains available items yet.
+This function can return the empty list of available items but
+indicates that there are more items is available.
+This situation appears when the iterator doesn't reach iterated range
+but database doesn't contains available items yet.
 
-If application requests resume state in `return_resume_state` parameter then this function returns `resume_state` that can be used later to resume the iteration from the position after returned items.
+If application requests resume state in `return_resume_state` parameter
+then this function returns `resume_state` that can be used later to
+resume the iteration from the position after returned items.
 
-The structure of the items returned depends on the iterator used. See the description to the appropriated iterator creation function.
+The structure of the items returned depends on the iterator used.
+See the description to the appropriated iterator creation function.
 
 ```ts
 type ParamsOfIteratorNext = {
@@ -1033,38 +1054,31 @@ function iterator_next_sync(
     params: ParamsOfIteratorNext,
 ): ResultOfIteratorNext;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `iterator`: _number_ – Iterator handle
+- `limit`?: _number_ – Maximum count of the returned items.
+<br>If value is missing or is less than 1 the library uses 1.
+- `return_resume_state`?: _boolean_ – Indicates that function must return the iterator state that can be used for resuming iteration.
 
-#### Parameters
 
-* `iterator`: _number_ – Iterator handle
-* `limit`?: _number_ – Maximum count of the returned items.\
-  If value is missing or is less than 1 the library uses 1.
-* `return_resume_state`?: _boolean_ – Indicates that function must return the iterator state that can be used for resuming iteration.
+### Result
 
-#### Result
+- `items`: _any[]_ – Next available items.
+<br>Note that `iterator_next` can return an empty items and `has_more`<br>equals to `true`. In this case the application have to continue<br>iteration. Such situation can take place when there is no data yet<br>but the requested `end_time` is not reached.
+- `has_more`: _boolean_ – Indicates that there are more available items in iterated range.
+- `resume_state`?: _any_ – Optional iterator state that can be used for resuming iteration.
+<br>This field is returned only if the `return_resume_state` parameter<br>is specified.<br><br>Note that `resume_state` corresponds to the iteration position<br>after the returned items.
 
-* `items`: _any\[]_ – Next available items.\
-  Note that `iterator_next` can return an empty items and `has_more` equals to `true`.\
-  In this case the application have to continue iteration.\
-  Such situation can take place when there is no data yet but\
-  the requested `end_time` is not reached.
-* `has_more`: _boolean_ – Indicates that there are more available items in iterated range.
-* `resume_state`?: _any_ – Optional iterator state that can be used for resuming iteration.\
-  This field is returned only if the `return_resume_state` parameter\
-  is specified.\
-  \
-  Note that `resume_state` corresponds to the iteration position\
-  after the returned items.
 
-### remove\_iterator
+## remove_iterator
 
 Removes an iterator
 
 Frees all resources allocated in library to serve iterator.
 
-Application always should call the `remove_iterator` when iterator is no longer required.
+Application always should call the `remove_iterator` when iterator
+is no longer required.
 
 ```ts
 type RegisteredIterator = {
@@ -1079,16 +1093,13 @@ function remove_iterator_sync(
     params: RegisteredIterator,
 ): void;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `handle`: _number_ – Iterator handle.
+<br>Must be removed using `remove_iterator`<br>when it is no more needed for the application.
 
-#### Parameters
 
-* `handle`: _number_ – Iterator handle.\
-  Must be removed using `remove_iterator`\
-  when it is no more needed for the application.
-
-### get\_signature\_id
+## get_signature_id
 
 Returns signature ID for configured network if it should be used in messages signature
 
@@ -1101,17 +1112,16 @@ function get_signature_id(): Promise<ResultOfGetSignatureId>;
 
 function get_signature_id_sync(): ResultOfGetSignatureId;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
 
-#### Result
 
-* `signature_id`?: _number_ – Signature ID for configured network if it should be used in messages signature
+### Result
 
-## Types
+- `signature_id`?: _number_ – Signature ID for configured network if it should be used in messages signature
 
-### NetErrorCode
 
+# Types
+## NetErrorCode
 ```ts
 enum NetErrorCode {
     QueryFailed = 601,
@@ -1131,59 +1141,66 @@ enum NetErrorCode {
     Unauthorized = 615,
     QueryTransactionTreeTimeout = 616,
     GraphqlConnectionError = 617,
-    WrongWebscoketProtocolSequence = 618
+    WrongWebscoketProtocolSequence = 618,
+    ParseUrlFailed = 619,
+    ModifyUrlFailed = 620,
+    SendMessageFailed = 621,
+    NotFound = 622,
+    AllAttemptsFailed = 623
 }
 ```
-
 One of the following value:
 
-* `QueryFailed = 601`
-* `SubscribeFailed = 602`
-* `WaitForFailed = 603`
-* `GetSubscriptionResultFailed = 604`
-* `InvalidServerResponse = 605`
-* `ClockOutOfSync = 606`
-* `WaitForTimeout = 607`
-* `GraphqlError = 608`
-* `NetworkModuleSuspended = 609`
-* `WebsocketDisconnected = 610`
-* `NotSupported = 611`
-* `NoEndpointsProvided = 612`
-* `GraphqlWebsocketInitError = 613`
-* `NetworkModuleResumed = 614`
-* `Unauthorized = 615`
-* `QueryTransactionTreeTimeout = 616`
-* `GraphqlConnectionError = 617`
-* `WrongWebscoketProtocolSequence = 618`
+- `QueryFailed = 601`
+- `SubscribeFailed = 602`
+- `WaitForFailed = 603`
+- `GetSubscriptionResultFailed = 604`
+- `InvalidServerResponse = 605`
+- `ClockOutOfSync = 606`
+- `WaitForTimeout = 607`
+- `GraphqlError = 608`
+- `NetworkModuleSuspended = 609`
+- `WebsocketDisconnected = 610`
+- `NotSupported = 611`
+- `NoEndpointsProvided = 612`
+- `GraphqlWebsocketInitError = 613`
+- `NetworkModuleResumed = 614`
+- `Unauthorized = 615`
+- `QueryTransactionTreeTimeout = 616`
+- `GraphqlConnectionError = 617`
+- `WrongWebscoketProtocolSequence = 618`
+- `ParseUrlFailed = 619`
+- `ModifyUrlFailed = 620`
+- `SendMessageFailed = 621`
+- `NotFound = 622`
+- `AllAttemptsFailed = 623`
 
-### OrderBy
 
+## OrderBy
 ```ts
 type OrderBy = {
     path: string,
     direction: SortDirection
 }
 ```
+- `path`: _string_
+- `direction`: _[SortDirection](mod\_net.md#sortdirection)_
 
-* `path`: _string_
-* `direction`: [_SortDirection_](mod_net.md#sortdirection)
 
-### SortDirection
-
+## SortDirection
 ```ts
 enum SortDirection {
     ASC = "ASC",
     DESC = "DESC"
 }
 ```
-
 One of the following value:
 
-* `ASC = "ASC"`
-* `DESC = "DESC"`
+- `ASC = "ASC"`
+- `DESC = "DESC"`
 
-### ParamsOfQueryOperation
 
+## ParamsOfQueryOperation
 ```ts
 type ParamsOfQueryOperation = ({
     type: 'QueryCollection'
@@ -1195,36 +1212,36 @@ type ParamsOfQueryOperation = ({
     type: 'QueryCounterparties'
 } & ParamsOfQueryCounterparties)
 ```
-
-Depends on value of the `type` field.
+Depends on value of the  `type` field.
 
 When _type_ is _'QueryCollection'_
 
-* `collection`: _string_ – Collection name (accounts, blocks, transactions, messages, block\_signatures)
-* `filter`?: _any_ – Collection filter
-* `result`: _string_ – Projection (result) string
-* `order`?: [_OrderBy_](mod_net.md#orderby)_\[]_ – Sorting order
-* `limit`?: _number_ – Number of documents to return
+- `collection`: _string_ – Collection name (accounts, blocks, transactions, messages, block_signatures)
+- `filter`?: _any_ – Collection filter
+- `result`: _string_ – Projection (result) string
+- `order`?: _[OrderBy](mod\_net.md#orderby)[]_ – Sorting order
+- `limit`?: _number_ – Number of documents to return
 
 When _type_ is _'WaitForCollection'_
 
-* `collection`: _string_ – Collection name (accounts, blocks, transactions, messages, block\_signatures)
-* `filter`?: _any_ – Collection filter
-* `result`: _string_ – Projection (result) string
-* `timeout`?: _number_ – Query timeout
+- `collection`: _string_ – Collection name (accounts, blocks, transactions, messages, block_signatures)
+- `filter`?: _any_ – Collection filter
+- `result`: _string_ – Projection (result) string
+- `timeout`?: _number_ – Query timeout
 
 When _type_ is _'AggregateCollection'_
 
-* `collection`: _string_ – Collection name (accounts, blocks, transactions, messages, block\_signatures)
-* `filter`?: _any_ – Collection filter
-* `fields`?: [_FieldAggregation_](mod_net.md#fieldaggregation)_\[]_ – Projection (result) string
+- `collection`: _string_ – Collection name (accounts, blocks, transactions, messages, block_signatures)
+- `filter`?: _any_ – Collection filter
+- `fields`?: _[FieldAggregation](mod\_net.md#fieldaggregation)[]_ – Projection (result) string
 
 When _type_ is _'QueryCounterparties'_
 
-* `account`: _string_ – Account address
-* `result`: _string_ – Projection (result) string
-* `first`?: _number_ – Number of counterparties to return
-* `after`?: _string_ – `cursor` field of the last received result
+- `account`: _string_ – Account address
+- `result`: _string_ – Projection (result) string
+- `first`?: _number_ – Number of counterparties to return
+- `after`?: _string_ – `cursor` field of the last received result
+
 
 Variant constructors:
 
@@ -1235,20 +1252,18 @@ function paramsOfQueryOperationAggregateCollection(params: ParamsOfAggregateColl
 function paramsOfQueryOperationQueryCounterparties(params: ParamsOfQueryCounterparties): ParamsOfQueryOperation;
 ```
 
-### FieldAggregation
-
+## FieldAggregation
 ```ts
 type FieldAggregation = {
     field: string,
     fn: AggregationFn
 }
 ```
+- `field`: _string_ – Dot separated path to the field
+- `fn`: _[AggregationFn](mod\_net.md#aggregationfn)_ – Aggregation function that must be applied to field values
 
-* `field`: _string_ – Dot separated path to the field
-* `fn`: [_AggregationFn_](mod_net.md#aggregationfn) – Aggregation function that must be applied to field values
 
-### AggregationFn
-
+## AggregationFn
 ```ts
 enum AggregationFn {
     COUNT = "COUNT",
@@ -1258,17 +1273,16 @@ enum AggregationFn {
     AVERAGE = "AVERAGE"
 }
 ```
-
 One of the following value:
 
-* `COUNT = "COUNT"` – Returns count of filtered record
-* `MIN = "MIN"` – Returns the minimal value for a field in filtered records
-* `MAX = "MAX"` – Returns the maximal value for a field in filtered records
-* `SUM = "SUM"` – Returns a sum of values for a field in filtered records
-* `AVERAGE = "AVERAGE"` – Returns an average value for a field in filtered records
+- `COUNT = "COUNT"` – Returns count of filtered record
+- `MIN = "MIN"` – Returns the minimal value for a field in filtered records
+- `MAX = "MAX"` – Returns the maximal value for a field in filtered records
+- `SUM = "SUM"` – Returns a sum of values for a field in filtered records
+- `AVERAGE = "AVERAGE"` – Returns an average value for a field in filtered records
 
-### TransactionNode
 
+## TransactionNode
 ```ts
 type TransactionNode = {
     id: string,
@@ -1280,17 +1294,16 @@ type TransactionNode = {
     exit_code?: number
 }
 ```
+- `id`: _string_ – Transaction id.
+- `in_msg`: _string_ – In message id.
+- `out_msgs`: _string[]_ – Out message ids.
+- `account_addr`: _string_ – Account address.
+- `total_fees`: _string_ – Transactions total fees.
+- `aborted`: _boolean_ – Aborted flag.
+- `exit_code`?: _number_ – Compute phase exit code.
 
-* `id`: _string_ – Transaction id.
-* `in_msg`: _string_ – In message id.
-* `out_msgs`: _string\[]_ – Out message ids.
-* `account_addr`: _string_ – Account address.
-* `total_fees`: _string_ – Transactions total fees.
-* `aborted`: _boolean_ – Aborted flag.
-* `exit_code`?: _number_ – Compute phase exit code.
 
-### MessageNode
-
+## MessageNode
 ```ts
 type MessageNode = {
     id: string,
@@ -1303,66 +1316,60 @@ type MessageNode = {
     decoded_body?: DecodedMessageBody
 }
 ```
+- `id`: _string_ – Message id.
+- `src_transaction_id`?: _string_ – Source transaction id.
+<br>This field is missing for an external inbound messages.
+- `dst_transaction_id`?: _string_ – Destination transaction id.
+<br>This field is missing for an external outbound messages.
+- `src`?: _string_ – Source address.
+- `dst`?: _string_ – Destination address.
+- `value`?: _string_ – Transferred tokens value.
+- `bounce`: _boolean_ – Bounce flag.
+- `decoded_body`?: _[DecodedMessageBody](mod\_abi.md#decodedmessagebody)_ – Decoded body.
+<br>Library tries to decode message body using provided<br>`params.abi_registry`. This field will be missing if none of the<br>provided abi can be used to decode.
 
-* `id`: _string_ – Message id.
-* `src_transaction_id`?: _string_ – Source transaction id.\
-  This field is missing for an external inbound messages.
-* `dst_transaction_id`?: _string_ – Destination transaction id.\
-  This field is missing for an external outbound messages.
-* `src`?: _string_ – Source address.
-* `dst`?: _string_ – Destination address.
-* `value`?: _string_ – Transferred tokens value.
-* `bounce`: _boolean_ – Bounce flag.
-* `decoded_body`?: [_DecodedMessageBody_](mod_abi.md#decodedmessagebody) – Decoded body.\
-  Library tries to decode message body using provided `params.abi_registry`.\
-  This field will be missing if none of the provided abi can be used to decode.
 
-### ParamsOfQuery
-
+## ParamsOfQuery
 ```ts
 type ParamsOfQuery = {
     query: string,
     variables?: any
 }
 ```
+- `query`: _string_ – GraphQL query text.
+- `variables`?: _any_ – Variables used in query.
+<br>Must be a map with named values that can be used in query.
 
-* `query`: _string_ – GraphQL query text.
-* `variables`?: _any_ – Variables used in query.\
-  Must be a map with named values that can be used in query.
 
-### ResultOfQuery
-
+## ResultOfQuery
 ```ts
 type ResultOfQuery = {
     result: any
 }
 ```
+- `result`: _any_ – Result provided by DAppServer.
 
-* `result`: _any_ – Result provided by DAppServer.
 
-### ParamsOfBatchQuery
-
+## ParamsOfBatchQuery
 ```ts
 type ParamsOfBatchQuery = {
     operations: ParamsOfQueryOperation[]
 }
 ```
+- `operations`: _[ParamsOfQueryOperation](mod\_net.md#paramsofqueryoperation)[]_ – List of query operations that must be performed per single fetch.
 
-* `operations`: [_ParamsOfQueryOperation_](mod_net.md#paramsofqueryoperation)_\[]_ – List of query operations that must be performed per single fetch.
 
-### ResultOfBatchQuery
-
+## ResultOfBatchQuery
 ```ts
 type ResultOfBatchQuery = {
     results: any[]
 }
 ```
+- `results`: _any[]_ – Result values for batched queries.
+<br>Returns an array of values. Each value corresponds to `queries` item.
 
-* `results`: _any\[]_ – Result values for batched queries.\
-  Returns an array of values. Each value corresponds to `queries` item.
 
-### ParamsOfQueryCollection
-
+## ParamsOfQueryCollection
 ```ts
 type ParamsOfQueryCollection = {
     collection: string,
@@ -1372,25 +1379,23 @@ type ParamsOfQueryCollection = {
     limit?: number
 }
 ```
+- `collection`: _string_ – Collection name (accounts, blocks, transactions, messages, block_signatures)
+- `filter`?: _any_ – Collection filter
+- `result`: _string_ – Projection (result) string
+- `order`?: _[OrderBy](mod\_net.md#orderby)[]_ – Sorting order
+- `limit`?: _number_ – Number of documents to return
 
-* `collection`: _string_ – Collection name (accounts, blocks, transactions, messages, block\_signatures)
-* `filter`?: _any_ – Collection filter
-* `result`: _string_ – Projection (result) string
-* `order`?: [_OrderBy_](mod_net.md#orderby)_\[]_ – Sorting order
-* `limit`?: _number_ – Number of documents to return
 
-### ResultOfQueryCollection
-
+## ResultOfQueryCollection
 ```ts
 type ResultOfQueryCollection = {
     result: any[]
 }
 ```
+- `result`: _any[]_ – Objects that match the provided criteria
 
-* `result`: _any\[]_ – Objects that match the provided criteria
 
-### ParamsOfAggregateCollection
-
+## ParamsOfAggregateCollection
 ```ts
 type ParamsOfAggregateCollection = {
     collection: string,
@@ -1398,25 +1403,22 @@ type ParamsOfAggregateCollection = {
     fields?: FieldAggregation[]
 }
 ```
+- `collection`: _string_ – Collection name (accounts, blocks, transactions, messages, block_signatures)
+- `filter`?: _any_ – Collection filter
+- `fields`?: _[FieldAggregation](mod\_net.md#fieldaggregation)[]_ – Projection (result) string
 
-* `collection`: _string_ – Collection name (accounts, blocks, transactions, messages, block\_signatures)
-* `filter`?: _any_ – Collection filter
-* `fields`?: [_FieldAggregation_](mod_net.md#fieldaggregation)_\[]_ – Projection (result) string
 
-### ResultOfAggregateCollection
-
+## ResultOfAggregateCollection
 ```ts
 type ResultOfAggregateCollection = {
     values: any
 }
 ```
+- `values`: _any_ – Values for requested fields.
+<br>Returns an array of strings. Each string refers to the corresponding<br>`fields` item. Numeric value is returned as a decimal string<br>representations.
 
-* `values`: _any_ – Values for requested fields.\
-  Returns an array of strings. Each string refers to the corresponding `fields` item.\
-  Numeric value is returned as a decimal string representations.
 
-### ParamsOfWaitForCollection
-
+## ParamsOfWaitForCollection
 ```ts
 type ParamsOfWaitForCollection = {
     collection: string,
@@ -1425,35 +1427,32 @@ type ParamsOfWaitForCollection = {
     timeout?: number
 }
 ```
+- `collection`: _string_ – Collection name (accounts, blocks, transactions, messages, block_signatures)
+- `filter`?: _any_ – Collection filter
+- `result`: _string_ – Projection (result) string
+- `timeout`?: _number_ – Query timeout
 
-* `collection`: _string_ – Collection name (accounts, blocks, transactions, messages, block\_signatures)
-* `filter`?: _any_ – Collection filter
-* `result`: _string_ – Projection (result) string
-* `timeout`?: _number_ – Query timeout
 
-### ResultOfWaitForCollection
-
+## ResultOfWaitForCollection
 ```ts
 type ResultOfWaitForCollection = {
     result: any
 }
 ```
+- `result`: _any_ – First found object that matches the provided criteria
 
-* `result`: _any_ – First found object that matches the provided criteria
 
-### ResultOfSubscribeCollection
-
+## ResultOfSubscribeCollection
 ```ts
 type ResultOfSubscribeCollection = {
     handle: number
 }
 ```
+- `handle`: _number_ – Subscription handle.
+<br>Must be closed with `unsubscribe`
 
-* `handle`: _number_ – Subscription handle.\
-  Must be closed with `unsubscribe`
 
-### ParamsOfSubscribeCollection
-
+## ParamsOfSubscribeCollection
 ```ts
 type ParamsOfSubscribeCollection = {
     collection: string,
@@ -1461,68 +1460,62 @@ type ParamsOfSubscribeCollection = {
     result: string
 }
 ```
+- `collection`: _string_ – Collection name (accounts, blocks, transactions, messages, block_signatures)
+- `filter`?: _any_ – Collection filter
+- `result`: _string_ – Projection (result) string
 
-* `collection`: _string_ – Collection name (accounts, blocks, transactions, messages, block\_signatures)
-* `filter`?: _any_ – Collection filter
-* `result`: _string_ – Projection (result) string
 
-### ParamsOfSubscribe
-
+## ParamsOfSubscribe
 ```ts
 type ParamsOfSubscribe = {
     subscription: string,
     variables?: any
 }
 ```
+- `subscription`: _string_ – GraphQL subscription text.
+- `variables`?: _any_ – Variables used in subscription.
+<br>Must be a map with named values that can be used in query.
 
-* `subscription`: _string_ – GraphQL subscription text.
-* `variables`?: _any_ – Variables used in subscription.\
-  Must be a map with named values that can be used in query.
 
-### ParamsOfFindLastShardBlock
-
+## ParamsOfFindLastShardBlock
 ```ts
 type ParamsOfFindLastShardBlock = {
     address: string
 }
 ```
+- `address`: _string_ – Account address
 
-* `address`: _string_ – Account address
 
-### ResultOfFindLastShardBlock
-
+## ResultOfFindLastShardBlock
 ```ts
 type ResultOfFindLastShardBlock = {
     block_id: string
 }
 ```
+- `block_id`: _string_ – Account shard last block ID
 
-* `block_id`: _string_ – Account shard last block ID
 
-### EndpointsSet
-
+## EndpointsSet
 ```ts
 type EndpointsSet = {
     endpoints: string[]
 }
 ```
+- `endpoints`: _string[]_ – List of endpoints provided by server
 
-* `endpoints`: _string\[]_ – List of endpoints provided by server
 
-### ResultOfGetEndpoints
-
+## ResultOfGetEndpoints
 ```ts
 type ResultOfGetEndpoints = {
     query: string,
     endpoints: string[]
 }
 ```
+- `query`: _string_ – Current query endpoint
+- `endpoints`: _string[]_ – List of all endpoints used by client
 
-* `query`: _string_ – Current query endpoint
-* `endpoints`: _string\[]_ – List of all endpoints used by client
 
-### ParamsOfQueryCounterparties
-
+## ParamsOfQueryCounterparties
 ```ts
 type ParamsOfQueryCounterparties = {
     account: string,
@@ -1531,14 +1524,13 @@ type ParamsOfQueryCounterparties = {
     after?: string
 }
 ```
+- `account`: _string_ – Account address
+- `result`: _string_ – Projection (result) string
+- `first`?: _number_ – Number of counterparties to return
+- `after`?: _string_ – `cursor` field of the last received result
 
-* `account`: _string_ – Account address
-* `result`: _string_ – Projection (result) string
-* `first`?: _number_ – Number of counterparties to return
-* `after`?: _string_ – `cursor` field of the last received result
 
-### ParamsOfQueryTransactionTree
-
+## ParamsOfQueryTransactionTree
 ```ts
 type ParamsOfQueryTransactionTree = {
     in_msg: string,
@@ -1547,35 +1539,26 @@ type ParamsOfQueryTransactionTree = {
     transaction_max_count?: number
 }
 ```
+- `in_msg`: _string_ – Input message id.
+- `abi_registry`?: _[Abi](mod\_abi.md#abi)[]_ – List of contract ABIs that will be used to decode message bodies. Library will try to decode each returned message body using any ABI from the registry.
+- `timeout`?: _number_ – Timeout used to limit waiting time for the missing messages and transaction.
+<br>If some of the following messages and transactions are missing yet<br>The maximum waiting time is regulated by this option.<br><br>Default value is 60000 (1 min). If `timeout` is set to 0 then function<br>will wait infinitely until the whole transaction tree is executed
+- `transaction_max_count`?: _number_ – Maximum transaction count to wait.
+<br>If transaction tree contains more transaction then this parameter then only first<br>`transaction_max_count` transaction are awaited and returned.<br><br>Default value is 50. If `transaction_max_count` is set to 0 then no<br>limitation on transaction count is used and all transaction are<br>returned.
 
-* `in_msg`: _string_ – Input message id.
-* `abi_registry`?: [_Abi_](mod_abi.md#abi)_\[]_ – List of contract ABIs that will be used to decode message bodies. Library will try to decode each returned message body using any ABI from the registry.
-* `timeout`?: _number_ – Timeout used to limit waiting time for the missing messages and transaction.\
-  If some of the following messages and transactions are missing yet\
-  The maximum waiting time is regulated by this option.\
-  \
-  Default value is 60000 (1 min). If `timeout` is set to 0 then function will wait infinitely\
-  until the whole transaction tree is executed
-* `transaction_max_count`?: _number_ – Maximum transaction count to wait.\
-  If transaction tree contains more transaction then this parameter then only first `transaction_max_count` transaction are awaited and returned.\
-  \
-  Default value is 50. If `transaction_max_count` is set to 0 then no limitation on\
-  transaction count is used and all transaction are returned.
 
-### ResultOfQueryTransactionTree
-
+## ResultOfQueryTransactionTree
 ```ts
 type ResultOfQueryTransactionTree = {
     messages: MessageNode[],
     transactions: TransactionNode[]
 }
 ```
+- `messages`: _[MessageNode](mod\_net.md#messagenode)[]_ – Messages.
+- `transactions`: _[TransactionNode](mod\_net.md#transactionnode)[]_ – Transactions.
 
-* `messages`: [_MessageNode_](mod_net.md#messagenode)_\[]_ – Messages.
-* `transactions`: [_TransactionNode_](mod_net.md#transactionnode)_\[]_ – Transactions.
 
-### ParamsOfCreateBlockIterator
-
+## ParamsOfCreateBlockIterator
 ```ts
 type ParamsOfCreateBlockIterator = {
     start_time?: number,
@@ -1584,59 +1567,37 @@ type ParamsOfCreateBlockIterator = {
     result?: string
 }
 ```
+- `start_time`?: _number_ – Starting time to iterate from.
+<br>If the application specifies this parameter then the iteration<br>includes blocks with `gen_utime` >= `start_time`.<br>Otherwise the iteration starts from zero state.<br><br>Must be specified in seconds.
+- `end_time`?: _number_ – Optional end time to iterate for.
+<br>If the application specifies this parameter then the iteration<br>includes blocks with `gen_utime` < `end_time`.<br>Otherwise the iteration never stops.<br><br>Must be specified in seconds.
+- `shard_filter`?: _string[]_ – Shard prefix filter.
+<br>If the application specifies this parameter and it is not the empty<br>array then the iteration will include items related to accounts that<br>belongs to the specified shard prefixes.<br>Shard prefix must be represented as a string "workchain:prefix".<br>Where `workchain` is a signed integer and the `prefix` if a hexadecimal<br>representation if the 64-bit unsigned integer with tagged shard prefix.<br>For example: "0:3800000000000000".
+- `result`?: _string_ – Projection (result) string.
+<br>List of the fields that must be returned for iterated items.<br>This field is the same as the `result` parameter of<br>the `query_collection` function.<br>Note that iterated items can contains additional fields that are<br>not requested in the `result`.
 
-* `start_time`?: _number_ – Starting time to iterate from.\
-  If the application specifies this parameter then the iteration\
-  includes blocks with `gen_utime` >= `start_time`.\
-  Otherwise the iteration starts from zero state.\
-  \
-  Must be specified in seconds.
-* `end_time`?: _number_ – Optional end time to iterate for.\
-  If the application specifies this parameter then the iteration\
-  includes blocks with `gen_utime` < `end_time`.\
-  Otherwise the iteration never stops.\
-  \
-  Must be specified in seconds.
-* `shard_filter`?: _string\[]_ – Shard prefix filter.\
-  If the application specifies this parameter and it is not the empty array\
-  then the iteration will include items related to accounts that belongs to\
-  the specified shard prefixes.\
-  Shard prefix must be represented as a string "workchain:prefix".\
-  Where `workchain` is a signed integer and the `prefix` if a hexadecimal\
-  representation if the 64-bit unsigned integer with tagged shard prefix.\
-  For example: "0:3800000000000000".
-* `result`?: _string_ – Projection (result) string.\
-  List of the fields that must be returned for iterated items.\
-  This field is the same as the `result` parameter of\
-  the `query_collection` function.\
-  Note that iterated items can contains additional fields that are\
-  not requested in the `result`.
 
-### RegisteredIterator
-
+## RegisteredIterator
 ```ts
 type RegisteredIterator = {
     handle: number
 }
 ```
+- `handle`: _number_ – Iterator handle.
+<br>Must be removed using `remove_iterator`<br>when it is no more needed for the application.
 
-* `handle`: _number_ – Iterator handle.\
-  Must be removed using `remove_iterator`\
-  when it is no more needed for the application.
 
-### ParamsOfResumeBlockIterator
-
+## ParamsOfResumeBlockIterator
 ```ts
 type ParamsOfResumeBlockIterator = {
     resume_state: any
 }
 ```
+- `resume_state`: _any_ – Iterator state from which to resume.
+<br>Same as value returned from `iterator_next`.
 
-* `resume_state`: _any_ – Iterator state from which to resume.\
-  Same as value returned from `iterator_next`.
 
-### ParamsOfCreateTransactionIterator
-
+## ParamsOfCreateTransactionIterator
 ```ts
 type ParamsOfCreateTransactionIterator = {
     start_time?: number,
@@ -1647,74 +1608,34 @@ type ParamsOfCreateTransactionIterator = {
     include_transfers?: boolean
 }
 ```
+- `start_time`?: _number_ – Starting time to iterate from.
+<br>If the application specifies this parameter then the iteration<br>includes blocks with `gen_utime` >= `start_time`.<br>Otherwise the iteration starts from zero state.<br><br>Must be specified in seconds.
+- `end_time`?: _number_ – Optional end time to iterate for.
+<br>If the application specifies this parameter then the iteration<br>includes blocks with `gen_utime` < `end_time`.<br>Otherwise the iteration never stops.<br><br>Must be specified in seconds.
+- `shard_filter`?: _string[]_ – Shard prefix filters.
+<br>If the application specifies this parameter and it is not an empty array<br>then the iteration will include items related to accounts that belongs<br>to the specified shard prefixes.<br>Shard prefix must be represented as a string "workchain:prefix".<br>Where `workchain` is a signed integer and the `prefix` if a hexadecimal<br>representation if the 64-bit unsigned integer with tagged shard prefix.<br>For example: "0:3800000000000000".<br>Account address conforms to the shard filter if<br>it belongs to the filter workchain and the first bits of address match<br>to the shard prefix. Only transactions with suitable account<br>addresses are iterated.
+- `accounts_filter`?: _string[]_ – Account address filter.
+<br>Application can specify the list of accounts for which<br>it wants to iterate transactions.<br><br>If this parameter is missing or an empty list then the library iterates<br>transactions for all accounts that pass the shard filter.<br><br>Note that the library doesn't detect conflicts between the account<br>filter and the shard filter if both are specified.<br>So it is an application responsibility to specify the correct filter<br>combination.
+- `result`?: _string_ – Projection (result) string.
+<br>List of the fields that must be returned for iterated items.<br>This field is the same as the `result` parameter of<br>the `query_collection` function.<br>Note that iterated items can contain additional fields that are<br>not requested in the `result`.
+- `include_transfers`?: _boolean_ – Include `transfers` field in iterated transactions.
+<br>If this parameter is `true` then each transaction contains field<br>`transfers` with list of transfer. See more about this structure in<br>function description.
 
-* `start_time`?: _number_ – Starting time to iterate from.\
-  If the application specifies this parameter then the iteration\
-  includes blocks with `gen_utime` >= `start_time`.\
-  Otherwise the iteration starts from zero state.\
-  \
-  Must be specified in seconds.
-* `end_time`?: _number_ – Optional end time to iterate for.\
-  If the application specifies this parameter then the iteration\
-  includes blocks with `gen_utime` < `end_time`.\
-  Otherwise the iteration never stops.\
-  \
-  Must be specified in seconds.
-* `shard_filter`?: _string\[]_ – Shard prefix filters.\
-  If the application specifies this parameter and it is not an empty array\
-  then the iteration will include items related to accounts that belongs to\
-  the specified shard prefixes.\
-  Shard prefix must be represented as a string "workchain:prefix".\
-  Where `workchain` is a signed integer and the `prefix` if a hexadecimal\
-  representation if the 64-bit unsigned integer with tagged shard prefix.\
-  For example: "0:3800000000000000".\
-  Account address conforms to the shard filter if\
-  it belongs to the filter workchain and the first bits of address match to\
-  the shard prefix. Only transactions with suitable account addresses are iterated.
-* `accounts_filter`?: _string\[]_ – Account address filter.\
-  Application can specify the list of accounts for which\
-  it wants to iterate transactions.\
-  \
-  If this parameter is missing or an empty list then the library iterates\
-  transactions for all accounts that pass the shard filter.\
-  \
-  Note that the library doesn't detect conflicts between the account filter and the shard filter\
-  if both are specified.\
-  So it is an application responsibility to specify the correct filter combination.
-* `result`?: _string_ – Projection (result) string.\
-  List of the fields that must be returned for iterated items.\
-  This field is the same as the `result` parameter of\
-  the `query_collection` function.\
-  Note that iterated items can contain additional fields that are\
-  not requested in the `result`.
-* `include_transfers`?: _boolean_ – Include `transfers` field in iterated transactions.\
-  If this parameter is `true` then each transaction contains field\
-  `transfers` with list of transfer. See more about this structure in function description.
 
-### ParamsOfResumeTransactionIterator
-
+## ParamsOfResumeTransactionIterator
 ```ts
 type ParamsOfResumeTransactionIterator = {
     resume_state: any,
     accounts_filter?: string[]
 }
 ```
+- `resume_state`: _any_ – Iterator state from which to resume.
+<br>Same as value returned from `iterator_next`.
+- `accounts_filter`?: _string[]_ – Account address filter.
+<br>Application can specify the list of accounts for which<br>it wants to iterate transactions.<br><br>If this parameter is missing or an empty list then the library iterates<br>transactions for all accounts that passes the shard filter.<br><br>Note that the library doesn't detect conflicts between the account<br>filter and the shard filter if both are specified.<br>So it is the application's responsibility to specify the correct filter<br>combination.
 
-* `resume_state`: _any_ – Iterator state from which to resume.\
-  Same as value returned from `iterator_next`.
-* `accounts_filter`?: _string\[]_ – Account address filter.\
-  Application can specify the list of accounts for which\
-  it wants to iterate transactions.\
-  \
-  If this parameter is missing or an empty list then the library iterates\
-  transactions for all accounts that passes the shard filter.\
-  \
-  Note that the library doesn't detect conflicts between the account filter and the shard filter\
-  if both are specified.\
-  So it is the application's responsibility to specify the correct filter combination.
 
-### ParamsOfIteratorNext
-
+## ParamsOfIteratorNext
 ```ts
 type ParamsOfIteratorNext = {
     iterator: number,
@@ -1722,14 +1643,13 @@ type ParamsOfIteratorNext = {
     return_resume_state?: boolean
 }
 ```
+- `iterator`: _number_ – Iterator handle
+- `limit`?: _number_ – Maximum count of the returned items.
+<br>If value is missing or is less than 1 the library uses 1.
+- `return_resume_state`?: _boolean_ – Indicates that function must return the iterator state that can be used for resuming iteration.
 
-* `iterator`: _number_ – Iterator handle
-* `limit`?: _number_ – Maximum count of the returned items.\
-  If value is missing or is less than 1 the library uses 1.
-* `return_resume_state`?: _boolean_ – Indicates that function must return the iterator state that can be used for resuming iteration.
 
-### ResultOfIteratorNext
-
+## ResultOfIteratorNext
 ```ts
 type ResultOfIteratorNext = {
     items: any[],
@@ -1737,26 +1657,19 @@ type ResultOfIteratorNext = {
     resume_state?: any
 }
 ```
+- `items`: _any[]_ – Next available items.
+<br>Note that `iterator_next` can return an empty items and `has_more`<br>equals to `true`. In this case the application have to continue<br>iteration. Such situation can take place when there is no data yet<br>but the requested `end_time` is not reached.
+- `has_more`: _boolean_ – Indicates that there are more available items in iterated range.
+- `resume_state`?: _any_ – Optional iterator state that can be used for resuming iteration.
+<br>This field is returned only if the `return_resume_state` parameter<br>is specified.<br><br>Note that `resume_state` corresponds to the iteration position<br>after the returned items.
 
-* `items`: _any\[]_ – Next available items.\
-  Note that `iterator_next` can return an empty items and `has_more` equals to `true`.\
-  In this case the application have to continue iteration.\
-  Such situation can take place when there is no data yet but\
-  the requested `end_time` is not reached.
-* `has_more`: _boolean_ – Indicates that there are more available items in iterated range.
-* `resume_state`?: _any_ – Optional iterator state that can be used for resuming iteration.\
-  This field is returned only if the `return_resume_state` parameter\
-  is specified.\
-  \
-  Note that `resume_state` corresponds to the iteration position\
-  after the returned items.
 
-### ResultOfGetSignatureId
-
+## ResultOfGetSignatureId
 ```ts
 type ResultOfGetSignatureId = {
     signature_id?: number
 }
 ```
+- `signature_id`?: _number_ – Signature ID for configured network if it should be used in messages signature
 
-* `signature_id`?: _number_ – Signature ID for configured network if it should be used in messages signature
+

--- a/docs/acki-nacki-sdk/types-and-methods/mod_processing.md
+++ b/docs/acki-nacki-sdk/types-and-methods/mod_processing.md
@@ -1,133 +1,143 @@
 # Module processing
 
-## Module processing
-
 Message processing module.
 
-This module incorporates functions related to complex message processing scenarios.
+This module incorporates functions related to complex message
+processing scenarios.
 
-### Functions
-
-[monitor\_messages](mod_processing.md#monitor_messages) – Starts monitoring for the processing results of the specified messages.
-
-[get\_monitor\_info](mod_processing.md#get_monitor_info) – Returns summary information about current state of the specified monitoring queue.
-
-[fetch\_next\_monitor\_results](mod_processing.md#fetch_next_monitor_results) – Fetches next resolved results from the specified monitoring queue.
-
-[cancel\_monitor](mod_processing.md#cancel_monitor) – Cancels all background activity and releases all allocated system resources for the specified monitoring queue.
-
-[send\_messages](mod_processing.md#send_messages) – Sends specified messages to the blockchain.
-
-[send\_message](mod_processing.md#send_message) – Sends message to the network
-
-[wait\_for\_transaction](mod_processing.md#wait_for_transaction) – Performs monitoring of the network for the result transaction of the external inbound message processing.
-
-[process\_message](mod_processing.md#process_message) – Creates message, sends it to the network and monitors its processing.
-
-### Types
-
-[ProcessingErrorCode](mod_processing.md#processingerrorcode)
-
-[ProcessingEventWillFetchFirstBlockVariant](mod_processing.md#processingeventwillfetchfirstblockvariant) – Notifies the application that the account's current shard block will be fetched from the network. This step is performed before the message sending so that sdk knows starting from which block it will search for the transaction.
-
-[ProcessingEventFetchFirstBlockFailedVariant](mod_processing.md#processingeventfetchfirstblockfailedvariant) – Notifies the app that the client has failed to fetch the account's current shard block.
-
-[ProcessingEventWillSendVariant](mod_processing.md#processingeventwillsendvariant) – Notifies the app that the message will be sent to the network. This event means that the account's current shard block was successfully fetched and the message was successfully created (`abi.encode_message` function was executed successfully).
-
-[ProcessingEventDidSendVariant](mod_processing.md#processingeventdidsendvariant) – Notifies the app that the message was sent to the network, i.e `processing.send_message` was successfully executed. Now, the message is in the blockchain. If Application exits at this phase, Developer needs to proceed with processing after the application is restored with `wait_for_transaction` function, passing shard\_block\_id and message from this event.
-
-[ProcessingEventSendFailedVariant](mod_processing.md#processingeventsendfailedvariant) – Notifies the app that the sending operation was failed with network error.
-
-[ProcessingEventWillFetchNextBlockVariant](mod_processing.md#processingeventwillfetchnextblockvariant) – Notifies the app that the next shard block will be fetched from the network.
-
-[ProcessingEventFetchNextBlockFailedVariant](mod_processing.md#processingeventfetchnextblockfailedvariant) – Notifies the app that the next block can't be fetched.
-
-[ProcessingEventMessageExpiredVariant](mod_processing.md#processingeventmessageexpiredvariant) – Notifies the app that the message was not executed within expire timeout on-chain and will never be because it is already expired. The expiration timeout can be configured with `AbiConfig` parameters.
-
-[ProcessingEventRempSentToValidatorsVariant](mod_processing.md#processingeventrempsenttovalidatorsvariant) – Notifies the app that the message has been delivered to the thread's validators
-
-[ProcessingEventRempIncludedIntoBlockVariant](mod_processing.md#processingeventrempincludedintoblockvariant) – Notifies the app that the message has been successfully included into a block candidate by the thread's collator
-
-[ProcessingEventRempIncludedIntoAcceptedBlockVariant](mod_processing.md#processingeventrempincludedintoacceptedblockvariant) – Notifies the app that the block candidate with the message has been accepted by the thread's validators
-
-[ProcessingEventRempOtherVariant](mod_processing.md#processingeventrempothervariant) – Notifies the app about some other minor REMP statuses occurring during message processing
-
-[ProcessingEventRempErrorVariant](mod_processing.md#processingeventremperrorvariant) – Notifies the app about any problem that has occurred in REMP processing - in this case library switches to the fallback transaction awaiting scenario (sequential block reading).
-
-[ProcessingEvent](mod_processing.md#processingevent)
-
-[ResultOfProcessMessage](mod_processing.md#resultofprocessmessage)
-
-[DecodedOutput](mod_processing.md#decodedoutput)
-
-[MessageMonitoringTransactionCompute](mod_processing.md#messagemonitoringtransactioncompute)
-
-[MessageMonitoringTransaction](mod_processing.md#messagemonitoringtransaction)
-
-[MessageMonitoringParams](mod_processing.md#messagemonitoringparams)
-
-[MessageMonitoringResult](mod_processing.md#messagemonitoringresult)
-
-[MonitorFetchWaitMode](mod_processing.md#monitorfetchwaitmode)
-
-[MonitoredMessageBocVariant](mod_processing.md#monitoredmessagebocvariant) – BOC of the message.
-
-[MonitoredMessageHashAddressVariant](mod_processing.md#monitoredmessagehashaddressvariant) – Message's hash and destination address.
-
-[MonitoredMessage](mod_processing.md#monitoredmessage)
-
-[MessageMonitoringStatus](mod_processing.md#messagemonitoringstatus)
-
-[MessageSendingParams](mod_processing.md#messagesendingparams)
-
-[ParamsOfMonitorMessages](mod_processing.md#paramsofmonitormessages)
-
-[ParamsOfGetMonitorInfo](mod_processing.md#paramsofgetmonitorinfo)
-
-[MonitoringQueueInfo](mod_processing.md#monitoringqueueinfo)
-
-[ParamsOfFetchNextMonitorResults](mod_processing.md#paramsoffetchnextmonitorresults)
-
-[ResultOfFetchNextMonitorResults](mod_processing.md#resultoffetchnextmonitorresults)
-
-[ParamsOfCancelMonitor](mod_processing.md#paramsofcancelmonitor)
-
-[ParamsOfSendMessages](mod_processing.md#paramsofsendmessages)
-
-[ResultOfSendMessages](mod_processing.md#resultofsendmessages)
-
-[ParamsOfSendMessage](mod_processing.md#paramsofsendmessage)
-
-[ResultOfSendMessage](mod_processing.md#resultofsendmessage)
-
-[ParamsOfWaitForTransaction](mod_processing.md#paramsofwaitfortransaction)
-
-[ParamsOfProcessMessage](mod_processing.md#paramsofprocessmessage)
 
 ## Functions
+[monitor_messages](mod\_processing.md#monitor_messages) – Starts monitoring for the processing results of the specified messages.
 
-### monitor\_messages
+[get_monitor_info](mod\_processing.md#get_monitor_info) – Returns summary information about current state of the specified monitoring queue.
+
+[fetch_next_monitor_results](mod\_processing.md#fetch_next_monitor_results) – Fetches next resolved results from the specified monitoring queue.
+
+[cancel_monitor](mod\_processing.md#cancel_monitor) – Cancels all background activity and releases all allocated system resources for the specified monitoring queue.
+
+[send_messages](mod\_processing.md#send_messages) – Sends specified messages to the blockchain.
+
+[send_message](mod\_processing.md#send_message) – Sends message to the network
+
+[wait_for_transaction](mod\_processing.md#wait_for_transaction) – Performs monitoring of the network for the result transaction of the external inbound message processing.
+
+[process_message](mod\_processing.md#process_message) – Creates message, sends it to the network and monitors its processing.
+
+## Types
+[ProcessingErrorCode](mod\_processing.md#processingerrorcode)
+
+[ProcessingEventWillFetchFirstBlockVariant](mod\_processing.md#processingeventwillfetchfirstblockvariant) – Notifies the application that the account's current shard block will be fetched from the network. This step is performed before the message sending so that sdk knows starting from which block it will search for the transaction.
+
+[ProcessingEventFetchFirstBlockFailedVariant](mod\_processing.md#processingeventfetchfirstblockfailedvariant) – Notifies the app that the client has failed to fetch the account's current shard block.
+
+[ProcessingEventWillSendVariant](mod\_processing.md#processingeventwillsendvariant) – Notifies the app that the message will be sent to the network. This event means that the account's current shard block was successfully fetched and the message was successfully created (`abi.encode_message` function was executed successfully).
+
+[ProcessingEventDidSendVariant](mod\_processing.md#processingeventdidsendvariant) – Notifies the app that the message was sent to the network, i.e `processing.send_message` was successfully executed. Now, the message is in the blockchain. If Application exits at this phase, Developer needs to proceed with processing after the application is restored with `wait_for_transaction` function, passing shard_block_id and message from this event.
+
+[ProcessingEventSendFailedVariant](mod\_processing.md#processingeventsendfailedvariant) – Notifies the app that the sending operation was failed with network error.
+
+[ProcessingEventWillFetchNextBlockVariant](mod\_processing.md#processingeventwillfetchnextblockvariant) – Notifies the app that the next shard block will be fetched from the network.
+
+[ProcessingEventFetchNextBlockFailedVariant](mod\_processing.md#processingeventfetchnextblockfailedvariant) – Notifies the app that the next block can't be fetched.
+
+[ProcessingEventMessageExpiredVariant](mod\_processing.md#processingeventmessageexpiredvariant) – Notifies the app that the message was not executed within expire timeout on-chain and will never be because it is already expired. The expiration timeout can be configured with `AbiConfig` parameters.
+
+[ProcessingEventRempSentToValidatorsVariant](mod\_processing.md#processingeventrempsenttovalidatorsvariant) – Notifies the app that the message has been delivered to the thread's validators
+
+[ProcessingEventRempIncludedIntoBlockVariant](mod\_processing.md#processingeventrempincludedintoblockvariant) – Notifies the app that the message has been successfully included into a block candidate by the thread's collator
+
+[ProcessingEventRempIncludedIntoAcceptedBlockVariant](mod\_processing.md#processingeventrempincludedintoacceptedblockvariant) – Notifies the app that the block candidate with the message has been accepted by the thread's validators
+
+[ProcessingEventRempOtherVariant](mod\_processing.md#processingeventrempothervariant) – Notifies the app about some other minor REMP statuses occurring during message processing
+
+[ProcessingEventRempErrorVariant](mod\_processing.md#processingeventremperrorvariant) – Notifies the app about any problem that has occurred in REMP processing - in this case library switches to the fallback transaction awaiting   scenario (sequential block reading).
+
+[ProcessingEvent](mod\_processing.md#processingevent)
+
+[ResultOfProcessMessage](mod\_processing.md#resultofprocessmessage)
+
+[DecodedOutput](mod\_processing.md#decodedoutput)
+
+[MessageMonitoringTransactionCompute](mod\_processing.md#messagemonitoringtransactioncompute)
+
+[MessageMonitoringTransaction](mod\_processing.md#messagemonitoringtransaction)
+
+[MessageMonitoringParams](mod\_processing.md#messagemonitoringparams)
+
+[MessageMonitoringResult](mod\_processing.md#messagemonitoringresult)
+
+[MonitorFetchWaitMode](mod\_processing.md#monitorfetchwaitmode)
+
+[MonitoredMessageBocVariant](mod\_processing.md#monitoredmessagebocvariant)
+
+[MonitoredMessageHashAddressVariant](mod\_processing.md#monitoredmessagehashaddressvariant)
+
+[MonitoredMessage](mod\_processing.md#monitoredmessage)
+
+[MessageMonitoringStatus](mod\_processing.md#messagemonitoringstatus)
+
+[MessageSendingParams](mod\_processing.md#messagesendingparams)
+
+[ParamsOfMonitorMessages](mod\_processing.md#paramsofmonitormessages)
+
+[ParamsOfGetMonitorInfo](mod\_processing.md#paramsofgetmonitorinfo)
+
+[MonitoringQueueInfo](mod\_processing.md#monitoringqueueinfo)
+
+[ParamsOfFetchNextMonitorResults](mod\_processing.md#paramsoffetchnextmonitorresults)
+
+[ResultOfFetchNextMonitorResults](mod\_processing.md#resultoffetchnextmonitorresults)
+
+[ParamsOfCancelMonitor](mod\_processing.md#paramsofcancelmonitor)
+
+[ParamsOfSendMessages](mod\_processing.md#paramsofsendmessages)
+
+[ResultOfSendMessages](mod\_processing.md#resultofsendmessages)
+
+[ParamsOfSendMessage](mod\_processing.md#paramsofsendmessage)
+
+[ResultOfSendMessage](mod\_processing.md#resultofsendmessage)
+
+[ParamsOfWaitForTransaction](mod\_processing.md#paramsofwaitfortransaction)
+
+[ParamsOfProcessMessage](mod\_processing.md#paramsofprocessmessage)
+
+
+# Functions
+## monitor_messages
 
 Starts monitoring for the processing results of the specified messages.
 
-Message monitor performs background monitoring for a message processing results for the specified set of messages.
+Message monitor performs background monitoring for a message processing
+results for the specified set of messages.
 
-Message monitor can serve several isolated monitoring queues. Each monitor queue has a unique application defined identifier (or name) used to separate several queue's.
+Message monitor can serve several isolated monitoring queues.
+Each monitor queue has a unique application defined identifier (or name)
+used to separate several queue's.
 
 There are two important lists inside of the monitoring queue:
 
-* unresolved messages: contains messages requested by the application for monitoring and not yet resolved;
-* resolved results: contains resolved processing results for monitored messages.
+- unresolved messages: contains messages requested by the application for
+  monitoring and not yet resolved;
 
-Each monitoring queue tracks own unresolved and resolved lists. Application can add more messages to the monitoring queue at any time.
+- resolved results: contains resolved processing results for monitored
+  messages.
 
-Message monitor accumulates resolved results. Application should fetch this results with `fetchNextMonitorResults` function.
+Each monitoring queue tracks own unresolved and resolved lists.
+Application can add more messages to the monitoring queue at any time.
 
-When both unresolved and resolved lists becomes empty, monitor stops any background activity and frees all allocated internal memory.
+Message monitor accumulates resolved results.
+Application should fetch this results with `fetchNextMonitorResults`
+function.
 
-If monitoring queue with specified name already exists then messages will be added to the unresolved list.
+When both unresolved and resolved lists becomes empty, monitor stops any
+background activity and frees all allocated internal memory.
 
-If monitoring queue with specified name does not exist then monitoring queue will be created with specified unresolved messages.
+If monitoring queue with specified name already exists then messages will be
+added to the unresolved list.
+
+If monitoring queue with specified name does not exist then monitoring queue
+will be created with specified unresolved messages.
 
 ```ts
 type ParamsOfMonitorMessages = {
@@ -143,15 +153,13 @@ function monitor_messages_sync(
     params: ParamsOfMonitorMessages,
 ): void;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `queue`: _string_ – Name of the monitoring queue.
+- `messages`: _[MessageMonitoringParams](mod\_processing.md#messagemonitoringparams)[]_ – Messages to start monitoring for.
 
-#### Parameters
 
-* `queue`: _string_ – Name of the monitoring queue.
-* `messages`: [_MessageMonitoringParams_](mod_processing.md#messagemonitoringparams)_\[]_ – Messages to start monitoring for.
-
-### get\_monitor\_info
+## get_monitor_info
 
 Returns summary information about current state of the specified monitoring queue.
 
@@ -173,23 +181,23 @@ function get_monitor_info_sync(
     params: ParamsOfGetMonitorInfo,
 ): MonitoringQueueInfo;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `queue`: _string_ – Name of the monitoring queue.
 
-#### Parameters
 
-* `queue`: _string_ – Name of the monitoring queue.
+### Result
 
-#### Result
+- `unresolved`: _number_
+- `resolved`: _number_
 
-* `unresolved`: _number_ – Count of the unresolved messages.
-* `resolved`: _number_ – Count of resolved results.
 
-### fetch\_next\_monitor\_results
+## fetch_next_monitor_results
 
 Fetches next resolved results from the specified monitoring queue.
 
-Results and waiting options are depends on the `wait` parameter. All returned results will be removed from the queue's resolved list.
+Results and waiting options are depends on the `wait` parameter.
+All returned results will be removed from the queue's resolved list.
 
 ```ts
 type ParamsOfFetchNextMonitorResults = {
@@ -209,20 +217,19 @@ function fetch_next_monitor_results_sync(
     params: ParamsOfFetchNextMonitorResults,
 ): ResultOfFetchNextMonitorResults;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `queue`: _string_ – Name of the monitoring queue.
+- `wait_mode`?: _[MonitorFetchWaitMode](mod\_processing.md#monitorfetchwaitmode)_ – Wait mode.
+<br>Default is `NO_WAIT`.
 
-#### Parameters
 
-* `queue`: _string_ – Name of the monitoring queue.
-* `wait_mode`?: [_MonitorFetchWaitMode_](mod_processing.md#monitorfetchwaitmode) – Wait mode.\
-  Default is `NO_WAIT`.
+### Result
 
-#### Result
+- `results`: _[MessageMonitoringResult](mod\_processing.md#messagemonitoringresult)[]_ – List of the resolved results.
 
-* `results`: [_MessageMonitoringResult_](mod_processing.md#messagemonitoringresult)_\[]_ – List of the resolved results.
 
-### cancel\_monitor
+## cancel_monitor
 
 Cancels all background activity and releases all allocated system resources for the specified monitoring queue.
 
@@ -239,14 +246,12 @@ function cancel_monitor_sync(
     params: ParamsOfCancelMonitor,
 ): void;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `queue`: _string_ – Name of the monitoring queue.
 
-#### Parameters
 
-* `queue`: _string_ – Name of the monitoring queue.
-
-### send\_messages
+## send_messages
 
 Sends specified messages to the blockchain.
 
@@ -268,34 +273,46 @@ function send_messages_sync(
     params: ParamsOfSendMessages,
 ): ResultOfSendMessages;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `messages`: _[MessageSendingParams](mod\_processing.md#messagesendingparams)[]_ – Messages that must be sent to the blockchain.
+- `monitor_queue`?: _string_ – Optional message monitor queue that starts monitoring for the processing results for sent messages.
 
-#### Parameters
 
-* `messages`: [_MessageSendingParams_](mod_processing.md#messagesendingparams)_\[]_ – Messages that must be sent to the blockchain.
-* `monitor_queue`?: _string_ – Optional message monitor queue that starts monitoring for the processing results for sent messages.
+### Result
 
-#### Result
+- `messages`: _[MessageMonitoringParams](mod\_processing.md#messagemonitoringparams)[]_ – Messages that was sent to the blockchain for execution.
 
-* `messages`: [_MessageMonitoringParams_](mod_processing.md#messagemonitoringparams)_\[]_ – Messages that was sent to the blockchain for execution.
 
-### send\_message
+## send_message
 
 Sends message to the network
 
-Sends message to the network and returns the last generated shard block of the destination account before the message was sent. It will be required later for message processing.
+Sends message to the network and returns the last generated shard block of
+the destination account before the message was sent. It will be required
+later for message processing.
 
 ```ts
 type ParamsOfSendMessage = {
     message: string,
     abi?: Abi,
-    send_events?: boolean
+    thread_id?: string,
+    send_events?: boolean,
+    dapp_id?: string
 }
 
 type ResultOfSendMessage = {
-    shard_block_id: string,
-    sending_endpoints: string[]
+    message_hash?: string,
+    block_hash?: string,
+    tx_hash?: string,
+    return_value?: any,
+    aborted?: boolean,
+    exit_code?: number,
+    thread_id?: string,
+    producers: string[],
+    current_time?: string,
+    account_id?: string,
+    dapp_id?: string
 }
 
 function send_message(
@@ -307,60 +324,69 @@ function send_message_sync(
     params: ParamsOfSendMessage,
 ): ResultOfSendMessage;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `message`: _string_ – Message BOC.
+- `abi`?: _[Abi](mod\_abi.md#abi)_ – Optional message ABI.
+<br>If this parameter is specified and the message has the<br>`expire` header then expiration time will be checked against<br>the current time to prevent unnecessary sending of already expired<br>message.<br><br>The `message already expired` error will be returned in this<br>case.<br><br>Note, that specifying `abi` for ABI compliant contracts is<br>strongly recommended, so that proper processing strategy can be<br>chosen.
+- `thread_id`?: _string_
+- `send_events`?: _boolean_ – Flag for requesting events sending. Default is `false`.
+- `dapp_id`?: _string_ – Destination dapp_id (64-character hex, no 0x). Required for v>=1.0.0 servers; for v<1.0.0 may be empty (sent as legacy `dst_dapp_id: null`).
+- `responseHandler`?: _[ResponseHandler](modules.md#responsehandler)_ – additional responses handler.
 
-#### Parameters
+### Result
 
-* `message`: _string_ – Message BOC.
-* `abi`?: [_Abi_](mod_abi.md#abi) – Optional message ABI.\
-  If this parameter is specified and the message has the\
-  `expire` header then expiration time will be checked against\
-  the current time to prevent unnecessary sending of already expired message.\
-  \
-  The `message already expired` error will be returned in this\
-  case.\
-  \
-  Note, that specifying `abi` for ABI compliant contracts is\
-  strongly recommended, so that proper processing strategy can be\
-  chosen.
-* `send_events`?: _boolean_ – Flag for requesting events sending. Default is `false`.
-* `responseHandler`?: [_ResponseHandler_](modules.md#responsehandler) – additional responses handler.
+- `message_hash`?: _string_ – The hash of the processed message.
+- `block_hash`?: _string_ – The hash of the block in which the message was included.
+- `tx_hash`?: _string_ – The hash of the transaction generated by the message.
+- `return_value`?: _any_ – Returned values
+- `aborted`?: _boolean_ – The flag is set either if there is no action phase or if the action phase was unsuccessful.
+- `exit_code`?: _number_ – The exit code of the computing phase
+- `thread_id`?: _string_ – The identifier of the thread in which the message was processed.
+- `producers`: _string[]_ – The list (IP addresses) of block producers processing the thread.
+- `current_time`?: _string_ – The timestamp of generating this response.
+- `account_id`?: _string_ – Destination account_id (64-hex, no workchain).
+<br>Always populated: taken from the server response on v>=1.0.0, derived locally<br>from the message destination on v<1.0.0.
+- `dapp_id`?: _string_ – Destination dapp_id (64-hex).
+<br>Always populated: taken from the server response on v>=1.0.0, mirrored from the request on v<1.0.0.
 
-#### Result
 
-* `shard_block_id`: _string_ – The last generated shard block of the message destination account before the message was sent.\
-  This block id must be used as a parameter of the\
-  `wait_for_transaction`.
-* `sending_endpoints`: _string\[]_ – The list of endpoints to which the message was sent.\
-  This list id must be used as a parameter of the\
-  `wait_for_transaction`.
-
-### wait\_for\_transaction
+## wait_for_transaction
 
 Performs monitoring of the network for the result transaction of the external inbound message processing.
 
-`send_events` enables intermediate events, such as `WillFetchNextBlock`, `FetchNextBlockFailed` that may be useful for logging of new shard blocks creation during message processing.
+`send_events` enables intermediate events, such as `WillFetchNextBlock`,
+`FetchNextBlockFailed` that may be useful for logging of new shard blocks
+creation during message processing.
 
-Note, that presence of the `abi` parameter is critical for ABI compliant contracts. Message processing uses drastically different strategy for processing message for contracts which ABI includes "expire" header.
+Note, that presence of the `abi` parameter is critical for ABI
+compliant contracts. Message processing uses drastically
+different strategy for processing message for contracts which
+ABI includes "expire" header.
 
-When the ABI header `expire` is present, the processing uses `message expiration` strategy:
+When the ABI header `expire` is present, the processing uses
+`message expiration` strategy:
+- The maximum block gen time is set to `message_expiration_timeout +
+  transaction_wait_timeout`.
+- When maximum block gen time is reached, the processing will be finished
+  with `MessageExpired` error.
 
-* The maximum block gen time is set to `message_expiration_timeout + transaction_wait_timeout`.
-* When maximum block gen time is reached, the processing will be finished with `MessageExpired` error.
+When the ABI header `expire` isn't present or `abi` parameter
+isn't specified, the processing uses `transaction waiting`
+strategy:
+- The maximum block gen time is set to `now() + transaction_wait_timeout`.
 
-When the ABI header `expire` isn't present or `abi` parameter isn't specified, the processing uses `transaction waiting` strategy:
-
-* The maximum block gen time is set to `now() + transaction_wait_timeout`.
-* If maximum block gen time is reached and no result transaction is found, the processing will exit with an error.
+- If maximum block gen time is reached and no result transaction is found,
+the processing will exit with an error.
 
 ```ts
 type ParamsOfWaitForTransaction = {
     abi?: Abi,
     message: string,
-    shard_block_id: string,
+    shard_block_id?: string,
     send_events?: boolean,
-    sending_endpoints?: string[]
+    sending_endpoints?: string[],
+    tx_hash?: string | null
 }
 
 type ResultOfProcessMessage = {
@@ -379,56 +405,59 @@ function wait_for_transaction_sync(
     params: ParamsOfWaitForTransaction,
 ): ResultOfProcessMessage;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `abi`?: _[Abi](mod\_abi.md#abi)_ – Optional ABI for decoding the transaction result.
+<br>If it is specified, then the output messages' bodies will be<br>decoded according to this ABI.<br><br>The `abi_decoded` result field will be filled out.
+- `message`: _string_ – Message BOC.
+<br>Encoded with `base64`.
+- `shard_block_id`?: _string_ – The last generated block id of the destination account shard before the message was sent.
+<br>Deprecated: no longer used. Block walking has been removed.
+- `send_events`?: _boolean_ – Flag that enables/disables intermediate events. Default is `false`.
+- `sending_endpoints`?: _string[]_ – The list of endpoints to which the message was sent.
+<br>Use this field to get more informative errors.<br>Provide the same value as the `send_message` has returned.<br>If the message was not delivered (expired), SDK will log the endpoint<br>URLs, used for its sending.
+- `tx_hash`?: _string?_ – Transaction hash returned by `send_message`. Used to poll for the transaction directly by hash.
+- `responseHandler`?: _[ResponseHandler](modules.md#responsehandler)_ – additional responses handler.
 
-#### Parameters
+### Result
 
-* `abi`?: [_Abi_](mod_abi.md#abi) – Optional ABI for decoding the transaction result.\
-  If it is specified, then the output messages' bodies will be\
-  decoded according to this ABI.\
-  \
-  The `abi_decoded` result field will be filled out.
-* `message`: _string_ – Message BOC.\
-  Encoded with `base64`.
-* `shard_block_id`: _string_ – The last generated block id of the destination account shard before the message was sent.\
-  You must provide the same value as the `send_message` has returned.
-* `send_events`?: _boolean_ – Flag that enables/disables intermediate events. Default is `false`.
-* `sending_endpoints`?: _string\[]_ – The list of endpoints to which the message was sent.\
-  Use this field to get more informative errors.\
-  Provide the same value as the `send_message` has returned.\
-  If the message was not delivered (expired), SDK will log the endpoint URLs, used for its sending.
-* `responseHandler`?: [_ResponseHandler_](modules.md#responsehandler) – additional responses handler.
+- `transaction`: _any_ – Parsed transaction.
+<br>In addition to the regular transaction fields there is a<br>`boc` field encoded with `base64` which contains source<br>transaction BOC.
+- `out_messages`: _string[]_ – List of output messages' BOCs.
+<br>Encoded as `base64`
+- `decoded`?: _[DecodedOutput](mod\_processing.md#decodedoutput)_ – Optional decoded message bodies according to the optional `abi` parameter.
+- `fees`: _[TransactionFees](mod\_tvm.md#transactionfees)_ – Transaction fees
 
-#### Result
 
-* `transaction`: _any_ – Parsed transaction.\
-  In addition to the regular transaction fields there is a\
-  `boc` field encoded with `base64` which contains source\
-  transaction BOC.
-* `out_messages`: _string\[]_ – List of output messages' BOCs.\
-  Encoded as `base64`
-* `decoded`?: [_DecodedOutput_](mod_processing.md#decodedoutput) – Optional decoded message bodies according to the optional `abi` parameter.
-* `fees`: [_TransactionFees_](mod_tvm.md#transactionfees) – Transaction fees
-
-### process\_message
+## process_message
 
 Creates message, sends it to the network and monitors its processing.
 
-Creates ABI-compatible message, sends it to the network and monitors for the result transaction. Decodes the output messages' bodies.
+Creates ABI-compatible message,
+sends it to the network and monitors for the result transaction.
+Decodes the output messages' bodies.
 
-If contract's ABI includes "expire" header, then SDK implements retries in case of unsuccessful message delivery within the expiration timeout: SDK recreates the message, sends it and processes it again.
+If contract's ABI includes "expire" header, then
+SDK implements retries in case of unsuccessful message delivery within the
+expiration timeout: SDK recreates the message, sends it and processes it
+again.
 
-The intermediate events, such as `WillFetchFirstBlock`, `WillSend`, `DidSend`, `WillFetchNextBlock`, etc - are switched on/off by `send_events` flag and logged into the supplied callback function.
+The intermediate events, such as `WillFetchFirstBlock`, `WillSend`,
+`DidSend`, `WillFetchNextBlock`, etc - are switched on/off by `send_events`
+flag and logged into the supplied callback function.
 
-The retry configuration parameters are defined in the client's `NetworkConfig` and `AbiConfig`.
+The retry configuration parameters are defined in the client's
+`NetworkConfig` and `AbiConfig`.
 
-If contract's ABI does not include "expire" header then, if no transaction is found within the network timeout (see config parameter ), exits with error.
+If contract's ABI does not include "expire" header
+then, if no transaction is found within the network timeout (see config
+parameter ), exits with error.
 
 ```ts
 type ParamsOfProcessMessage = {
     message_encode_params: ParamsOfEncodeMessage,
-    send_events?: boolean
+    send_events?: boolean,
+    dapp_id?: string
 }
 
 type ResultOfProcessMessage = {
@@ -447,30 +476,25 @@ function process_message_sync(
     params: ParamsOfProcessMessage,
 ): ResultOfProcessMessage;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `message_encode_params`: _[ParamsOfEncodeMessage](mod\_abi.md#paramsofencodemessage)_ – Message encode parameters.
+- `send_events`?: _boolean_ – Flag for requesting events sending. Default is `false`.
+- `dapp_id`?: _string_ – Destination dapp_id (64-character hex, no 0x). Required for v>=1.0.0 servers; for v<1.0.0 may be empty.
+- `responseHandler`?: _[ResponseHandler](modules.md#responsehandler)_ – additional responses handler.
 
-#### Parameters
+### Result
 
-* `message_encode_params`: [_ParamsOfEncodeMessage_](mod_abi.md#paramsofencodemessage) – Message encode parameters.
-* `send_events`?: _boolean_ – Flag for requesting events sending. Default is `false`.
-* `responseHandler`?: [_ResponseHandler_](modules.md#responsehandler) – additional responses handler.
+- `transaction`: _any_ – Parsed transaction.
+<br>In addition to the regular transaction fields there is a<br>`boc` field encoded with `base64` which contains source<br>transaction BOC.
+- `out_messages`: _string[]_ – List of output messages' BOCs.
+<br>Encoded as `base64`
+- `decoded`?: _[DecodedOutput](mod\_processing.md#decodedoutput)_ – Optional decoded message bodies according to the optional `abi` parameter.
+- `fees`: _[TransactionFees](mod\_tvm.md#transactionfees)_ – Transaction fees
 
-#### Result
 
-* `transaction`: _any_ – Parsed transaction.\
-  In addition to the regular transaction fields there is a\
-  `boc` field encoded with `base64` which contains source\
-  transaction BOC.
-* `out_messages`: _string\[]_ – List of output messages' BOCs.\
-  Encoded as `base64`
-* `decoded`?: [_DecodedOutput_](mod_processing.md#decodedoutput) – Optional decoded message bodies according to the optional `abi` parameter.
-* `fees`: [_TransactionFees_](mod_tvm.md#transactionfees) – Transaction fees
-
-## Types
-
-### ProcessingErrorCode
-
+# Types
+## ProcessingErrorCode
 ```ts
 enum ProcessingErrorCode {
     MessageAlreadyExpired = 501,
@@ -488,31 +512,34 @@ enum ProcessingErrorCode {
     ExternalSignerMustNotBeUsed = 513,
     MessageRejected = 514,
     InvalidRempStatus = 515,
-    NextRempStatusTimeout = 516
+    NextRempStatusTimeout = 516,
+    InvalidThread = 517,
+    DappIdRequired = 518
 }
 ```
-
 One of the following value:
 
-* `MessageAlreadyExpired = 501`
-* `MessageHasNotDestinationAddress = 502`
-* `CanNotBuildMessageCell = 503`
-* `FetchBlockFailed = 504`
-* `SendMessageFailed = 505`
-* `InvalidMessageBoc = 506`
-* `MessageExpired = 507`
-* `TransactionWaitTimeout = 508`
-* `InvalidBlockReceived = 509`
-* `CanNotCheckBlockShard = 510`
-* `BlockNotFound = 511`
-* `InvalidData = 512`
-* `ExternalSignerMustNotBeUsed = 513`
-* `MessageRejected = 514`
-* `InvalidRempStatus = 515`
-* `NextRempStatusTimeout = 516`
+- `MessageAlreadyExpired = 501`
+- `MessageHasNotDestinationAddress = 502`
+- `CanNotBuildMessageCell = 503`
+- `FetchBlockFailed = 504`
+- `SendMessageFailed = 505`
+- `InvalidMessageBoc = 506`
+- `MessageExpired = 507`
+- `TransactionWaitTimeout = 508`
+- `InvalidBlockReceived = 509`
+- `CanNotCheckBlockShard = 510`
+- `BlockNotFound = 511`
+- `InvalidData = 512`
+- `ExternalSignerMustNotBeUsed = 513`
+- `MessageRejected = 514`
+- `InvalidRempStatus = 515`
+- `NextRempStatusTimeout = 516`
+- `InvalidThread = 517`
+- `DappIdRequired = 518`
 
-### ProcessingEventWillFetchFirstBlockVariant
 
+## ProcessingEventWillFetchFirstBlockVariant
 Notifies the application that the account's current shard block will be fetched from the network. This step is performed before the message sending so that sdk knows starting from which block it will search for the transaction.
 
 Fetched block will be used later in waiting phase.
@@ -523,15 +550,16 @@ type ProcessingEventWillFetchFirstBlockVariant = {
     message_dst: string
 }
 ```
+- `message_id`: _string_
+- `message_dst`: _string_
 
-* `message_id`: _string_
-* `message_dst`: _string_
 
-### ProcessingEventFetchFirstBlockFailedVariant
-
+## ProcessingEventFetchFirstBlockFailedVariant
 Notifies the app that the client has failed to fetch the account's current shard block.
 
-This may happen due to the network issues. Receiving this event means that message processing will not proceed - message was not sent, and Developer can try to run `process_message` again, in the hope that the connection is restored.
+This may happen due to the network issues. Receiving this event means that message processing will not proceed -
+message was not sent, and Developer can try to run `process_message`
+again, in the hope that the connection is restored.
 
 ```ts
 type ProcessingEventFetchFirstBlockFailedVariant = {
@@ -540,13 +568,12 @@ type ProcessingEventFetchFirstBlockFailedVariant = {
     message_dst: string
 }
 ```
+- `error`: _[ClientError](mod\_client.md#clienterror)_
+- `message_id`: _string_
+- `message_dst`: _string_
 
-* `error`: [_ClientError_](mod_client.md#clienterror)
-* `message_id`: _string_
-* `message_dst`: _string_
 
-### ProcessingEventWillSendVariant
-
+## ProcessingEventWillSendVariant
 Notifies the app that the message will be sent to the network. This event means that the account's current shard block was successfully fetched and the message was successfully created (`abi.encode_message` function was executed successfully).
 
 ```ts
@@ -557,17 +584,17 @@ type ProcessingEventWillSendVariant = {
     message: string
 }
 ```
+- `shard_block_id`: _string_
+- `message_id`: _string_
+- `message_dst`: _string_
+- `message`: _string_
 
-* `shard_block_id`: _string_
-* `message_id`: _string_
-* `message_dst`: _string_
-* `message`: _string_
 
-### ProcessingEventDidSendVariant
+## ProcessingEventDidSendVariant
+Notifies the app that the message was sent to the network, i.e `processing.send_message` was successfully executed. Now, the message is in the blockchain. If Application exits at this phase, Developer needs to proceed with processing after the application is restored with `wait_for_transaction` function, passing shard_block_id and message from this event.
 
-Notifies the app that the message was sent to the network, i.e `processing.send_message` was successfully executed. Now, the message is in the blockchain. If Application exits at this phase, Developer needs to proceed with processing after the application is restored with `wait_for_transaction` function, passing shard\_block\_id and message from this event.
-
-Do not forget to specify abi of your contract as well, it is crucial for processing. See `processing.wait_for_transaction` documentation.
+Do not forget to specify abi of your contract as well, it is crucial for processing. See
+`processing.wait_for_transaction` documentation.
 
 ```ts
 type ProcessingEventDidSendVariant = {
@@ -577,17 +604,24 @@ type ProcessingEventDidSendVariant = {
     message: string
 }
 ```
+- `shard_block_id`: _string_
+- `message_id`: _string_
+- `message_dst`: _string_
+- `message`: _string_
 
-* `shard_block_id`: _string_
-* `message_id`: _string_
-* `message_dst`: _string_
-* `message`: _string_
 
-### ProcessingEventSendFailedVariant
-
+## ProcessingEventSendFailedVariant
 Notifies the app that the sending operation was failed with network error.
 
-Nevertheless the processing will be continued at the waiting phase because the message possibly has been delivered to the node. If Application exits at this phase, Developer needs to proceed with processing after the application is restored with `wait_for_transaction` function, passing shard\_block\_id and message from this event. Do not forget to specify abi of your contract as well, it is crucial for processing. See `processing.wait_for_transaction` documentation.
+Nevertheless the processing will be continued at the waiting
+phase because the message possibly has been delivered to the
+node.
+If Application exits at this phase, Developer needs to proceed with
+processing after the application is restored with
+`wait_for_transaction` function, passing shard_block_id and message
+from this event. Do not forget to specify abi of your contract
+as well, it is crucial for processing. See
+`processing.wait_for_transaction` documentation.
 
 ```ts
 type ProcessingEventSendFailedVariant = {
@@ -598,18 +632,24 @@ type ProcessingEventSendFailedVariant = {
     error: ClientError
 }
 ```
+- `shard_block_id`: _string_
+- `message_id`: _string_
+- `message_dst`: _string_
+- `message`: _string_
+- `error`: _[ClientError](mod\_client.md#clienterror)_
 
-* `shard_block_id`: _string_
-* `message_id`: _string_
-* `message_dst`: _string_
-* `message`: _string_
-* `error`: [_ClientError_](mod_client.md#clienterror)
 
-### ProcessingEventWillFetchNextBlockVariant
-
+## ProcessingEventWillFetchNextBlockVariant
 Notifies the app that the next shard block will be fetched from the network.
 
-Event can occurs more than one time due to block walking procedure. If Application exits at this phase, Developer needs to proceed with processing after the application is restored with `wait_for_transaction` function, passing shard\_block\_id and message from this event. Do not forget to specify abi of your contract as well, it is crucial for processing. See `processing.wait_for_transaction` documentation.
+Event can occurs more than one time due to block walking
+procedure.
+If Application exits at this phase, Developer needs to proceed with
+processing after the application is restored with
+`wait_for_transaction` function, passing shard_block_id and message
+from this event. Do not forget to specify abi of your contract
+as well, it is crucial for processing. See
+`processing.wait_for_transaction` documentation.
 
 ```ts
 type ProcessingEventWillFetchNextBlockVariant = {
@@ -619,19 +659,24 @@ type ProcessingEventWillFetchNextBlockVariant = {
     message: string
 }
 ```
+- `shard_block_id`: _string_
+- `message_id`: _string_
+- `message_dst`: _string_
+- `message`: _string_
 
-* `shard_block_id`: _string_
-* `message_id`: _string_
-* `message_dst`: _string_
-* `message`: _string_
 
-### ProcessingEventFetchNextBlockFailedVariant
-
+## ProcessingEventFetchNextBlockFailedVariant
 Notifies the app that the next block can't be fetched.
 
-If no block was fetched within `NetworkConfig.wait_for_timeout` then processing stops. This may happen when the shard stops, or there are other network issues. In this case Developer should resume message processing with `wait_for_transaction`, passing shard\_block\_id, message and contract abi to it. Note that passing ABI is crucial, because it will influence the processing strategy.
+If no block was fetched within `NetworkConfig.wait_for_timeout` then
+processing stops. This may happen when the shard stops, or there are
+other network issues. In this case Developer should resume message
+processing with `wait_for_transaction`, passing shard_block_id,
+message and contract abi to it. Note that passing ABI is crucial,
+because it will influence the processing strategy.
 
-Another way to tune this is to specify long timeout in `NetworkConfig.wait_for_timeout`
+Another way to tune this is to specify long timeout in
+`NetworkConfig.wait_for_timeout`
 
 ```ts
 type ProcessingEventFetchNextBlockFailedVariant = {
@@ -642,20 +687,24 @@ type ProcessingEventFetchNextBlockFailedVariant = {
     error: ClientError
 }
 ```
+- `shard_block_id`: _string_
+- `message_id`: _string_
+- `message_dst`: _string_
+- `message`: _string_
+- `error`: _[ClientError](mod\_client.md#clienterror)_
 
-* `shard_block_id`: _string_
-* `message_id`: _string_
-* `message_dst`: _string_
-* `message`: _string_
-* `error`: [_ClientError_](mod_client.md#clienterror)
 
-### ProcessingEventMessageExpiredVariant
-
+## ProcessingEventMessageExpiredVariant
 Notifies the app that the message was not executed within expire timeout on-chain and will never be because it is already expired. The expiration timeout can be configured with `AbiConfig` parameters.
 
-This event occurs only for the contracts which ABI includes "expire" header.
+This event occurs only for the contracts which ABI includes "expire"
+header.
 
-If Application specifies `NetworkConfig.message_retries_count` > 0, then `process_message` will perform retries: will create a new message and send it again and repeat it until it reaches the maximum retries count or receives a successful result. All the processing events will be repeated.
+If Application specifies `NetworkConfig.message_retries_count` > 0, then
+`process_message` will perform retries: will create a new message
+and send it again and repeat it until it reaches the maximum retries
+count or receives a successful result.  All the processing
+events will be repeated.
 
 ```ts
 type ProcessingEventMessageExpiredVariant = {
@@ -665,14 +714,13 @@ type ProcessingEventMessageExpiredVariant = {
     error: ClientError
 }
 ```
+- `message_id`: _string_
+- `message_dst`: _string_
+- `message`: _string_
+- `error`: _[ClientError](mod\_client.md#clienterror)_
 
-* `message_id`: _string_
-* `message_dst`: _string_
-* `message`: _string_
-* `error`: [_ClientError_](mod_client.md#clienterror)
 
-### ProcessingEventRempSentToValidatorsVariant
-
+## ProcessingEventRempSentToValidatorsVariant
 Notifies the app that the message has been delivered to the thread's validators
 
 ```ts
@@ -683,14 +731,13 @@ type ProcessingEventRempSentToValidatorsVariant = {
     json: any
 }
 ```
+- `message_id`: _string_
+- `message_dst`: _string_
+- `timestamp`: _bigint_
+- `json`: _any_
 
-* `message_id`: _string_
-* `message_dst`: _string_
-* `timestamp`: _bigint_
-* `json`: _any_
 
-### ProcessingEventRempIncludedIntoBlockVariant
-
+## ProcessingEventRempIncludedIntoBlockVariant
 Notifies the app that the message has been successfully included into a block candidate by the thread's collator
 
 ```ts
@@ -701,14 +748,13 @@ type ProcessingEventRempIncludedIntoBlockVariant = {
     json: any
 }
 ```
+- `message_id`: _string_
+- `message_dst`: _string_
+- `timestamp`: _bigint_
+- `json`: _any_
 
-* `message_id`: _string_
-* `message_dst`: _string_
-* `timestamp`: _bigint_
-* `json`: _any_
 
-### ProcessingEventRempIncludedIntoAcceptedBlockVariant
-
+## ProcessingEventRempIncludedIntoAcceptedBlockVariant
 Notifies the app that the block candidate with the message has been accepted by the thread's validators
 
 ```ts
@@ -719,14 +765,13 @@ type ProcessingEventRempIncludedIntoAcceptedBlockVariant = {
     json: any
 }
 ```
+- `message_id`: _string_
+- `message_dst`: _string_
+- `timestamp`: _bigint_
+- `json`: _any_
 
-* `message_id`: _string_
-* `message_dst`: _string_
-* `timestamp`: _bigint_
-* `json`: _any_
 
-### ProcessingEventRempOtherVariant
-
+## ProcessingEventRempOtherVariant
 Notifies the app about some other minor REMP statuses occurring during message processing
 
 ```ts
@@ -737,15 +782,14 @@ type ProcessingEventRempOtherVariant = {
     json: any
 }
 ```
+- `message_id`: _string_
+- `message_dst`: _string_
+- `timestamp`: _bigint_
+- `json`: _any_
 
-* `message_id`: _string_
-* `message_dst`: _string_
-* `timestamp`: _bigint_
-* `json`: _any_
 
-### ProcessingEventRempErrorVariant
-
-Notifies the app about any problem that has occurred in REMP processing - in this case library switches to the fallback transaction awaiting scenario (sequential block reading).
+## ProcessingEventRempErrorVariant
+Notifies the app about any problem that has occurred in REMP processing - in this case library switches to the fallback transaction awaiting   scenario (sequential block reading).
 
 ```ts
 type ProcessingEventRempErrorVariant = {
@@ -754,13 +798,12 @@ type ProcessingEventRempErrorVariant = {
     error: ClientError
 }
 ```
+- `message_id`: _string_
+- `message_dst`: _string_
+- `error`: _[ClientError](mod\_client.md#clienterror)_
 
-* `message_id`: _string_
-* `message_dst`: _string_
-* `error`: [_ClientError_](mod_client.md#clienterror)
 
-### ProcessingEvent
-
+## ProcessingEvent
 ```ts
 type ProcessingEvent = ({
     type: 'WillFetchFirstBlock'
@@ -790,8 +833,7 @@ type ProcessingEvent = ({
     type: 'RempError'
 } & ProcessingEventRempErrorVariant)
 ```
-
-Depends on value of the `type` field.
+Depends on value of the  `type` field.
 
 When _type_ is _'WillFetchFirstBlock'_
 
@@ -799,132 +841,162 @@ Notifies the application that the account's current shard block will be fetched 
 
 Fetched block will be used later in waiting phase.
 
-* `message_id`: _string_
-* `message_dst`: _string_
+- `message_id`: _string_
+- `message_dst`: _string_
 
 When _type_ is _'FetchFirstBlockFailed'_
 
 Notifies the app that the client has failed to fetch the account's current shard block.
 
-This may happen due to the network issues. Receiving this event means that message processing will not proceed - message was not sent, and Developer can try to run `process_message` again, in the hope that the connection is restored.
+This may happen due to the network issues. Receiving this event means that message processing will not proceed -
+message was not sent, and Developer can try to run `process_message`
+again, in the hope that the connection is restored.
 
-* `error`: [_ClientError_](mod_client.md#clienterror)
-* `message_id`: _string_
-* `message_dst`: _string_
+- `error`: _[ClientError](mod\_client.md#clienterror)_
+- `message_id`: _string_
+- `message_dst`: _string_
 
 When _type_ is _'WillSend'_
 
 Notifies the app that the message will be sent to the network. This event means that the account's current shard block was successfully fetched and the message was successfully created (`abi.encode_message` function was executed successfully).
 
-* `shard_block_id`: _string_
-* `message_id`: _string_
-* `message_dst`: _string_
-* `message`: _string_
+- `shard_block_id`: _string_
+- `message_id`: _string_
+- `message_dst`: _string_
+- `message`: _string_
 
 When _type_ is _'DidSend'_
 
-Notifies the app that the message was sent to the network, i.e `processing.send_message` was successfully executed. Now, the message is in the blockchain. If Application exits at this phase, Developer needs to proceed with processing after the application is restored with `wait_for_transaction` function, passing shard\_block\_id and message from this event.
+Notifies the app that the message was sent to the network, i.e `processing.send_message` was successfully executed. Now, the message is in the blockchain. If Application exits at this phase, Developer needs to proceed with processing after the application is restored with `wait_for_transaction` function, passing shard_block_id and message from this event.
 
-Do not forget to specify abi of your contract as well, it is crucial for processing. See `processing.wait_for_transaction` documentation.
+Do not forget to specify abi of your contract as well, it is crucial for processing. See
+`processing.wait_for_transaction` documentation.
 
-* `shard_block_id`: _string_
-* `message_id`: _string_
-* `message_dst`: _string_
-* `message`: _string_
+- `shard_block_id`: _string_
+- `message_id`: _string_
+- `message_dst`: _string_
+- `message`: _string_
 
 When _type_ is _'SendFailed'_
 
 Notifies the app that the sending operation was failed with network error.
 
-Nevertheless the processing will be continued at the waiting phase because the message possibly has been delivered to the node. If Application exits at this phase, Developer needs to proceed with processing after the application is restored with `wait_for_transaction` function, passing shard\_block\_id and message from this event. Do not forget to specify abi of your contract as well, it is crucial for processing. See `processing.wait_for_transaction` documentation.
+Nevertheless the processing will be continued at the waiting
+phase because the message possibly has been delivered to the
+node.
+If Application exits at this phase, Developer needs to proceed with
+processing after the application is restored with
+`wait_for_transaction` function, passing shard_block_id and message
+from this event. Do not forget to specify abi of your contract
+as well, it is crucial for processing. See
+`processing.wait_for_transaction` documentation.
 
-* `shard_block_id`: _string_
-* `message_id`: _string_
-* `message_dst`: _string_
-* `message`: _string_
-* `error`: [_ClientError_](mod_client.md#clienterror)
+- `shard_block_id`: _string_
+- `message_id`: _string_
+- `message_dst`: _string_
+- `message`: _string_
+- `error`: _[ClientError](mod\_client.md#clienterror)_
 
 When _type_ is _'WillFetchNextBlock'_
 
 Notifies the app that the next shard block will be fetched from the network.
 
-Event can occurs more than one time due to block walking procedure. If Application exits at this phase, Developer needs to proceed with processing after the application is restored with `wait_for_transaction` function, passing shard\_block\_id and message from this event. Do not forget to specify abi of your contract as well, it is crucial for processing. See `processing.wait_for_transaction` documentation.
+Event can occurs more than one time due to block walking
+procedure.
+If Application exits at this phase, Developer needs to proceed with
+processing after the application is restored with
+`wait_for_transaction` function, passing shard_block_id and message
+from this event. Do not forget to specify abi of your contract
+as well, it is crucial for processing. See
+`processing.wait_for_transaction` documentation.
 
-* `shard_block_id`: _string_
-* `message_id`: _string_
-* `message_dst`: _string_
-* `message`: _string_
+- `shard_block_id`: _string_
+- `message_id`: _string_
+- `message_dst`: _string_
+- `message`: _string_
 
 When _type_ is _'FetchNextBlockFailed'_
 
 Notifies the app that the next block can't be fetched.
 
-If no block was fetched within `NetworkConfig.wait_for_timeout` then processing stops. This may happen when the shard stops, or there are other network issues. In this case Developer should resume message processing with `wait_for_transaction`, passing shard\_block\_id, message and contract abi to it. Note that passing ABI is crucial, because it will influence the processing strategy.
+If no block was fetched within `NetworkConfig.wait_for_timeout` then
+processing stops. This may happen when the shard stops, or there are
+other network issues. In this case Developer should resume message
+processing with `wait_for_transaction`, passing shard_block_id,
+message and contract abi to it. Note that passing ABI is crucial,
+because it will influence the processing strategy.
 
-Another way to tune this is to specify long timeout in `NetworkConfig.wait_for_timeout`
+Another way to tune this is to specify long timeout in
+`NetworkConfig.wait_for_timeout`
 
-* `shard_block_id`: _string_
-* `message_id`: _string_
-* `message_dst`: _string_
-* `message`: _string_
-* `error`: [_ClientError_](mod_client.md#clienterror)
+- `shard_block_id`: _string_
+- `message_id`: _string_
+- `message_dst`: _string_
+- `message`: _string_
+- `error`: _[ClientError](mod\_client.md#clienterror)_
 
 When _type_ is _'MessageExpired'_
 
 Notifies the app that the message was not executed within expire timeout on-chain and will never be because it is already expired. The expiration timeout can be configured with `AbiConfig` parameters.
 
-This event occurs only for the contracts which ABI includes "expire" header.
+This event occurs only for the contracts which ABI includes "expire"
+header.
 
-If Application specifies `NetworkConfig.message_retries_count` > 0, then `process_message` will perform retries: will create a new message and send it again and repeat it until it reaches the maximum retries count or receives a successful result. All the processing events will be repeated.
+If Application specifies `NetworkConfig.message_retries_count` > 0, then
+`process_message` will perform retries: will create a new message
+and send it again and repeat it until it reaches the maximum retries
+count or receives a successful result.  All the processing
+events will be repeated.
 
-* `message_id`: _string_
-* `message_dst`: _string_
-* `message`: _string_
-* `error`: [_ClientError_](mod_client.md#clienterror)
+- `message_id`: _string_
+- `message_dst`: _string_
+- `message`: _string_
+- `error`: _[ClientError](mod\_client.md#clienterror)_
 
 When _type_ is _'RempSentToValidators'_
 
 Notifies the app that the message has been delivered to the thread's validators
 
-* `message_id`: _string_
-* `message_dst`: _string_
-* `timestamp`: _bigint_
-* `json`: _any_
+- `message_id`: _string_
+- `message_dst`: _string_
+- `timestamp`: _bigint_
+- `json`: _any_
 
 When _type_ is _'RempIncludedIntoBlock'_
 
 Notifies the app that the message has been successfully included into a block candidate by the thread's collator
 
-* `message_id`: _string_
-* `message_dst`: _string_
-* `timestamp`: _bigint_
-* `json`: _any_
+- `message_id`: _string_
+- `message_dst`: _string_
+- `timestamp`: _bigint_
+- `json`: _any_
 
 When _type_ is _'RempIncludedIntoAcceptedBlock'_
 
 Notifies the app that the block candidate with the message has been accepted by the thread's validators
 
-* `message_id`: _string_
-* `message_dst`: _string_
-* `timestamp`: _bigint_
-* `json`: _any_
+- `message_id`: _string_
+- `message_dst`: _string_
+- `timestamp`: _bigint_
+- `json`: _any_
 
 When _type_ is _'RempOther'_
 
 Notifies the app about some other minor REMP statuses occurring during message processing
 
-* `message_id`: _string_
-* `message_dst`: _string_
-* `timestamp`: _bigint_
-* `json`: _any_
+- `message_id`: _string_
+- `message_dst`: _string_
+- `timestamp`: _bigint_
+- `json`: _any_
 
 When _type_ is _'RempError'_
 
-Notifies the app about any problem that has occurred in REMP processing - in this case library switches to the fallback transaction awaiting scenario (sequential block reading).
+Notifies the app about any problem that has occurred in REMP processing - in this case library switches to the fallback transaction awaiting   scenario (sequential block reading).
 
-* `message_id`: _string_
-* `message_dst`: _string_
-* `error`: [_ClientError_](mod_client.md#clienterror)
+- `message_id`: _string_
+- `message_dst`: _string_
+- `error`: _[ClientError](mod\_client.md#clienterror)_
+
 
 Variant constructors:
 
@@ -944,8 +1016,7 @@ function processingEventRempOther(message_id: string, message_dst: string, times
 function processingEventRempError(message_id: string, message_dst: string, error: ClientError): ProcessingEvent;
 ```
 
-### ResultOfProcessMessage
-
+## ResultOfProcessMessage
 ```ts
 type ResultOfProcessMessage = {
     transaction: any,
@@ -954,42 +1025,36 @@ type ResultOfProcessMessage = {
     fees: TransactionFees
 }
 ```
+- `transaction`: _any_ – Parsed transaction.
+<br>In addition to the regular transaction fields there is a<br>`boc` field encoded with `base64` which contains source<br>transaction BOC.
+- `out_messages`: _string[]_ – List of output messages' BOCs.
+<br>Encoded as `base64`
+- `decoded`?: _[DecodedOutput](mod\_processing.md#decodedoutput)_ – Optional decoded message bodies according to the optional `abi` parameter.
+- `fees`: _[TransactionFees](mod\_tvm.md#transactionfees)_ – Transaction fees
 
-* `transaction`: _any_ – Parsed transaction.\
-  In addition to the regular transaction fields there is a\
-  `boc` field encoded with `base64` which contains source\
-  transaction BOC.
-* `out_messages`: _string\[]_ – List of output messages' BOCs.\
-  Encoded as `base64`
-* `decoded`?: [_DecodedOutput_](mod_processing.md#decodedoutput) – Optional decoded message bodies according to the optional `abi` parameter.
-* `fees`: [_TransactionFees_](mod_tvm.md#transactionfees) – Transaction fees
 
-### DecodedOutput
-
+## DecodedOutput
 ```ts
 type DecodedOutput = {
     out_messages: DecodedMessageBody | null[],
     output?: any
 }
 ```
+- `out_messages`: _[DecodedMessageBody](mod\_abi.md#decodedmessagebody)?[]_ – Decoded bodies of the out messages.
+<br>If the message can't be decoded, then `None` will be stored in<br>the appropriate position.
+- `output`?: _any_ – Decoded body of the function output message.
 
-* `out_messages`: [_DecodedMessageBody_](mod_abi.md#decodedmessagebody)_?\[]_ – Decoded bodies of the out messages.\
-  If the message can't be decoded, then `None` will be stored in\
-  the appropriate position.
-* `output`?: _any_ – Decoded body of the function output message.
 
-### MessageMonitoringTransactionCompute
-
+## MessageMonitoringTransactionCompute
 ```ts
 type MessageMonitoringTransactionCompute = {
     exit_code: number
 }
 ```
+- `exit_code`: _number_
 
-* `exit_code`: _number_ – Compute phase exit code.
 
-### MessageMonitoringTransaction
-
+## MessageMonitoringTransaction
 ```ts
 type MessageMonitoringTransaction = {
     hash?: string,
@@ -997,13 +1062,12 @@ type MessageMonitoringTransaction = {
     compute?: MessageMonitoringTransactionCompute
 }
 ```
+- `hash`?: _string_
+- `aborted`: _boolean_
+- `compute`?: _[MessageMonitoringTransactionCompute](mod\_processing.md#messagemonitoringtransactioncompute)_
 
-* `hash`?: _string_ – Hash of the transaction. Present if transaction was included into the blocks. When then transaction was emulated this field will be missing.
-* `aborted`: _boolean_ – Aborted field of the transaction.
-* `compute`?: [_MessageMonitoringTransactionCompute_](mod_processing.md#messagemonitoringtransactioncompute) – Optional information about the compute phase of the transaction.
 
-### MessageMonitoringParams
-
+## MessageMonitoringParams
 ```ts
 type MessageMonitoringParams = {
     message: MonitoredMessage,
@@ -1011,13 +1075,12 @@ type MessageMonitoringParams = {
     user_data?: any
 }
 ```
+- `message`: _[MonitoredMessage](mod\_processing.md#monitoredmessage)_
+- `wait_until`: _number_
+- `user_data`?: _any_
 
-* `message`: [_MonitoredMessage_](mod_processing.md#monitoredmessage) – Monitored message identification. Can be provided as a message's BOC or (hash, address) pair. BOC is a preferable way because it helps to determine possible error reason (using TVM execution of the message).
-* `wait_until`: _number_ – Block time Must be specified as a UNIX timestamp in seconds
-* `user_data`?: _any_ – User defined data associated with this message. Helps to identify this message when user received `MessageMonitoringResult`.
 
-### MessageMonitoringResult
-
+## MessageMonitoringResult
 ```ts
 type MessageMonitoringResult = {
     hash: string,
@@ -1027,15 +1090,14 @@ type MessageMonitoringResult = {
     user_data?: any
 }
 ```
+- `hash`: _string_
+- `status`: _[MessageMonitoringStatus](mod\_processing.md#messagemonitoringstatus)_
+- `transaction`?: _[MessageMonitoringTransaction](mod\_processing.md#messagemonitoringtransaction)_
+- `error`?: _string_
+- `user_data`?: _any_
 
-* `hash`: _string_ – Hash of the message.
-* `status`: [_MessageMonitoringStatus_](mod_processing.md#messagemonitoringstatus) – Processing status.
-* `transaction`?: [_MessageMonitoringTransaction_](mod_processing.md#messagemonitoringtransaction) – In case of `Finalized` the transaction is extracted from the block. In case of `Timeout` the transaction is emulated using the last known account state.
-* `error`?: _string_ – In case of `Timeout` contains possible error reason.
-* `user_data`?: _any_ – User defined data related to this message. This is the same value as passed before with `MessageMonitoringParams` or `SendMessageParams`.
 
-### MonitorFetchWaitMode
-
+## MonitorFetchWaitMode
 ```ts
 enum MonitorFetchWaitMode {
     AtLeastOne = "AtLeastOne",
@@ -1043,41 +1105,34 @@ enum MonitorFetchWaitMode {
     NoWait = "NoWait"
 }
 ```
-
 One of the following value:
 
-* `AtLeastOne = "AtLeastOne"` – If there are no resolved results yet, then monitor awaits for the next resolved result.
-* `All = "All"` – Monitor waits until all unresolved messages will be resolved. If there are no unresolved messages then monitor will wait.
-* `NoWait = "NoWait"`
+- `AtLeastOne = "AtLeastOne"`
+- `All = "All"`
+- `NoWait = "NoWait"`
 
-### MonitoredMessageBocVariant
 
-BOC of the message.
-
+## MonitoredMessageBocVariant
 ```ts
 type MonitoredMessageBocVariant = {
     boc: string
 }
 ```
+- `boc`: _string_
 
-* `boc`: _string_
 
-### MonitoredMessageHashAddressVariant
-
-Message's hash and destination address.
-
+## MonitoredMessageHashAddressVariant
 ```ts
 type MonitoredMessageHashAddressVariant = {
     hash: string,
     address: string
 }
 ```
+- `hash`: _string_
+- `address`: _string_
 
-* `hash`: _string_ – Hash of the message.
-* `address`: _string_ – Destination address of the message.
 
-### MonitoredMessage
-
+## MonitoredMessage
 ```ts
 type MonitoredMessage = ({
     type: 'Boc'
@@ -1085,21 +1140,17 @@ type MonitoredMessage = ({
     type: 'HashAddress'
 } & MonitoredMessageHashAddressVariant)
 ```
-
-Depends on value of the `type` field.
+Depends on value of the  `type` field.
 
 When _type_ is _'Boc'_
 
-BOC of the message.
-
-* `boc`: _string_
+- `boc`: _string_
 
 When _type_ is _'HashAddress'_
 
-Message's hash and destination address.
+- `hash`: _string_
+- `address`: _string_
 
-* `hash`: _string_ – Hash of the message.
-* `address`: _string_ – Destination address of the message.
 
 Variant constructors:
 
@@ -1108,8 +1159,7 @@ function monitoredMessageBoc(boc: string): MonitoredMessage;
 function monitoredMessageHashAddress(hash: string, address: string): MonitoredMessage;
 ```
 
-### MessageMonitoringStatus
-
+## MessageMonitoringStatus
 ```ts
 enum MessageMonitoringStatus {
     Finalized = "Finalized",
@@ -1117,17 +1167,14 @@ enum MessageMonitoringStatus {
     Reserved = "Reserved"
 }
 ```
-
 One of the following value:
 
-* `Finalized = "Finalized"` – Returned when the messages was processed and included into finalized block before `wait_until` block time.
-* `Timeout = "Timeout"` – Returned when the message was not processed until `wait_until` block time.
-* `Reserved = "Reserved"` – Reserved for future statuses.\
-  Is never returned. Application should wait for one of the `Finalized` or `Timeout` statuses.\
-  All other statuses are intermediate.
+- `Finalized = "Finalized"`
+- `Timeout = "Timeout"`
+- `Reserved = "Reserved"`
 
-### MessageSendingParams
 
+## MessageSendingParams
 ```ts
 type MessageSendingParams = {
     boc: string,
@@ -1135,175 +1182,174 @@ type MessageSendingParams = {
     user_data?: any
 }
 ```
+- `boc`: _string_ – BOC of the message, that must be sent to the blockchain.
+- `wait_until`: _number_ – Expiration time of the message. Must be specified as a UNIX timestamp in seconds.
+- `user_data`?: _any_ – User defined data associated with this message. Helps to identify this message when user received `MessageMonitoringResult`.
 
-* `boc`: _string_ – BOC of the message, that must be sent to the blockchain.
-* `wait_until`: _number_ – Expiration time of the message. Must be specified as a UNIX timestamp in seconds.
-* `user_data`?: _any_ – User defined data associated with this message. Helps to identify this message when user received `MessageMonitoringResult`.
 
-### ParamsOfMonitorMessages
-
+## ParamsOfMonitorMessages
 ```ts
 type ParamsOfMonitorMessages = {
     queue: string,
     messages: MessageMonitoringParams[]
 }
 ```
+- `queue`: _string_ – Name of the monitoring queue.
+- `messages`: _[MessageMonitoringParams](mod\_processing.md#messagemonitoringparams)[]_ – Messages to start monitoring for.
 
-* `queue`: _string_ – Name of the monitoring queue.
-* `messages`: [_MessageMonitoringParams_](mod_processing.md#messagemonitoringparams)_\[]_ – Messages to start monitoring for.
 
-### ParamsOfGetMonitorInfo
-
+## ParamsOfGetMonitorInfo
 ```ts
 type ParamsOfGetMonitorInfo = {
     queue: string
 }
 ```
+- `queue`: _string_ – Name of the monitoring queue.
 
-* `queue`: _string_ – Name of the monitoring queue.
 
-### MonitoringQueueInfo
-
+## MonitoringQueueInfo
 ```ts
 type MonitoringQueueInfo = {
     unresolved: number,
     resolved: number
 }
 ```
+- `unresolved`: _number_
+- `resolved`: _number_
 
-* `unresolved`: _number_ – Count of the unresolved messages.
-* `resolved`: _number_ – Count of resolved results.
 
-### ParamsOfFetchNextMonitorResults
-
+## ParamsOfFetchNextMonitorResults
 ```ts
 type ParamsOfFetchNextMonitorResults = {
     queue: string,
     wait_mode?: MonitorFetchWaitMode
 }
 ```
+- `queue`: _string_ – Name of the monitoring queue.
+- `wait_mode`?: _[MonitorFetchWaitMode](mod\_processing.md#monitorfetchwaitmode)_ – Wait mode.
+<br>Default is `NO_WAIT`.
 
-* `queue`: _string_ – Name of the monitoring queue.
-* `wait_mode`?: [_MonitorFetchWaitMode_](mod_processing.md#monitorfetchwaitmode) – Wait mode.\
-  Default is `NO_WAIT`.
 
-### ResultOfFetchNextMonitorResults
-
+## ResultOfFetchNextMonitorResults
 ```ts
 type ResultOfFetchNextMonitorResults = {
     results: MessageMonitoringResult[]
 }
 ```
+- `results`: _[MessageMonitoringResult](mod\_processing.md#messagemonitoringresult)[]_ – List of the resolved results.
 
-* `results`: [_MessageMonitoringResult_](mod_processing.md#messagemonitoringresult)_\[]_ – List of the resolved results.
 
-### ParamsOfCancelMonitor
-
+## ParamsOfCancelMonitor
 ```ts
 type ParamsOfCancelMonitor = {
     queue: string
 }
 ```
+- `queue`: _string_ – Name of the monitoring queue.
 
-* `queue`: _string_ – Name of the monitoring queue.
 
-### ParamsOfSendMessages
-
+## ParamsOfSendMessages
 ```ts
 type ParamsOfSendMessages = {
     messages: MessageSendingParams[],
     monitor_queue?: string
 }
 ```
+- `messages`: _[MessageSendingParams](mod\_processing.md#messagesendingparams)[]_ – Messages that must be sent to the blockchain.
+- `monitor_queue`?: _string_ – Optional message monitor queue that starts monitoring for the processing results for sent messages.
 
-* `messages`: [_MessageSendingParams_](mod_processing.md#messagesendingparams)_\[]_ – Messages that must be sent to the blockchain.
-* `monitor_queue`?: _string_ – Optional message monitor queue that starts monitoring for the processing results for sent messages.
 
-### ResultOfSendMessages
-
+## ResultOfSendMessages
 ```ts
 type ResultOfSendMessages = {
     messages: MessageMonitoringParams[]
 }
 ```
+- `messages`: _[MessageMonitoringParams](mod\_processing.md#messagemonitoringparams)[]_ – Messages that was sent to the blockchain for execution.
 
-* `messages`: [_MessageMonitoringParams_](mod_processing.md#messagemonitoringparams)_\[]_ – Messages that was sent to the blockchain for execution.
 
-### ParamsOfSendMessage
-
+## ParamsOfSendMessage
 ```ts
 type ParamsOfSendMessage = {
     message: string,
     abi?: Abi,
-    send_events?: boolean
+    thread_id?: string,
+    send_events?: boolean,
+    dapp_id?: string
 }
 ```
+- `message`: _string_ – Message BOC.
+- `abi`?: _[Abi](mod\_abi.md#abi)_ – Optional message ABI.
+<br>If this parameter is specified and the message has the<br>`expire` header then expiration time will be checked against<br>the current time to prevent unnecessary sending of already expired<br>message.<br><br>The `message already expired` error will be returned in this<br>case.<br><br>Note, that specifying `abi` for ABI compliant contracts is<br>strongly recommended, so that proper processing strategy can be<br>chosen.
+- `thread_id`?: _string_
+- `send_events`?: _boolean_ – Flag for requesting events sending. Default is `false`.
+- `dapp_id`?: _string_ – Destination dapp_id (64-character hex, no 0x). Required for v>=1.0.0 servers; for v<1.0.0 may be empty (sent as legacy `dst_dapp_id: null`).
 
-* `message`: _string_ – Message BOC.
-* `abi`?: [_Abi_](mod_abi.md#abi) – Optional message ABI.\
-  If this parameter is specified and the message has the\
-  `expire` header then expiration time will be checked against\
-  the current time to prevent unnecessary sending of already expired message.\
-  \
-  The `message already expired` error will be returned in this\
-  case.\
-  \
-  Note, that specifying `abi` for ABI compliant contracts is\
-  strongly recommended, so that proper processing strategy can be\
-  chosen.
-* `send_events`?: _boolean_ – Flag for requesting events sending. Default is `false`.
 
-### ResultOfSendMessage
-
+## ResultOfSendMessage
 ```ts
 type ResultOfSendMessage = {
-    shard_block_id: string,
-    sending_endpoints: string[]
+    message_hash?: string,
+    block_hash?: string,
+    tx_hash?: string,
+    return_value?: any,
+    aborted?: boolean,
+    exit_code?: number,
+    thread_id?: string,
+    producers: string[],
+    current_time?: string,
+    account_id?: string,
+    dapp_id?: string
 }
 ```
+- `message_hash`?: _string_ – The hash of the processed message.
+- `block_hash`?: _string_ – The hash of the block in which the message was included.
+- `tx_hash`?: _string_ – The hash of the transaction generated by the message.
+- `return_value`?: _any_ – Returned values
+- `aborted`?: _boolean_ – The flag is set either if there is no action phase or if the action phase was unsuccessful.
+- `exit_code`?: _number_ – The exit code of the computing phase
+- `thread_id`?: _string_ – The identifier of the thread in which the message was processed.
+- `producers`: _string[]_ – The list (IP addresses) of block producers processing the thread.
+- `current_time`?: _string_ – The timestamp of generating this response.
+- `account_id`?: _string_ – Destination account_id (64-hex, no workchain).
+<br>Always populated: taken from the server response on v>=1.0.0, derived locally<br>from the message destination on v<1.0.0.
+- `dapp_id`?: _string_ – Destination dapp_id (64-hex).
+<br>Always populated: taken from the server response on v>=1.0.0, mirrored from the request on v<1.0.0.
 
-* `shard_block_id`: _string_ – The last generated shard block of the message destination account before the message was sent.\
-  This block id must be used as a parameter of the\
-  `wait_for_transaction`.
-* `sending_endpoints`: _string\[]_ – The list of endpoints to which the message was sent.\
-  This list id must be used as a parameter of the\
-  `wait_for_transaction`.
 
-### ParamsOfWaitForTransaction
-
+## ParamsOfWaitForTransaction
 ```ts
 type ParamsOfWaitForTransaction = {
     abi?: Abi,
     message: string,
-    shard_block_id: string,
+    shard_block_id?: string,
     send_events?: boolean,
-    sending_endpoints?: string[]
+    sending_endpoints?: string[],
+    tx_hash?: string | null
 }
 ```
+- `abi`?: _[Abi](mod\_abi.md#abi)_ – Optional ABI for decoding the transaction result.
+<br>If it is specified, then the output messages' bodies will be<br>decoded according to this ABI.<br><br>The `abi_decoded` result field will be filled out.
+- `message`: _string_ – Message BOC.
+<br>Encoded with `base64`.
+- `shard_block_id`?: _string_ – The last generated block id of the destination account shard before the message was sent.
+<br>Deprecated: no longer used. Block walking has been removed.
+- `send_events`?: _boolean_ – Flag that enables/disables intermediate events. Default is `false`.
+- `sending_endpoints`?: _string[]_ – The list of endpoints to which the message was sent.
+<br>Use this field to get more informative errors.<br>Provide the same value as the `send_message` has returned.<br>If the message was not delivered (expired), SDK will log the endpoint<br>URLs, used for its sending.
+- `tx_hash`?: _string?_ – Transaction hash returned by `send_message`. Used to poll for the transaction directly by hash.
 
-* `abi`?: [_Abi_](mod_abi.md#abi) – Optional ABI for decoding the transaction result.\
-  If it is specified, then the output messages' bodies will be\
-  decoded according to this ABI.\
-  \
-  The `abi_decoded` result field will be filled out.
-* `message`: _string_ – Message BOC.\
-  Encoded with `base64`.
-* `shard_block_id`: _string_ – The last generated block id of the destination account shard before the message was sent.\
-  You must provide the same value as the `send_message` has returned.
-* `send_events`?: _boolean_ – Flag that enables/disables intermediate events. Default is `false`.
-* `sending_endpoints`?: _string\[]_ – The list of endpoints to which the message was sent.\
-  Use this field to get more informative errors.\
-  Provide the same value as the `send_message` has returned.\
-  If the message was not delivered (expired), SDK will log the endpoint URLs, used for its sending.
 
-### ParamsOfProcessMessage
-
+## ParamsOfProcessMessage
 ```ts
 type ParamsOfProcessMessage = {
     message_encode_params: ParamsOfEncodeMessage,
-    send_events?: boolean
+    send_events?: boolean,
+    dapp_id?: string
 }
 ```
+- `message_encode_params`: _[ParamsOfEncodeMessage](mod\_abi.md#paramsofencodemessage)_ – Message encode parameters.
+- `send_events`?: _boolean_ – Flag for requesting events sending. Default is `false`.
+- `dapp_id`?: _string_ – Destination dapp_id (64-character hex, no 0x). Required for v>=1.0.0 servers; for v<1.0.0 may be empty.
 
-* `message_encode_params`: [_ParamsOfEncodeMessage_](mod_abi.md#paramsofencodemessage) – Message encode parameters.
-* `send_events`?: _boolean_ – Flag for requesting events sending. Default is `false`.
+

--- a/docs/acki-nacki-sdk/types-and-methods/mod_proofs.md
+++ b/docs/acki-nacki-sdk/types-and-methods/mod_proofs.md
@@ -1,60 +1,100 @@
 # Module proofs
 
-## Module proofs
+[UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Module for proving data, retrieved from TONOS API.
 
-[UNSTABLE](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/UNSTABLE.md) [DEPRECATED](https://github.com/tvmlabs/tvm-sdk/blob/main/docs/reference/types-and-methods/DEPRECATED.md) Module for proving data, retrieved from TVM API.
-
-### Functions
-
-[proof\_block\_data](mod_proofs.md#proof_block_data) – Proves that a given block's data, which is queried from TVM API, can be trusted.
-
-[proof\_transaction\_data](mod_proofs.md#proof_transaction_data) – Proves that a given transaction's data, which is queried from TVM API, can be trusted.
-
-[proof\_message\_data](mod_proofs.md#proof_message_data) – Proves that a given message's data, which is queried from TVM API, can be trusted.
-
-### Types
-
-[ProofsErrorCode](mod_proofs.md#proofserrorcode)
-
-[ParamsOfProofBlockData](mod_proofs.md#paramsofproofblockdata)
-
-[ParamsOfProofTransactionData](mod_proofs.md#paramsofprooftransactiondata)
-
-[ParamsOfProofMessageData](mod_proofs.md#paramsofproofmessagedata)
 
 ## Functions
+[proof_block_data](mod\_proofs.md#proof_block_data) – Proves that a given block's data, which is queried from TONOS API, can be trusted.
 
-### proof\_block\_data
+[proof_transaction_data](mod\_proofs.md#proof_transaction_data) – Proves that a given transaction's data, which is queried from TONOS API, can be trusted.
 
-Proves that a given block's data, which is queried from TVM API, can be trusted.
+[proof_message_data](mod\_proofs.md#proof_message_data) – Proves that a given message's data, which is queried from TONOS API, can be trusted.
 
-This function checks block proofs and compares given data with the proven. If the given data differs from the proven, the exception will be thrown. The input param is a single block's JSON object, which was queried from DApp server using functions such as `net.query`, `net.query_collection` or `net.wait_for_collection`. If block's BOC is not provided in the JSON, it will be queried from DApp server (in this case it is required to provide at least `id` of block).
+## Types
+[ProofsErrorCode](mod\_proofs.md#proofserrorcode)
 
-Please note, that joins (like `signatures` in `Block`) are separated entities and not supported, so function will throw an exception in a case if JSON being checked has such entities in it.
+[ParamsOfProofBlockData](mod\_proofs.md#paramsofproofblockdata)
 
-If `cache_in_local_storage` in config is set to `true` (default), downloaded proofs and master-chain BOCs are saved into the persistent local storage (e.g. file system for native environments or browser's IndexedDB for the web); otherwise all the data is cached only in memory in current client's context and will be lost after destruction of the client.
+[ParamsOfProofTransactionData](mod\_proofs.md#paramsofprooftransactiondata)
+
+[ParamsOfProofMessageData](mod\_proofs.md#paramsofproofmessagedata)
+
+
+# Functions
+## proof_block_data
+
+Proves that a given block's data, which is queried from TONOS API, can be trusted.
+
+This function checks block proofs and compares given data with the proven.
+If the given data differs from the proven, the exception will be thrown.
+The input param is a single block's JSON object, which was queried from DApp
+server using functions such as `net.query`, `net.query_collection` or
+`net.wait_for_collection`. If block's BOC is not provided in the JSON, it
+will be queried from DApp server (in this case it is required to provide at
+least `id` of block).
+
+Please note, that joins (like `signatures` in `Block`) are separated
+entities and not supported, so function will throw an exception in a case if
+JSON being checked has such entities in it.
+
+If `cache_in_local_storage` in config is set to `true` (default), downloaded
+proofs and master-chain BOCs are saved into the persistent local storage
+(e.g. file system for native environments or browser's IndexedDB for the
+web); otherwise all the data is cached only in memory in current client's
+context and will be lost after destruction of the client.
 
 **Why Proofs are needed**
 
-Proofs are needed to ensure that the data downloaded from a DApp server is real blockchain data. Checking proofs can protect from the malicious DApp server which can potentially provide fake data, or also from "Man in the Middle" attacks class.
+Proofs are needed to ensure that the data downloaded from a DApp server is
+real blockchain data. Checking proofs can protect from the malicious DApp
+server which can potentially provide fake data, or also from "Man in the
+Middle" attacks class.
 
 **What Proofs are**
 
-Simply, proof is a list of signatures of validators', which have signed this particular master- block.
+Simply, proof is a list of signatures of validators', which have signed this
+particular master- block.
 
-The very first validator set's public keys are included in the zero-state. Whe know a root hash of the zero-state, because it is stored in the network configuration file, it is our authority root. For proving zero-state it is enough to calculate and compare its root hash.
+The very first validator set's public keys are included in the zero-state.
+Whe know a root hash of the zero-state, because it is stored in the network
+configuration file, it is our authority root. For proving zero-state it is
+enough to calculate and compare its root hash.
 
-In each new validator cycle the validator set is changed. The new one is stored in a key-block, which is signed by the validator set, which we already trust, the next validator set will be stored to the new key-block and signed by the current validator set, and so on.
+In each new validator cycle the validator set is changed. The new one is
+stored in a key-block, which is signed by the validator set, which we
+already trust, the next validator set will be stored to the new key-block
+and signed by the current validator set, and so on.
 
-In order to prove any block in the master-chain we need to check, that it has been signed by a trusted validator set. So we need to check all key-blocks' proofs, started from the zero-state and until the block, which we want to prove. But it can take a lot of time and traffic to download and prove all key-blocks on a client. For solving this, special trusted blocks are used in TVM-SDK.
+In order to prove any block in the master-chain we need to check, that it
+has been signed by a trusted validator set. So we need to check all
+key-blocks' proofs, started from the zero-state and until the block, which
+we want to prove. But it can take a lot of time and traffic to download and
+prove all key-blocks on a client. For solving this, special trusted blocks
+are used in Ever-SDK.
 
-The trusted block is the authority root, as well, as the zero-state. Each trusted block is the `id` (e.g. `root_hash`) of the already proven key-block. There can be plenty of trusted blocks, so there can be a lot of authority roots. The hashes of trusted blocks for MainNet and TestNet are hardcoded in SDK in a separated binary file (trusted\_key\_blocks.bin) and is being updated for each release by using `update_trusted_blocks` utility.
+The trusted block is the authority root, as well, as the zero-state. Each
+trusted block is the `id` (e.g. `root_hash`) of the already proven
+key-block. There can be plenty of trusted blocks, so there can be a lot of
+authority roots. The hashes of trusted blocks for MainNet and DevNet are
+hardcoded in SDK in a separated binary file (trusted_key_blocks.bin) and is
+being updated for each release by using `update_trusted_blocks` utility.
 
-See [update\_trusted\_blocks](https://github.com/tvmlabs/tvm-sdk/blob/main/tools/update_trusted_blocks/README.md) directory for more info.
+See [update_trusted_blocks](../../../tools/update_trusted_blocks) directory
+for more info.
 
-In future SDK releases, one will also be able to provide their hashes of trusted blocks for other networks, besides for MainNet and DevNet. By using trusted key-blocks, in order to prove any block, we can prove chain of key-blocks to the closest previous trusted key-block, not only to the zero-state.
+In future SDK releases, one will also be able to provide their hashes of
+trusted blocks for other networks, besides for MainNet and DevNet.
+By using trusted key-blocks, in order to prove any block, we can prove chain
+of key-blocks to the closest previous trusted key-block, not only to the
+zero-state.
 
-But shard-blocks don't have proofs on DApp server. In this case, in order to prove any shard- block data, we search for a corresponding master-block, which contains the root hash of this shard-block, or some shard block which is linked to that block in shard-chain. After proving this master-block, we traverse through each link and calculate and compare hashes with links, one-by-one. After that we can ensure that this shard-block has also been proven.
+But shard-blocks don't have proofs on DApp server. In this case, in order to
+prove any shard- block data, we search for a corresponding master-block,
+which contains the root hash of this shard-block, or some shard block which
+is linked to that block in shard-chain. After proving this master-block, we
+traverse through each link and calculate and compare hashes with links,
+one-by-one. After that we can ensure that this shard-block has also been
+proven.
 
 ```ts
 type ParamsOfProofBlockData = {
@@ -69,24 +109,32 @@ function proof_block_data_sync(
     params: ParamsOfProofBlockData,
 ): void;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `block`: _any_ – Single block's data, retrieved from TONOS API, that needs proof. Required fields are `id` and/or top-level `boc` (for block identification), others are optional.
 
-#### Parameters
 
-* `block`: _any_ – Single block's data, retrieved from TVM API, that needs proof. Required fields are `id` and/or top-level `boc` (for block identification), others are optional.
+## proof_transaction_data
 
-### proof\_transaction\_data
+Proves that a given transaction's data, which is queried from TONOS API, can be trusted.
 
-Proves that a given transaction's data, which is queried from TVM API, can be trusted.
+This function requests the corresponding block, checks block proofs, ensures
+that given transaction exists in the proven block and compares given data
+with the proven. If the given data differs from the proven, the exception
+will be thrown. The input parameter is a single transaction's JSON object
+(see params description), which was queried from TONOS API using functions
+such as `net.query`, `net.query_collection` or `net.wait_for_collection`.
 
-This function requests the corresponding block, checks block proofs, ensures that given transaction exists in the proven block and compares given data with the proven. If the given data differs from the proven, the exception will be thrown. The input parameter is a single transaction's JSON object (see params description), which was queried from TVM API using functions such as `net.query`, `net.query_collection` or `net.wait_for_collection`.
+If transaction's BOC and/or `block_id` are not provided in the JSON, they
+will be queried from TONOS API.
 
-If transaction's BOC and/or `block_id` are not provided in the JSON, they will be queried from TVM API.
+Please note, that joins (like `account`, `in_message`, `out_messages`, etc.
+in `Transaction` entity) are separated entities and not supported, so
+function will throw an exception in a case if JSON being checked has such
+entities in it.
 
-Please note, that joins (like `account`, `in_message`, `out_messages`, etc. in `Transaction` entity) are separated entities and not supported, so function will throw an exception in a case if JSON being checked has such entities in it.
-
-For more information about proofs checking, see description of `proof_block_data` function.
+For more information about proofs checking, see description of
+`proof_block_data` function.
 
 ```ts
 type ParamsOfProofTransactionData = {
@@ -101,24 +149,34 @@ function proof_transaction_data_sync(
     params: ParamsOfProofTransactionData,
 ): void;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `transaction`: _any_ – Single transaction's data as queried from DApp server, without modifications.
+<br>The required fields are `id` and/or top-level `boc`, others are optional. In order to reduce network requests count, it<br>is recommended to provide `block_id` and `boc` of transaction.
 
-#### Parameters
 
-* `transaction`: _any_ – Single transaction's data as queried from DApp server, without modifications. The required fields are `id` and/or top-level `boc`, others are optional. In order to reduce network requests count, it is recommended to provide `block_id` and `boc` of transaction.
-
-### proof\_message\_data
+## proof_message_data
 
 Proves that a given message's data, which is queried from TONOS API, can be trusted.
 
-This function first proves the corresponding transaction, ensures that the proven transaction refers to the given message and compares given data with the proven. If the given data differs from the proven, the exception will be thrown. The input parameter is a single message's JSON object (see params description), which was queried from TONOS API using functions such as `net.query`, `net.query_collection` or `net.wait_for_collection`.
+This function first proves the corresponding transaction, ensures that the
+proven transaction refers to the given message and compares given data with
+the proven. If the given data differs from the proven, the exception will be
+thrown. The input parameter is a single message's JSON object (see params
+description), which was queried from TONOS API using functions such as
+`net.query`, `net.query_collection` or `net.wait_for_collection`.
 
-If message's BOC and/or non-null `src_transaction.id` or `dst_transaction.id` are not provided in the JSON, they will be queried from TONOS API.
+If message's BOC and/or non-null `src_transaction.id` or
+`dst_transaction.id` are not provided in the JSON, they will be queried from
+TONOS API.
 
-Please note, that joins (like `block`, `dst_account`, `dst_transaction`, `src_account`, `src_transaction`, etc. in `Message` entity) are separated entities and not supported, so function will throw an exception in a case if JSON being checked has such entities in it.
+Please note, that joins (like `block`, `dst_account`, `dst_transaction`,
+`src_account`, `src_transaction`, etc. in `Message` entity) are separated
+entities and not supported, so function will throw an exception in a case if
+JSON being checked has such entities in it.
 
-For more information about proofs checking, see description of `proof_block_data` function.
+For more information about proofs checking, see description of
+`proof_block_data` function.
 
 ```ts
 type ParamsOfProofMessageData = {
@@ -133,17 +191,14 @@ function proof_message_data_sync(
     params: ParamsOfProofMessageData,
 ): void;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `message`: _any_ – Single message's data as queried from DApp server, without modifications.
+<br>The required fields are `id` and/or top-level `boc`, others are optional. In order to reduce network requests count, it<br>is recommended to provide at least `boc` of message and non-null<br>`src_transaction.id` or `dst_transaction.id`.
 
-#### Parameters
 
-* `message`: _any_ – Single message's data as queried from DApp server, without modifications. The required fields are `id` and/or top-level `boc`, others are optional. In order to reduce network requests count, it is recommended to provide at least `boc` of message and non-null `src_transaction.id` or `dst_transaction.id`.
-
-## Types
-
-### ProofsErrorCode
-
+# Types
+## ProofsErrorCode
 ```ts
 enum ProofsErrorCode {
     InvalidData = 901,
@@ -152,40 +207,40 @@ enum ProofsErrorCode {
     DataDiffersFromProven = 904
 }
 ```
-
 One of the following value:
 
-* `InvalidData = 901`
-* `ProofCheckFailed = 902`
-* `InternalError = 903`
-* `DataDiffersFromProven = 904`
+- `InvalidData = 901`
+- `ProofCheckFailed = 902`
+- `InternalError = 903`
+- `DataDiffersFromProven = 904`
 
-### ParamsOfProofBlockData
 
+## ParamsOfProofBlockData
 ```ts
 type ParamsOfProofBlockData = {
     block: any
 }
 ```
+- `block`: _any_ – Single block's data, retrieved from TONOS API, that needs proof. Required fields are `id` and/or top-level `boc` (for block identification), others are optional.
 
-* `block`: _any_ – Single block's data, retrieved from TONOS API, that needs proof. Required fields are `id` and/or top-level `boc` (for block identification), others are optional.
 
-### ParamsOfProofTransactionData
-
+## ParamsOfProofTransactionData
 ```ts
 type ParamsOfProofTransactionData = {
     transaction: any
 }
 ```
+- `transaction`: _any_ – Single transaction's data as queried from DApp server, without modifications.
+<br>The required fields are `id` and/or top-level `boc`, others are optional. In order to reduce network requests count, it<br>is recommended to provide `block_id` and `boc` of transaction.
 
-* `transaction`: _any_ – Single transaction's data as queried from DApp server, without modifications. The required fields are `id` and/or top-level `boc`, others are optional. In order to reduce network requests count, it is recommended to provide `block_id` and `boc` of transaction.
 
-### ParamsOfProofMessageData
-
+## ParamsOfProofMessageData
 ```ts
 type ParamsOfProofMessageData = {
     message: any
 }
 ```
+- `message`: _any_ – Single message's data as queried from DApp server, without modifications.
+<br>The required fields are `id` and/or top-level `boc`, others are optional. In order to reduce network requests count, it<br>is recommended to provide at least `boc` of message and non-null<br>`src_transaction.id` or `dst_transaction.id`.
 
-* `message`: _any_ – Single message's data as queried from DApp server, without modifications. The required fields are `id` and/or top-level `boc`, others are optional. In order to reduce network requests count, it is recommended to provide at least `boc` of message and non-null `src_transaction.id` or `dst_transaction.id`.
+

--- a/docs/acki-nacki-sdk/types-and-methods/mod_tvm.md
+++ b/docs/acki-nacki-sdk/types-and-methods/mod_tvm.md
@@ -1,64 +1,83 @@
 # Module tvm
 
-## Module tvm
-
-### Functions
-
-[run\_executor](mod_tvm.md#run_executor) – Emulates all the phases of contract execution locally
-
-[run\_tvm](mod_tvm.md#run_tvm) – Executes get-methods of ABI-compatible contracts
-
-[run\_get](mod_tvm.md#run_get) – Executes a get-method of FIFT contract
-
-### Types
-
-[TvmErrorCode](mod_tvm.md#tvmerrorcode)
-
-[ExecutionOptions](mod_tvm.md#executionoptions)
-
-[AccountForExecutorNoneVariant](mod_tvm.md#accountforexecutornonevariant) – Non-existing account to run a creation internal message. Should be used with `skip_transaction_check = true` if the message has no deploy data since transactions on the uninitialized account are always aborted
-
-[AccountForExecutorUninitVariant](mod_tvm.md#accountforexecutoruninitvariant) – Emulate uninitialized account to run deploy message
-
-[AccountForExecutorAccountVariant](mod_tvm.md#accountforexecutoraccountvariant) – Account state to run message
-
-[AccountForExecutor](mod_tvm.md#accountforexecutor)
-
-[TransactionFees](mod_tvm.md#transactionfees)
-
-[ParamsOfRunExecutor](mod_tvm.md#paramsofrunexecutor)
-
-[ResultOfRunExecutor](mod_tvm.md#resultofrunexecutor)
-
-[ParamsOfRunTvm](mod_tvm.md#paramsofruntvm)
-
-[ResultOfRunTvm](mod_tvm.md#resultofruntvm)
-
-[ParamsOfRunGet](mod_tvm.md#paramsofrunget)
-
-[ResultOfRunGet](mod_tvm.md#resultofrunget)
 
 ## Functions
+[run_executor](mod\_tvm.md#run_executor) – Emulates all the phases of contract execution locally
 
-### run\_executor
+[run_tvm](mod\_tvm.md#run_tvm) – Executes get-methods of ABI-compatible contracts
+
+[run_get](mod\_tvm.md#run_get) – Executes a get-method of FIFT contract
+
+## Types
+[TvmErrorCode](mod\_tvm.md#tvmerrorcode)
+
+[ExecutionOptions](mod\_tvm.md#executionoptions)
+
+[AccountForExecutorNoneVariant](mod\_tvm.md#accountforexecutornonevariant) – Non-existing account to run a creation internal message. Should be used with `skip_transaction_check = true` if the message has no deploy data since transactions on the uninitialized account are always aborted
+
+[AccountForExecutorUninitVariant](mod\_tvm.md#accountforexecutoruninitvariant) – Emulate uninitialized account to run deploy message
+
+[AccountForExecutorAccountVariant](mod\_tvm.md#accountforexecutoraccountvariant) – Account state to run message
+
+[AccountForExecutor](mod\_tvm.md#accountforexecutor)
+
+[TransactionFees](mod\_tvm.md#transactionfees)
+
+[ParamsOfRunExecutor](mod\_tvm.md#paramsofrunexecutor)
+
+[ResultOfRunExecutor](mod\_tvm.md#resultofrunexecutor)
+
+[ParamsOfRunTvm](mod\_tvm.md#paramsofruntvm)
+
+[ResultOfRunTvm](mod\_tvm.md#resultofruntvm)
+
+[ParamsOfRunGet](mod\_tvm.md#paramsofrunget)
+
+[ResultOfRunGet](mod\_tvm.md#resultofrunget)
+
+
+# Functions
+## run_executor
 
 Emulates all the phases of contract execution locally
 
-Performs all the phases of contract execution on Transaction Executor - the same component that is used on Validator Nodes.
+Performs all the phases of contract execution on Transaction Executor -
+the same component that is used on Validator Nodes.
 
-Can be used for contract debugging, to find out the reason why a message was not delivered successfully. Validators throw away the failed external inbound messages (if they failed before `ACCEPT`) in the real network. This is why these messages are impossible to debug in the real network. With the help of run\_executor you can do that. In fact, `process_message` function performs local check with `run_executor` if there was no transaction as a result of processing and returns the error, if there is one.
+Can be used for contract debugging, to find out the reason why a message was
+not delivered successfully. Validators throw away the failed external
+inbound messages (if they failed before `ACCEPT`) in the real network.
+This is why these messages are impossible to debug in the real network.
+With the help of run_executor you can do that. In fact, `process_message`
+function performs local check with `run_executor` if there was no
+transaction as a result of processing and returns the error, if there is
+one.
 
-Another use case to use `run_executor` is to estimate fees for message execution. Set `AccountForExecutor::Account.unlimited_balance` to `true` so that emulation will not depend on the actual balance. This may be needed to calculate deploy fees for an account that does not exist yet. JSON with fees is in `fees` field of the result.
+Another use case to use `run_executor` is to estimate fees for message
+execution. Set  `AccountForExecutor::Account.unlimited_balance`
+to `true` so that emulation will not depend on the actual balance.
+This may be needed to calculate deploy fees for an account that does not
+exist yet. JSON with fees is in `fees` field of the result.
 
-One more use case - you can produce the sequence of operations, thus emulating the sequential contract calls locally. And so on.
+One more use case - you can produce the sequence of operations,
+thus emulating the sequential contract calls locally.
+And so on.
 
-Transaction executor requires account BOC (bag of cells) as a parameter. To get the account BOC - use `net.query` method to download it from GraphQL API (field `boc` of `account`) or generate it with `abi.encode_account` method.
+Transaction executor requires account BOC (bag of cells) as a parameter.
+To get the account BOC - use `net.query` method to download it from GraphQL
+API (field `boc` of `account`) or generate it with `abi.encode_account`
+method.
 
-Also it requires message BOC. To get the message BOC - use `abi.encode_message` or `abi.encode_internal_message`.
+Also it requires message BOC. To get the message BOC - use
+`abi.encode_message` or `abi.encode_internal_message`.
 
-If you need this emulation to be as precise as possible (for instance - emulate transaction with particular lt in particular block or use particular blockchain config, downloaded from a particular key block - then specify `execution_options` parameter.
+If you need this emulation to be as precise as possible (for instance -
+emulate transaction with particular lt in particular block or use particular
+blockchain config, downloaded from a particular key block - then specify
+`execution_options` parameter.
 
-If you need to see the aborted transaction as a result, not as an error, set `skip_transaction_check` to `true`.
+If you need to see the aborted transaction as a result, not as an error, set
+`skip_transaction_check` to `true`.
 
 ```ts
 type ParamsOfRunExecutor = {
@@ -87,46 +106,51 @@ function run_executor_sync(
     params: ParamsOfRunExecutor,
 ): ResultOfRunExecutor;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `message`: _string_ – Input message BOC.
+<br>Must be encoded as base64.
+- `account`: _[AccountForExecutor](mod\_tvm.md#accountforexecutor)_ – Account to run on executor
+- `execution_options`?: _[ExecutionOptions](mod\_tvm.md#executionoptions)_ – Execution options.
+- `abi`?: _[Abi](mod\_abi.md#abi)_ – Contract ABI for decoding output messages
+- `skip_transaction_check`?: _boolean_ – Skip transaction check flag
+- `boc_cache`?: _[BocCacheType](mod\_boc.md#boccachetype)_ – Cache type to put the result.
+<br>The BOC itself returned if no cache type provided
+- `return_updated_account`?: _boolean_ – Return updated account flag.
+<br>Empty string is returned if the flag is `false`
 
-#### Parameters
 
-* `message`: _string_ – Input message BOC.\
-  Must be encoded as base64.
-* `account`: [_AccountForExecutor_](mod_tvm.md#accountforexecutor) – Account to run on executor
-* `execution_options`?: [_ExecutionOptions_](mod_tvm.md#executionoptions) – Execution options.
-* `abi`?: [_Abi_](mod_abi.md#abi) – Contract ABI for decoding output messages
-* `skip_transaction_check`?: _boolean_ – Skip transaction check flag
-* `boc_cache`?: [_BocCacheType_](mod_boc.md#boccachetype) – Cache type to put the result.\
-  The BOC itself returned if no cache type provided
-* `return_updated_account`?: _boolean_ – Return updated account flag.\
-  Empty string is returned if the flag is `false`
+### Result
 
-#### Result
+- `transaction`: _any_ – Parsed transaction.
+<br>In addition to the regular transaction fields there is a<br>`boc` field encoded with `base64` which contains source<br>transaction BOC.
+- `out_messages`: _string[]_ – List of output messages' BOCs.
+<br>Encoded as `base64`
+- `decoded`?: _[DecodedOutput](mod\_processing.md#decodedoutput)_ – Optional decoded message bodies according to the optional `abi` parameter.
+- `account`: _string_ – Updated account state BOC.
+<br>Encoded as `base64`
+- `fees`: _[TransactionFees](mod\_tvm.md#transactionfees)_ – Transaction fees
 
-* `transaction`: _any_ – Parsed transaction.\
-  In addition to the regular transaction fields there is a\
-  `boc` field encoded with `base64` which contains source\
-  transaction BOC.
-* `out_messages`: _string\[]_ – List of output messages' BOCs.\
-  Encoded as `base64`
-* `decoded`?: [_DecodedOutput_](mod_processing.md#decodedoutput) – Optional decoded message bodies according to the optional `abi` parameter.
-* `account`: _string_ – Updated account state BOC.\
-  Encoded as `base64`
-* `fees`: [_TransactionFees_](mod_tvm.md#transactionfees) – Transaction fees
 
-### run\_tvm
+## run_tvm
 
 Executes get-methods of ABI-compatible contracts
 
-Performs only a part of compute phase of transaction execution that is used to run get-methods of ABI-compatible contracts.
+Performs only a part of compute phase of transaction execution
+that is used to run get-methods of ABI-compatible contracts.
 
-If you try to run get-methods with `run_executor` you will get an error, because it checks ACCEPT and exits if there is none, which is actually true for get-methods.
+If you try to run get-methods with `run_executor` you will get an error,
+because it checks ACCEPT and exits if there is none, which is actually true
+for get-methods.
 
-To get the account BOC (bag of cells) - use `net.query` method to download it from GraphQL API (field `boc` of `account`) or generate it with `abi.encode_account method`. To get the message BOC - use `abi.encode_message` or prepare it any other way, for instance, with FIFT script.
+ To get the account BOC (bag of cells) - use `net.query` method to download
+it from GraphQL API (field `boc` of `account`) or generate it with
+`abi.encode_account method`. To get the message BOC - use
+`abi.encode_message` or prepare it any other way, for instance, with FIFT
+script.
 
-Attention! Updated account state is produces as well, but only `account_state.storage.state.data` part of the BOC is updated.
+Attention! Updated account state is produces as well, but only
+`account_state.storage.state.data`  part of the BOC is updated.
 
 ```ts
 type ParamsOfRunTvm = {
@@ -152,35 +176,35 @@ function run_tvm_sync(
     params: ParamsOfRunTvm,
 ): ResultOfRunTvm;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `message`: _string_ – Input message BOC.
+<br>Must be encoded as base64.
+- `account`: _string_ – Account BOC.
+<br>Must be encoded as base64.
+- `execution_options`?: _[ExecutionOptions](mod\_tvm.md#executionoptions)_ – Execution options.
+- `abi`?: _[Abi](mod\_abi.md#abi)_ – Contract ABI for decoding output messages
+- `boc_cache`?: _[BocCacheType](mod\_boc.md#boccachetype)_ – Cache type to put the result.
+<br>The BOC itself returned if no cache type provided
+- `return_updated_account`?: _boolean_ – Return updated account flag.
+<br>Empty string is returned if the flag is `false`
 
-#### Parameters
 
-* `message`: _string_ – Input message BOC.\
-  Must be encoded as base64.
-* `account`: _string_ – Account BOC.\
-  Must be encoded as base64.
-* `execution_options`?: [_ExecutionOptions_](mod_tvm.md#executionoptions) – Execution options.
-* `abi`?: [_Abi_](mod_abi.md#abi) – Contract ABI for decoding output messages
-* `boc_cache`?: [_BocCacheType_](mod_boc.md#boccachetype) – Cache type to put the result.\
-  The BOC itself returned if no cache type provided
-* `return_updated_account`?: _boolean_ – Return updated account flag.\
-  Empty string is returned if the flag is `false`
+### Result
 
-#### Result
+- `out_messages`: _string[]_ – List of output messages' BOCs.
+<br>Encoded as `base64`
+- `decoded`?: _[DecodedOutput](mod\_processing.md#decodedoutput)_ – Optional decoded message bodies according to the optional `abi` parameter.
+- `account`: _string_ – Updated account state BOC.
+<br>Encoded as `base64`. Attention! Only `account_state.storage.state.data` part of the BOC is<br>updated.
 
-* `out_messages`: _string\[]_ – List of output messages' BOCs.\
-  Encoded as `base64`
-* `decoded`?: [_DecodedOutput_](mod_processing.md#decodedoutput) – Optional decoded message bodies according to the optional `abi` parameter.
-* `account`: _string_ – Updated account state BOC.\
-  Encoded as `base64`. Attention! Only `account_state.storage.state.data` part of the BOC is updated.
 
-### run\_get
+## run_get
 
 Executes a get-method of FIFT contract
 
-Executes a get-method of FIFT contract that fulfills the smc-guidelines https://test.ton.org/smc-guidelines.txt and returns the result data from TVM's stack
+Executes a get-method of FIFT contract that fulfills the smc-guidelines https://test.ton.org/smc-guidelines.txt
+and returns the result data from TVM's stack
 
 ```ts
 type ParamsOfRunGet = {
@@ -203,29 +227,23 @@ function run_get_sync(
     params: ParamsOfRunGet,
 ): ResultOfRunGet;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `account`: _string_ – Account BOC in `base64`
+- `function_name`: _string_ – Function name
+- `input`?: _any_ – Input parameters
+- `execution_options`?: _[ExecutionOptions](mod\_tvm.md#executionoptions)_ – Execution options
+- `tuple_list_as_array`?: _boolean_ – Convert lists based on nested tuples in the **result** into plain arrays.
+<br>Default is `false`. Input parameters may use any of lists representations If you receive this error on Web: "Runtime error.<br>Unreachable code should not be executed...", set this flag to true.<br>This may happen, for example, when elector contract contains too many<br>participants
 
-#### Parameters
 
-* `account`: _string_ – Account BOC in `base64`
-* `function_name`: _string_ – Function name
-* `input`?: _any_ – Input parameters
-* `execution_options`?: [_ExecutionOptions_](mod_tvm.md#executionoptions) – Execution options
-* `tuple_list_as_array`?: _boolean_ – Convert lists based on nested tuples in the **result** into plain arrays.\
-  Default is `false`. Input parameters may use any of lists representations\
-  If you receive this error on Web: "Runtime error. Unreachable code should not be executed...",\
-  set this flag to true.\
-  This may happen, for example, when elector contract contains too many participants
+### Result
 
-#### Result
+- `output`: _any_ – Values returned by get-method on stack
 
-* `output`: _any_ – Values returned by get-method on stack
 
-## Types
-
-### TvmErrorCode
-
+# Types
+## TvmErrorCode
 ```ts
 enum TvmErrorCode {
     CanNotReadTransaction = 401,
@@ -245,27 +263,26 @@ enum TvmErrorCode {
     AccountIsSuspended = 415
 }
 ```
-
 One of the following value:
 
-* `CanNotReadTransaction = 401`
-* `CanNotReadBlockchainConfig = 402`
-* `TransactionAborted = 403`
-* `InternalError = 404`
-* `ActionPhaseFailed = 405`
-* `AccountCodeMissing = 406`
-* `LowBalance = 407`
-* `AccountFrozenOrDeleted = 408`
-* `AccountMissing = 409`
-* `UnknownExecutionError = 410`
-* `InvalidInputStack = 411`
-* `InvalidAccountBoc = 412`
-* `InvalidMessageType = 413`
-* `ContractExecutionError = 414`
-* `AccountIsSuspended = 415`
+- `CanNotReadTransaction = 401`
+- `CanNotReadBlockchainConfig = 402`
+- `TransactionAborted = 403`
+- `InternalError = 404`
+- `ActionPhaseFailed = 405`
+- `AccountCodeMissing = 406`
+- `LowBalance = 407`
+- `AccountFrozenOrDeleted = 408`
+- `AccountMissing = 409`
+- `UnknownExecutionError = 410`
+- `InvalidInputStack = 411`
+- `InvalidAccountBoc = 412`
+- `InvalidMessageType = 413`
+- `ContractExecutionError = 414`
+- `AccountIsSuspended = 415`
 
-### ExecutionOptions
 
+## ExecutionOptions
 ```ts
 type ExecutionOptions = {
     blockchain_config?: string,
@@ -276,16 +293,15 @@ type ExecutionOptions = {
     signature_id?: number
 }
 ```
+- `blockchain_config`?: _string_ – boc with config
+- `block_time`?: _number_ – time that is used as transaction time
+- `block_lt`?: _bigint_ – block logical time
+- `transaction_lt`?: _bigint_ – transaction logical time
+- `chksig_always_succeed`?: _boolean_ – Overrides standard TVM behaviour. If set to `true` then CHKSIG always will return `true`.
+- `signature_id`?: _number_ – Signature ID to be used in signature verifying instructions when CapSignatureWithId capability is enabled
 
-* `blockchain_config`?: _string_ – boc with config
-* `block_time`?: _number_ – time that is used as transaction time
-* `block_lt`?: _bigint_ – block logical time
-* `transaction_lt`?: _bigint_ – transaction logical time
-* `chksig_always_succeed`?: _boolean_ – Overrides standard TVM behaviour. If set to `true` then CHKSIG always will return `true`.
-* `signature_id`?: _number_ – Signature ID to be used in signature verifying instructions when CapSignatureWithId capability is enabled
 
-### AccountForExecutorNoneVariant
-
+## AccountForExecutorNoneVariant
 Non-existing account to run a creation internal message. Should be used with `skip_transaction_check = true` if the message has no deploy data since transactions on the uninitialized account are always aborted
 
 ```ts
@@ -294,8 +310,8 @@ type AccountForExecutorNoneVariant = {
 }
 ```
 
-### AccountForExecutorUninitVariant
 
+## AccountForExecutorUninitVariant
 Emulate uninitialized account to run deploy message
 
 ```ts
@@ -304,8 +320,8 @@ type AccountForExecutorUninitVariant = {
 }
 ```
 
-### AccountForExecutorAccountVariant
 
+## AccountForExecutorAccountVariant
 Account state to run message
 
 ```ts
@@ -314,14 +330,13 @@ type AccountForExecutorAccountVariant = {
     unlimited_balance?: boolean
 }
 ```
+- `boc`: _string_ – Account BOC.
+<br>Encoded as base64.
+- `unlimited_balance`?: _boolean_ – Flag for running account with the unlimited balance.
+<br>Can be used to calculate transaction fees without balance check
 
-* `boc`: _string_ – Account BOC.\
-  Encoded as base64.
-* `unlimited_balance`?: _boolean_ – Flag for running account with the unlimited balance.\
-  Can be used to calculate transaction fees without balance check
 
-### AccountForExecutor
-
+## AccountForExecutor
 ```ts
 type AccountForExecutor = ({
     type: 'None'
@@ -331,25 +346,27 @@ type AccountForExecutor = ({
     type: 'Account'
 } & AccountForExecutorAccountVariant)
 ```
-
-Depends on value of the `type` field.
+Depends on value of the  `type` field.
 
 When _type_ is _'None'_
 
 Non-existing account to run a creation internal message. Should be used with `skip_transaction_check = true` if the message has no deploy data since transactions on the uninitialized account are always aborted
 
+
 When _type_ is _'Uninit'_
 
 Emulate uninitialized account to run deploy message
+
 
 When _type_ is _'Account'_
 
 Account state to run message
 
-* `boc`: _string_ – Account BOC.\
-  Encoded as base64.
-* `unlimited_balance`?: _boolean_ – Flag for running account with the unlimited balance.\
-  Can be used to calculate transaction fees without balance check
+- `boc`: _string_ – Account BOC.
+<br>Encoded as base64.
+- `unlimited_balance`?: _boolean_ – Flag for running account with the unlimited balance.
+<br>Can be used to calculate transaction fees without balance check
+
 
 Variant constructors:
 
@@ -359,8 +376,7 @@ function accountForExecutorUninit(): AccountForExecutor;
 function accountForExecutorAccount(boc: string, unlimited_balance?: boolean): AccountForExecutor;
 ```
 
-### TransactionFees
-
+## TransactionFees
 ```ts
 type TransactionFees = {
     in_msg_fwd_fee: bigint,
@@ -374,22 +390,21 @@ type TransactionFees = {
     account_fees: bigint
 }
 ```
+- `in_msg_fwd_fee`: _bigint_ – Deprecated.
+<br>Contains the same data as ext_in_msg_fee field
+- `storage_fee`: _bigint_ – Fee for account storage
+- `gas_fee`: _bigint_ – Fee for processing
+- `out_msgs_fwd_fee`: _bigint_ – Deprecated.
+<br>Contains the same data as total_fwd_fees field. Deprecated because of its confusing name, that is not the same with GraphQL API<br>Transaction type's field.
+- `total_account_fees`: _bigint_ – Deprecated.
+<br>Contains the same data as account_fees field
+- `total_output`: _bigint_ – Deprecated because it means total value sent in the transaction, which does not relate to any fees.
+- `ext_in_msg_fee`: _bigint_ – Fee for inbound external message import.
+- `total_fwd_fees`: _bigint_ – Total fees the account pays for message forwarding
+- `account_fees`: _bigint_ – Total account fees for the transaction execution. Compounds of storage_fee + gas_fee + ext_in_msg_fee + total_fwd_fees
 
-* `in_msg_fwd_fee`: _bigint_ – Deprecated.\
-  Contains the same data as ext\_in\_msg\_fee field
-* `storage_fee`: _bigint_ – Fee for account storage
-* `gas_fee`: _bigint_ – Fee for processing
-* `out_msgs_fwd_fee`: _bigint_ – Deprecated.\
-  Contains the same data as total\_fwd\_fees field. Deprecated because of its confusing name, that is not the same with GraphQL API Transaction type's field.
-* `total_account_fees`: _bigint_ – Deprecated.\
-  Contains the same data as account\_fees field
-* `total_output`: _bigint_ – Deprecated because it means total value sent in the transaction, which does not relate to any fees.
-* `ext_in_msg_fee`: _bigint_ – Fee for inbound external message import.
-* `total_fwd_fees`: _bigint_ – Total fees the account pays for message forwarding
-* `account_fees`: _bigint_ – Total account fees for the transaction execution. Compounds of storage\_fee + gas\_fee + ext\_in\_msg\_fee + total\_fwd\_fees
 
-### ParamsOfRunExecutor
-
+## ParamsOfRunExecutor
 ```ts
 type ParamsOfRunExecutor = {
     message: string,
@@ -401,20 +416,19 @@ type ParamsOfRunExecutor = {
     return_updated_account?: boolean
 }
 ```
+- `message`: _string_ – Input message BOC.
+<br>Must be encoded as base64.
+- `account`: _[AccountForExecutor](mod\_tvm.md#accountforexecutor)_ – Account to run on executor
+- `execution_options`?: _[ExecutionOptions](mod\_tvm.md#executionoptions)_ – Execution options.
+- `abi`?: _[Abi](mod\_abi.md#abi)_ – Contract ABI for decoding output messages
+- `skip_transaction_check`?: _boolean_ – Skip transaction check flag
+- `boc_cache`?: _[BocCacheType](mod\_boc.md#boccachetype)_ – Cache type to put the result.
+<br>The BOC itself returned if no cache type provided
+- `return_updated_account`?: _boolean_ – Return updated account flag.
+<br>Empty string is returned if the flag is `false`
 
-* `message`: _string_ – Input message BOC.\
-  Must be encoded as base64.
-* `account`: [_AccountForExecutor_](mod_tvm.md#accountforexecutor) – Account to run on executor
-* `execution_options`?: [_ExecutionOptions_](mod_tvm.md#executionoptions) – Execution options.
-* `abi`?: [_Abi_](mod_abi.md#abi) – Contract ABI for decoding output messages
-* `skip_transaction_check`?: _boolean_ – Skip transaction check flag
-* `boc_cache`?: [_BocCacheType_](mod_boc.md#boccachetype) – Cache type to put the result.\
-  The BOC itself returned if no cache type provided
-* `return_updated_account`?: _boolean_ – Return updated account flag.\
-  Empty string is returned if the flag is `false`
 
-### ResultOfRunExecutor
-
+## ResultOfRunExecutor
 ```ts
 type ResultOfRunExecutor = {
     transaction: any,
@@ -424,20 +438,17 @@ type ResultOfRunExecutor = {
     fees: TransactionFees
 }
 ```
+- `transaction`: _any_ – Parsed transaction.
+<br>In addition to the regular transaction fields there is a<br>`boc` field encoded with `base64` which contains source<br>transaction BOC.
+- `out_messages`: _string[]_ – List of output messages' BOCs.
+<br>Encoded as `base64`
+- `decoded`?: _[DecodedOutput](mod\_processing.md#decodedoutput)_ – Optional decoded message bodies according to the optional `abi` parameter.
+- `account`: _string_ – Updated account state BOC.
+<br>Encoded as `base64`
+- `fees`: _[TransactionFees](mod\_tvm.md#transactionfees)_ – Transaction fees
 
-* `transaction`: _any_ – Parsed transaction.\
-  In addition to the regular transaction fields there is a\
-  `boc` field encoded with `base64` which contains source\
-  transaction BOC.
-* `out_messages`: _string\[]_ – List of output messages' BOCs.\
-  Encoded as `base64`
-* `decoded`?: [_DecodedOutput_](mod_processing.md#decodedoutput) – Optional decoded message bodies according to the optional `abi` parameter.
-* `account`: _string_ – Updated account state BOC.\
-  Encoded as `base64`
-* `fees`: [_TransactionFees_](mod_tvm.md#transactionfees) – Transaction fees
 
-### ParamsOfRunTvm
-
+## ParamsOfRunTvm
 ```ts
 type ParamsOfRunTvm = {
     message: string,
@@ -448,20 +459,19 @@ type ParamsOfRunTvm = {
     return_updated_account?: boolean
 }
 ```
+- `message`: _string_ – Input message BOC.
+<br>Must be encoded as base64.
+- `account`: _string_ – Account BOC.
+<br>Must be encoded as base64.
+- `execution_options`?: _[ExecutionOptions](mod\_tvm.md#executionoptions)_ – Execution options.
+- `abi`?: _[Abi](mod\_abi.md#abi)_ – Contract ABI for decoding output messages
+- `boc_cache`?: _[BocCacheType](mod\_boc.md#boccachetype)_ – Cache type to put the result.
+<br>The BOC itself returned if no cache type provided
+- `return_updated_account`?: _boolean_ – Return updated account flag.
+<br>Empty string is returned if the flag is `false`
 
-* `message`: _string_ – Input message BOC.\
-  Must be encoded as base64.
-* `account`: _string_ – Account BOC.\
-  Must be encoded as base64.
-* `execution_options`?: [_ExecutionOptions_](mod_tvm.md#executionoptions) – Execution options.
-* `abi`?: [_Abi_](mod_abi.md#abi) – Contract ABI for decoding output messages
-* `boc_cache`?: [_BocCacheType_](mod_boc.md#boccachetype) – Cache type to put the result.\
-  The BOC itself returned if no cache type provided
-* `return_updated_account`?: _boolean_ – Return updated account flag.\
-  Empty string is returned if the flag is `false`
 
-### ResultOfRunTvm
-
+## ResultOfRunTvm
 ```ts
 type ResultOfRunTvm = {
     out_messages: string[],
@@ -469,15 +479,14 @@ type ResultOfRunTvm = {
     account: string
 }
 ```
+- `out_messages`: _string[]_ – List of output messages' BOCs.
+<br>Encoded as `base64`
+- `decoded`?: _[DecodedOutput](mod\_processing.md#decodedoutput)_ – Optional decoded message bodies according to the optional `abi` parameter.
+- `account`: _string_ – Updated account state BOC.
+<br>Encoded as `base64`. Attention! Only `account_state.storage.state.data` part of the BOC is<br>updated.
 
-* `out_messages`: _string\[]_ – List of output messages' BOCs.\
-  Encoded as `base64`
-* `decoded`?: [_DecodedOutput_](mod_processing.md#decodedoutput) – Optional decoded message bodies according to the optional `abi` parameter.
-* `account`: _string_ – Updated account state BOC.\
-  Encoded as `base64`. Attention! Only `account_state.storage.state.data` part of the BOC is updated.
 
-### ParamsOfRunGet
-
+## ParamsOfRunGet
 ```ts
 type ParamsOfRunGet = {
     account: string,
@@ -487,23 +496,20 @@ type ParamsOfRunGet = {
     tuple_list_as_array?: boolean
 }
 ```
+- `account`: _string_ – Account BOC in `base64`
+- `function_name`: _string_ – Function name
+- `input`?: _any_ – Input parameters
+- `execution_options`?: _[ExecutionOptions](mod\_tvm.md#executionoptions)_ – Execution options
+- `tuple_list_as_array`?: _boolean_ – Convert lists based on nested tuples in the **result** into plain arrays.
+<br>Default is `false`. Input parameters may use any of lists representations If you receive this error on Web: "Runtime error.<br>Unreachable code should not be executed...", set this flag to true.<br>This may happen, for example, when elector contract contains too many<br>participants
 
-* `account`: _string_ – Account BOC in `base64`
-* `function_name`: _string_ – Function name
-* `input`?: _any_ – Input parameters
-* `execution_options`?: [_ExecutionOptions_](mod_tvm.md#executionoptions) – Execution options
-* `tuple_list_as_array`?: _boolean_ – Convert lists based on nested tuples in the **result** into plain arrays.\
-  Default is `false`. Input parameters may use any of lists representations\
-  If you receive this error on Web: "Runtime error. Unreachable code should not be executed...",\
-  set this flag to true.\
-  This may happen, for example, when elector contract contains too many participants
 
-### ResultOfRunGet
-
+## ResultOfRunGet
 ```ts
 type ResultOfRunGet = {
     output: any
 }
 ```
+- `output`: _any_ – Values returned by get-method on stack
 
-* `output`: _any_ – Values returned by get-method on stack
+

--- a/docs/acki-nacki-sdk/types-and-methods/mod_utils.md
+++ b/docs/acki-nacki-sdk/types-and-methods/mod_utils.md
@@ -1,58 +1,55 @@
 # Module utils
 
-## Module utils
-
 Misc utility Functions.
 
-### Functions
-
-[convert\_address](mod_utils.md#convert_address) – Converts address from any TVM format to TVM format
-
-[get\_address\_type](mod_utils.md#get_address_type) – Validates and returns the type of any Acki Nacki address.
-
-[calc\_storage\_fee](mod_utils.md#calc_storage_fee) – Calculates storage fee for an account over a specified time period
-
-[compress\_zstd](mod_utils.md#compress_zstd) – Compresses data using Zstandard algorithm
-
-[decompress\_zstd](mod_utils.md#decompress_zstd) – Decompresses data using Zstandard algorithm
-
-### Types
-
-[AddressStringFormatAccountIdVariant](mod_utils.md#addressstringformataccountidvariant)
-
-[AddressStringFormatHexVariant](mod_utils.md#addressstringformathexvariant)
-
-[AddressStringFormatBase64Variant](mod_utils.md#addressstringformatbase64variant)
-
-[AddressStringFormat](mod_utils.md#addressstringformat)
-
-[AccountAddressType](mod_utils.md#accountaddresstype)
-
-[ParamsOfConvertAddress](mod_utils.md#paramsofconvertaddress)
-
-[ResultOfConvertAddress](mod_utils.md#resultofconvertaddress)
-
-[ParamsOfGetAddressType](mod_utils.md#paramsofgetaddresstype)
-
-[ResultOfGetAddressType](mod_utils.md#resultofgetaddresstype)
-
-[ParamsOfCalcStorageFee](mod_utils.md#paramsofcalcstoragefee)
-
-[ResultOfCalcStorageFee](mod_utils.md#resultofcalcstoragefee)
-
-[ParamsOfCompressZstd](mod_utils.md#paramsofcompresszstd)
-
-[ResultOfCompressZstd](mod_utils.md#resultofcompresszstd)
-
-[ParamsOfDecompressZstd](mod_utils.md#paramsofdecompresszstd)
-
-[ResultOfDecompressZstd](mod_utils.md#resultofdecompresszstd)
 
 ## Functions
+[convert_address](mod\_utils.md#convert_address) – Converts address from any TON format to any TON format
 
-### convert\_address
+[get_address_type](mod\_utils.md#get_address_type) – Validates and returns the type of any TON address.
 
-Converts address from any Acki Nacki format to any Acki Nacki format
+[calc_storage_fee](mod\_utils.md#calc_storage_fee) – Calculates storage fee for an account over a specified time period
+
+[compress_zstd](mod\_utils.md#compress_zstd) – Compresses data using Zstandard algorithm
+
+[decompress_zstd](mod\_utils.md#decompress_zstd) – Decompresses data using Zstandard algorithm
+
+## Types
+[AddressStringFormatAccountIdVariant](mod\_utils.md#addressstringformataccountidvariant)
+
+[AddressStringFormatHexVariant](mod\_utils.md#addressstringformathexvariant)
+
+[AddressStringFormatBase64Variant](mod\_utils.md#addressstringformatbase64variant)
+
+[AddressStringFormat](mod\_utils.md#addressstringformat)
+
+[AccountAddressType](mod\_utils.md#accountaddresstype)
+
+[ParamsOfConvertAddress](mod\_utils.md#paramsofconvertaddress)
+
+[ResultOfConvertAddress](mod\_utils.md#resultofconvertaddress)
+
+[ParamsOfGetAddressType](mod\_utils.md#paramsofgetaddresstype)
+
+[ResultOfGetAddressType](mod\_utils.md#resultofgetaddresstype)
+
+[ParamsOfCalcStorageFee](mod\_utils.md#paramsofcalcstoragefee)
+
+[ResultOfCalcStorageFee](mod\_utils.md#resultofcalcstoragefee)
+
+[ParamsOfCompressZstd](mod\_utils.md#paramsofcompresszstd)
+
+[ResultOfCompressZstd](mod\_utils.md#resultofcompresszstd)
+
+[ParamsOfDecompressZstd](mod\_utils.md#paramsofdecompresszstd)
+
+[ResultOfDecompressZstd](mod\_utils.md#resultofdecompresszstd)
+
+
+# Functions
+## convert_address
+
+Converts address from any TON format to any TON format
 
 ```ts
 type ParamsOfConvertAddress = {
@@ -72,25 +69,30 @@ function convert_address_sync(
     params: ParamsOfConvertAddress,
 ): ResultOfConvertAddress;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `address`: _string_ – Account address in any TON format.
+- `output_format`: _[AddressStringFormat](mod\_utils.md#addressstringformat)_ – Specify the format to convert to.
 
-#### Parameters
 
-* `address`: _string_ – Account address in any Acki NAcki format.
-* `output_format`: [_AddressStringFormat_](mod_utils.md#addressstringformat) – Specify the format to convert to.
+### Result
 
-#### Result
+- `address`: _string_ – Address in the specified format
 
-* `address`: _string_ – Address in the specified format
 
-### get\_address\_type
+## get_address_type
 
-Validates and returns the type of any Acki Nacki address.
+Validates and returns the type of any TON address.
 
 Address types are the following
 
-`0:919db8e740d50bf349df2eea03fa30c385d846b991ff5542e67098ee833fc7f7` - standard Acki Nacki address most commonly used in all cases. Also called as hex address `919db8e740d50bf349df2eea03fa30c385d846b991ff5542e67098ee833fc7f7` - account ID. A part of full address. Identifies account inside particular workchain `EQCRnbjnQNUL80nfLuoD+jDDhdhGuZH/VULmcJjugz/H9wam` - base64 address. Also called "user-friendly". Was used at the beginning of TVM. Now it is supported for compatibility
+`0:919db8e740d50bf349df2eea03fa30c385d846b991ff5542e67098ee833fc7f7` -
+standard TON address most commonly used in all cases. Also called as hex
+address `919db8e740d50bf349df2eea03fa30c385d846b991ff5542e67098ee833fc7f7` -
+account ID. A part of full address. Identifies account inside particular
+workchain `EQCRnbjnQNUL80nfLuoD+jDDhdhGuZH/VULmcJjugz/H9wam` - base64
+address. Also called "user-friendly". Was used at the beginning of TON. Now
+it is supported for compatibility
 
 ```ts
 type ParamsOfGetAddressType = {
@@ -109,18 +111,17 @@ function get_address_type_sync(
     params: ParamsOfGetAddressType,
 ): ResultOfGetAddressType;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `address`: _string_ – Account address in any TON format.
 
-#### Parameters
 
-* `address`: _string_ – Account address in any TVM format.
+### Result
 
-#### Result
+- `address_type`: _[AccountAddressType](mod\_utils.md#accountaddresstype)_ – Account address type.
 
-* `address_type`: [_AccountAddressType_](mod_utils.md#accountaddresstype) – Account address type.
 
-### calc\_storage\_fee
+## calc_storage_fee
 
 Calculates storage fee for an account over a specified time period
 
@@ -142,19 +143,18 @@ function calc_storage_fee_sync(
     params: ParamsOfCalcStorageFee,
 ): ResultOfCalcStorageFee;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `account`: _string_
+- `period`: _number_
 
-#### Parameters
 
-* `account`: _string_
-* `period`: _number_
+### Result
 
-#### Result
+- `fee`: _string_
 
-* `fee`: _string_
 
-### compress\_zstd
+## compress_zstd
 
 Compresses data using Zstandard algorithm
 
@@ -176,21 +176,20 @@ function compress_zstd_sync(
     params: ParamsOfCompressZstd,
 ): ResultOfCompressZstd;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `uncompressed`: _string_ – Uncompressed data.
+<br>Must be encoded as base64.
+- `level`?: _number_ – Compression level, from 1 to 21. Where: 1 - lowest compression level (fastest compression); 21 - highest compression level (slowest compression). If level is omitted, the default compression level is used (currently `3`).
 
-#### Parameters
 
-* `uncompressed`: _string_ – Uncompressed data.\
-  Must be encoded as base64.
-* `level`?: _number_ – Compression level, from 1 to 21. Where: 1 - lowest compression level (fastest compression); 21 - highest compression level (slowest compression). If level is omitted, the default compression level is used (currently `3`).
+### Result
 
-#### Result
+- `compressed`: _string_ – Compressed data.
+<br>Must be encoded as base64.
 
-* `compressed`: _string_ – Compressed data.\
-  Must be encoded as base64.
 
-### decompress\_zstd
+## decompress_zstd
 
 Decompresses data using Zstandard algorithm
 
@@ -211,39 +210,36 @@ function decompress_zstd_sync(
     params: ParamsOfDecompressZstd,
 ): ResultOfDecompressZstd;
 ```
-
 NOTE: Sync version is available only for `lib-node` binding.
+### Parameters
+- `compressed`: _string_ – Compressed data.
+<br>Must be encoded as base64.
 
-#### Parameters
 
-* `compressed`: _string_ – Compressed data.\
-  Must be encoded as base64.
+### Result
 
-#### Result
+- `decompressed`: _string_ – Decompressed data.
+<br>Must be encoded as base64.
 
-* `decompressed`: _string_ – Decompressed data.\
-  Must be encoded as base64.
 
-## Types
-
-### AddressStringFormatAccountIdVariant
-
+# Types
+## AddressStringFormatAccountIdVariant
 ```ts
 type AddressStringFormatAccountIdVariant = {
 
 }
 ```
 
-### AddressStringFormatHexVariant
 
+## AddressStringFormatHexVariant
 ```ts
 type AddressStringFormatHexVariant = {
 
 }
 ```
 
-### AddressStringFormatBase64Variant
 
+## AddressStringFormatBase64Variant
 ```ts
 type AddressStringFormatBase64Variant = {
     url: boolean,
@@ -251,13 +247,12 @@ type AddressStringFormatBase64Variant = {
     bounce: boolean
 }
 ```
+- `url`: _boolean_
+- `test`: _boolean_
+- `bounce`: _boolean_
 
-* `url`: _boolean_
-* `test`: _boolean_
-* `bounce`: _boolean_
 
-### AddressStringFormat
-
+## AddressStringFormat
 ```ts
 type AddressStringFormat = ({
     type: 'AccountId'
@@ -267,18 +262,20 @@ type AddressStringFormat = ({
     type: 'Base64'
 } & AddressStringFormatBase64Variant)
 ```
-
-Depends on value of the `type` field.
+Depends on value of the  `type` field.
 
 When _type_ is _'AccountId'_
 
+
 When _type_ is _'Hex'_
+
 
 When _type_ is _'Base64'_
 
-* `url`: _boolean_
-* `test`: _boolean_
-* `bounce`: _boolean_
+- `url`: _boolean_
+- `test`: _boolean_
+- `bounce`: _boolean_
+
 
 Variant constructors:
 
@@ -288,8 +285,7 @@ function addressStringFormatHex(): AddressStringFormat;
 function addressStringFormatBase64(url: boolean, test: boolean, bounce: boolean): AddressStringFormat;
 ```
 
-### AccountAddressType
-
+## AccountAddressType
 ```ts
 enum AccountAddressType {
     AccountId = "AccountId",
@@ -297,119 +293,110 @@ enum AccountAddressType {
     Base64 = "Base64"
 }
 ```
-
 One of the following value:
 
-* `AccountId = "AccountId"`
-* `Hex = "Hex"`
-* `Base64 = "Base64"`
+- `AccountId = "AccountId"`
+- `Hex = "Hex"`
+- `Base64 = "Base64"`
 
-### ParamsOfConvertAddress
 
+## ParamsOfConvertAddress
 ```ts
 type ParamsOfConvertAddress = {
     address: string,
     output_format: AddressStringFormat
 }
 ```
+- `address`: _string_ – Account address in any TON format.
+- `output_format`: _[AddressStringFormat](mod\_utils.md#addressstringformat)_ – Specify the format to convert to.
 
-* `address`: _string_ – Account address in any Acki Nacki format.
-* `output_format`: [_AddressStringFormat_](mod_utils.md#addressstringformat) – Specify the format to convert to.
 
-### ResultOfConvertAddress
-
+## ResultOfConvertAddress
 ```ts
 type ResultOfConvertAddress = {
     address: string
 }
 ```
+- `address`: _string_ – Address in the specified format
 
-* `address`: _string_ – Address in the specified format
 
-### ParamsOfGetAddressType
-
+## ParamsOfGetAddressType
 ```ts
 type ParamsOfGetAddressType = {
     address: string
 }
 ```
+- `address`: _string_ – Account address in any TON format.
 
-* `address`: _string_ – Account address in any TVM format.
 
-### ResultOfGetAddressType
-
+## ResultOfGetAddressType
 ```ts
 type ResultOfGetAddressType = {
     address_type: AccountAddressType
 }
 ```
+- `address_type`: _[AccountAddressType](mod\_utils.md#accountaddresstype)_ – Account address type.
 
-* `address_type`: [_AccountAddressType_](mod_utils.md#accountaddresstype) – Account address type.
 
-### ParamsOfCalcStorageFee
-
+## ParamsOfCalcStorageFee
 ```ts
 type ParamsOfCalcStorageFee = {
     account: string,
     period: number
 }
 ```
+- `account`: _string_
+- `period`: _number_
 
-* `account`: _string_
-* `period`: _number_
 
-### ResultOfCalcStorageFee
-
+## ResultOfCalcStorageFee
 ```ts
 type ResultOfCalcStorageFee = {
     fee: string
 }
 ```
+- `fee`: _string_
 
-* `fee`: _string_
 
-### ParamsOfCompressZstd
-
+## ParamsOfCompressZstd
 ```ts
 type ParamsOfCompressZstd = {
     uncompressed: string,
     level?: number
 }
 ```
+- `uncompressed`: _string_ – Uncompressed data.
+<br>Must be encoded as base64.
+- `level`?: _number_ – Compression level, from 1 to 21. Where: 1 - lowest compression level (fastest compression); 21 - highest compression level (slowest compression). If level is omitted, the default compression level is used (currently `3`).
 
-* `uncompressed`: _string_ – Uncompressed data.\
-  Must be encoded as base64.
-* `level`?: _number_ – Compression level, from 1 to 21. Where: 1 - lowest compression level (fastest compression); 21 - highest compression level (slowest compression). If level is omitted, the default compression level is used (currently `3`).
 
-### ResultOfCompressZstd
-
+## ResultOfCompressZstd
 ```ts
 type ResultOfCompressZstd = {
     compressed: string
 }
 ```
+- `compressed`: _string_ – Compressed data.
+<br>Must be encoded as base64.
 
-* `compressed`: _string_ – Compressed data.\
-  Must be encoded as base64.
 
-### ParamsOfDecompressZstd
-
+## ParamsOfDecompressZstd
 ```ts
 type ParamsOfDecompressZstd = {
     compressed: string
 }
 ```
+- `compressed`: _string_ – Compressed data.
+<br>Must be encoded as base64.
 
-* `compressed`: _string_ – Compressed data.\
-  Must be encoded as base64.
 
-### ResultOfDecompressZstd
-
+## ResultOfDecompressZstd
 ```ts
 type ResultOfDecompressZstd = {
     decompressed: string
 }
 ```
+- `decompressed`: _string_ – Decompressed data.
+<br>Must be encoded as base64.
 
-* `decompressed`: _string_ – Decompressed data.\
-  Must be encoded as base64.
+

--- a/docs/acki-nacki-sdk/types-and-methods/modules.md
+++ b/docs/acki-nacki-sdk/types-and-methods/modules.md
@@ -1,9 +1,5 @@
-# Modules
-
-## Common Types
-
-### ResponseHandler
-
+# Common Types
+## ResponseHandler
 ```ts
 type ResponseHandler = (params: any, responseType: number) => void;
 ```
@@ -11,289 +7,311 @@ type ResponseHandler = (params: any, responseType: number) => void;
 Handles additional function responses.
 
 Where:
+- `params`: _any_ – Response parameters. Actual type depends on API function. 
+- `responseType`: _number_ – Function specific response type.
 
-* `params`: _any_ – Response parameters. Actual type depends on API function.
-* `responseType`: _number_ – Function specific response type.
+# Modules
+## [client](mod\_client.md) – Provides information about library.
 
-## Modules
+[get_api_reference](mod\_client.md#get_api_reference) – Returns Core Library API reference
 
-### [client](mod_client.md) – Provides information about library.
+[version](mod\_client.md#version) – Returns Core Library version
 
-[get\_api\_reference](mod_client.md#get_api_reference) – Returns Core Library API reference
+[config](mod\_client.md#config) – Returns Core Library API reference
 
-[version](mod_client.md#version) – Returns Core Library version
+[build_info](mod\_client.md#build_info) – Returns detailed information about this build.
 
-[config](mod_client.md#config) – Returns Core Library API reference
+[resolve_app_request](mod\_client.md#resolve_app_request) – Resolves application request processing result
 
-[build\_info](mod_client.md#build_info) – Returns detailed information about this build.
+## [account](mod\_account.md) – Provides information about account.
 
-[resolve\_app\_request](mod_client.md#resolve_app_request) – Resolves application request processing result
+[get_account](mod\_account.md#get_account)
 
-### [crypto](mod_crypto.md) – Crypto functions.
+## [crypto](mod\_crypto.md) – Crypto functions.
 
-[factorize](mod_crypto.md#factorize) – Integer factorization
+[factorize](mod\_crypto.md#factorize) – Integer factorization
 
-[modular\_power](mod_crypto.md#modular_power) – Modular exponentiation
+[modular_power](mod\_crypto.md#modular_power) – Modular exponentiation
 
-[tvm\_crc16](mod_crypto.md#tvm_crc16) – Calculates CRC16 using TVM algorithm.
+[tvm_crc16](mod\_crypto.md#tvm_crc16) – Calculates CRC16 using TON algorithm.
 
-[generate\_random\_bytes](mod_crypto.md#generate_random_bytes) – Generates random byte array of the specified length and returns it in `base64` format
+[generate_random_bytes](mod\_crypto.md#generate_random_bytes) – Generates random byte array of the specified length and returns it in `base64` format
 
-[convert\_public\_key\_to\_tvm\_safe\_format](mod_crypto.md#convert_public_key_to_tvm_safe_format) – Converts public key to tvm safe\_format
+[convert_public_key_to_tvm_safe_format](mod\_crypto.md#convert_public_key_to_tvm_safe_format) – Converts public key to ton safe_format
 
-[generate\_random\_sign\_keys](mod_crypto.md#generate_random_sign_keys) – Generates random ed25519 key pair.
+[generate_random_sign_keys](mod\_crypto.md#generate_random_sign_keys) – Generates random ed25519 key pair.
 
-[sign](mod_crypto.md#sign) – Signs a data using the provided keys.
+[sign](mod\_crypto.md#sign) – Signs a data using the provided keys.
 
-[verify\_signature](mod_crypto.md#verify_signature) – Verifies signed data using the provided public key. Raises error if verification is failed.
+[verify_signature](mod\_crypto.md#verify_signature) – Verifies signed data using the provided public key. Raises error if verification is failed.
 
-[sha256](mod_crypto.md#sha256) – Calculates SHA256 hash of the specified data.
+[sha256](mod\_crypto.md#sha256) – Calculates SHA256 hash of the specified data.
 
-[sha512](mod_crypto.md#sha512) – Calculates SHA512 hash of the specified data.
+[sha512](mod\_crypto.md#sha512) – Calculates SHA512 hash of the specified data.
 
-[scrypt](mod_crypto.md#scrypt) – Perform `scrypt` encryption
+[scrypt](mod\_crypto.md#scrypt) – Perform `scrypt` encryption
 
-[nacl\_sign\_keypair\_from\_secret\_key](mod_crypto.md#nacl_sign_keypair_from_secret_key) – Generates a key pair for signing from the secret key
+[nacl_sign_keypair_from_secret_key](mod\_crypto.md#nacl_sign_keypair_from_secret_key) – Generates a key pair for signing from the secret key
 
-[nacl\_sign](mod_crypto.md#nacl_sign) – Signs data using the signer's secret key.
+[nacl_sign](mod\_crypto.md#nacl_sign) – Signs data using the signer's secret key.
 
-[nacl\_sign\_open](mod_crypto.md#nacl_sign_open) – Verifies the signature and returns the unsigned message
+[nacl_sign_open](mod\_crypto.md#nacl_sign_open) – Verifies the signature and returns the unsigned message
 
-[nacl\_sign\_detached](mod_crypto.md#nacl_sign_detached) – Signs the message using the secret key and returns a signature.
+[nacl_sign_detached](mod\_crypto.md#nacl_sign_detached) – Signs the message using the secret key and returns a signature.
 
-[nacl\_sign\_detached\_verify](mod_crypto.md#nacl_sign_detached_verify) – Verifies the signature with public key and `unsigned` data.
+[nacl_sign_detached_verify](mod\_crypto.md#nacl_sign_detached_verify) – Verifies the signature with public key and `unsigned` data.
 
-[nacl\_box\_keypair](mod_crypto.md#nacl_box_keypair) – Generates a random NaCl key pair
+[nacl_box_keypair](mod\_crypto.md#nacl_box_keypair) – Generates a random NaCl key pair
 
-[nacl\_box\_keypair\_from\_secret\_key](mod_crypto.md#nacl_box_keypair_from_secret_key) – Generates key pair from a secret key
+[nacl_box_keypair_from_secret_key](mod\_crypto.md#nacl_box_keypair_from_secret_key) – Generates key pair from a secret key
 
-[nacl\_box](mod_crypto.md#nacl_box) – Public key authenticated encryption
+[nacl_box](mod\_crypto.md#nacl_box) – Public key authenticated encryption
 
-[nacl\_box\_open](mod_crypto.md#nacl_box_open) – Decrypt and verify the cipher text using the receivers secret key, the senders public key, and the nonce.
+[nacl_box_open](mod\_crypto.md#nacl_box_open) – Decrypt and verify the cipher text using the receivers secret key, the senders public key, and the nonce.
 
-[nacl\_secret\_box](mod_crypto.md#nacl_secret_box) – Encrypt and authenticate message using nonce and secret key.
+[nacl_secret_box](mod\_crypto.md#nacl_secret_box) – Encrypt and authenticate message using nonce and secret key.
 
-[nacl\_secret\_box\_open](mod_crypto.md#nacl_secret_box_open) – Decrypts and verifies cipher text using `nonce` and secret `key`.
+[nacl_secret_box_open](mod\_crypto.md#nacl_secret_box_open) – Decrypts and verifies cipher text using `nonce` and secret `key`.
 
-[mnemonic\_words](mod_crypto.md#mnemonic_words) – Prints the list of words from the specified dictionary
+[mnemonic_words](mod\_crypto.md#mnemonic_words) – Prints the list of words from the specified dictionary
 
-[mnemonic\_from\_random](mod_crypto.md#mnemonic_from_random) – Generates a random mnemonic
+[mnemonic_from_random](mod\_crypto.md#mnemonic_from_random) – Generates a random mnemonic
 
-[mnemonic\_from\_entropy](mod_crypto.md#mnemonic_from_entropy) – Generates mnemonic from pre-generated entropy
+[mnemonic_from_entropy](mod\_crypto.md#mnemonic_from_entropy) – Generates mnemonic from pre-generated entropy
 
-[mnemonic\_verify](mod_crypto.md#mnemonic_verify) – Validates a mnemonic phrase
+[mnemonic_verify](mod\_crypto.md#mnemonic_verify) – Validates a mnemonic phrase
 
-[mnemonic\_derive\_sign\_keys](mod_crypto.md#mnemonic_derive_sign_keys) – Derives a key pair for signing from the seed phrase
+[mnemonic_derive_sign_keys](mod\_crypto.md#mnemonic_derive_sign_keys) – Derives a key pair for signing from the seed phrase
 
-[hdkey\_xprv\_from\_mnemonic](mod_crypto.md#hdkey_xprv_from_mnemonic) – Generates an extended master private key that will be the root for all the derived keys
+[hdkey_xprv_from_mnemonic](mod\_crypto.md#hdkey_xprv_from_mnemonic) – Generates an extended master private key that will be the root for all the derived keys
 
-[hdkey\_derive\_from\_xprv](mod_crypto.md#hdkey_derive_from_xprv) – Returns extended private key derived from the specified extended private key and child index
+[hdkey_derive_from_xprv](mod\_crypto.md#hdkey_derive_from_xprv) – Returns extended private key derived from the specified extended private key and child index
 
-[hdkey\_derive\_from\_xprv\_path](mod_crypto.md#hdkey_derive_from_xprv_path) – Derives the extended private key from the specified key and path
+[hdkey_derive_from_xprv_path](mod\_crypto.md#hdkey_derive_from_xprv_path) – Derives the extended private key from the specified key and path
 
-[hdkey\_secret\_from\_xprv](mod_crypto.md#hdkey_secret_from_xprv) – Extracts the private key from the serialized extended private key
+[hdkey_secret_from_xprv](mod\_crypto.md#hdkey_secret_from_xprv) – Extracts the private key from the serialized extended private key
 
-[hdkey\_public\_from\_xprv](mod_crypto.md#hdkey_public_from_xprv) – Extracts the public key from the serialized extended private key
+[hdkey_public_from_xprv](mod\_crypto.md#hdkey_public_from_xprv) – Extracts the public key from the serialized extended private key
 
-[chacha20](mod_crypto.md#chacha20) – Performs symmetric `chacha20` encryption.
+[chacha20](mod\_crypto.md#chacha20) – Performs symmetric `chacha20` encryption.
 
-[create\_crypto\_box](mod_crypto.md#create_crypto_box) – Creates a Crypto Box instance.
+[create_crypto_box](mod\_crypto.md#create_crypto_box) – Creates a Crypto Box instance.
 
-[remove\_crypto\_box](mod_crypto.md#remove_crypto_box) – Removes Crypto Box. Clears all secret data.
+[remove_crypto_box](mod\_crypto.md#remove_crypto_box) – Removes Crypto Box. Clears all secret data.
 
-[get\_crypto\_box\_info](mod_crypto.md#get_crypto_box_info) – Get Crypto Box Info. Used to get `encrypted_secret` that should be used for all the cryptobox initializations except the first one.
+[get_crypto_box_info](mod\_crypto.md#get_crypto_box_info) – Get Crypto Box Info. Used to get `encrypted_secret` that should be used for all the cryptobox initializations except the first one.
 
-[get\_crypto\_box\_seed\_phrase](mod_crypto.md#get_crypto_box_seed_phrase) – Get Crypto Box Seed Phrase.
+[get_crypto_box_seed_phrase](mod\_crypto.md#get_crypto_box_seed_phrase) – Get Crypto Box Seed Phrase.
 
-[get\_signing\_box\_from\_crypto\_box](mod_crypto.md#get_signing_box_from_crypto_box) – Get handle of Signing Box derived from Crypto Box.
+[get_signing_box_from_crypto_box](mod\_crypto.md#get_signing_box_from_crypto_box) – Get handle of Signing Box derived from Crypto Box.
 
-[get\_encryption\_box\_from\_crypto\_box](mod_crypto.md#get_encryption_box_from_crypto_box) – Gets Encryption Box from Crypto Box.
+[get_encryption_box_from_crypto_box](mod\_crypto.md#get_encryption_box_from_crypto_box) – Gets Encryption Box from Crypto Box.
 
-[clear\_crypto\_box\_secret\_cache](mod_crypto.md#clear_crypto_box_secret_cache) – Removes cached secrets (overwrites with zeroes) from all signing and encryption boxes, derived from crypto box.
+[clear_crypto_box_secret_cache](mod\_crypto.md#clear_crypto_box_secret_cache) – Removes cached secrets (overwrites with zeroes) from all signing and encryption boxes, derived from crypto box.
 
-[register\_signing\_box](mod_crypto.md#register_signing_box) – Register an application implemented signing box.
+[register_signing_box](mod\_crypto.md#register_signing_box) – Register an application implemented signing box.
 
-[get\_signing\_box](mod_crypto.md#get_signing_box) – Creates a default signing box implementation.
+[get_signing_box](mod\_crypto.md#get_signing_box) – Creates a default signing box implementation.
 
-[signing\_box\_get\_public\_key](mod_crypto.md#signing_box_get_public_key) – Returns public key of signing key pair.
+[signing_box_get_public_key](mod\_crypto.md#signing_box_get_public_key) – Returns public key of signing key pair.
 
-[signing\_box\_sign](mod_crypto.md#signing_box_sign) – Returns signed user data.
+[signing_box_sign](mod\_crypto.md#signing_box_sign) – Returns signed user data.
 
-[remove\_signing\_box](mod_crypto.md#remove_signing_box) – Removes signing box from SDK.
+[remove_signing_box](mod\_crypto.md#remove_signing_box) – Removes signing box from SDK.
 
-[register\_encryption\_box](mod_crypto.md#register_encryption_box) – Register an application implemented encryption box.
+[register_encryption_box](mod\_crypto.md#register_encryption_box) – Register an application implemented encryption box.
 
-[remove\_encryption\_box](mod_crypto.md#remove_encryption_box) – Removes encryption box from SDK
+[remove_encryption_box](mod\_crypto.md#remove_encryption_box) – Removes encryption box from SDK
 
-[encryption\_box\_get\_info](mod_crypto.md#encryption_box_get_info) – Queries info from the given encryption box
+[encryption_box_get_info](mod\_crypto.md#encryption_box_get_info) – Queries info from the given encryption box
 
-[encryption\_box\_encrypt](mod_crypto.md#encryption_box_encrypt) – Encrypts data using given encryption box Note.
+[encryption_box_encrypt](mod\_crypto.md#encryption_box_encrypt) – Encrypts data using given encryption box Note.
 
-[encryption\_box\_decrypt](mod_crypto.md#encryption_box_decrypt) – Decrypts data using given encryption box Note.
+[encryption_box_decrypt](mod\_crypto.md#encryption_box_decrypt) – Decrypts data using given encryption box Note.
 
-[create\_encryption\_box](mod_crypto.md#create_encryption_box) – Creates encryption box with specified algorithm
+[create_encryption_box](mod\_crypto.md#create_encryption_box) – Creates encryption box with specified algorithm
 
-### [abi](mod_abi.md) – Provides message encoding and decoding according to the ABI specification.
+## [abi](mod\_abi.md) – Provides message encoding and decoding according to the ABI specification.
 
-[encode\_message\_body](mod_abi.md#encode_message_body) – Encodes message body according to ABI function call.
+[encode_message_body](mod\_abi.md#encode_message_body) – Encodes message body according to ABI function call.
 
-[attach\_signature\_to\_message\_body](mod_abi.md#attach_signature_to_message_body)
+[attach_signature_to_message_body](mod\_abi.md#attach_signature_to_message_body) – Attach signature
 
-[encode\_message](mod_abi.md#encode_message) – Encodes an ABI-compatible message
+[encode_message](mod\_abi.md#encode_message) – Encodes an ABI-compatible message
 
-[encode\_internal\_message](mod_abi.md#encode_internal_message) – Encodes an internal ABI-compatible message
+[encode_internal_message](mod\_abi.md#encode_internal_message) – Encodes an internal ABI-compatible message
 
-[attach\_signature](mod_abi.md#attach_signature) – Combines `hex`-encoded `signature` with `base64`-encoded `unsigned_message`. Returns signed message encoded in `base64`.
+[attach_signature](mod\_abi.md#attach_signature) – Combines `hex`-encoded `signature` with `base64`-encoded `unsigned_message`. Returns signed message encoded in `base64`.
 
-[decode\_message](mod_abi.md#decode_message) – Decodes message body using provided message BOC and ABI.
+[decode_message](mod\_abi.md#decode_message) – Decodes message body using provided message BOC and ABI.
 
-[decode\_message\_body](mod_abi.md#decode_message_body) – Decodes message body using provided body BOC and ABI.
+[decode_message_body](mod\_abi.md#decode_message_body) – Decodes message body using provided body BOC and ABI.
 
-[encode\_account](mod_abi.md#encode_account) – Creates account state BOC
+[encode_account](mod\_abi.md#encode_account) – Creates account state BOC
 
-[decode\_account\_data](mod_abi.md#decode_account_data) – Decodes account data using provided data BOC and ABI.
+[decode_account_data](mod\_abi.md#decode_account_data) – Decodes account data using provided data BOC and ABI.
 
-[update\_initial\_data](mod_abi.md#update_initial_data) – Updates initial account data with initial values for the contract's static variables and owner's public key. This operation is applicable only for initial account data (before deploy). If the contract is already deployed, its data doesn't contain this data section any more.
+[update_initial_data](mod\_abi.md#update_initial_data) – Updates initial account data with initial values for the contract's static variables and owner's public key.
 
-[encode\_initial\_data](mod_abi.md#encode_initial_data) – Encodes initial account data with initial values for the contract's static variables and owner's public key into a data BOC that can be passed to `encode_tvc` function afterwards.
+[encode_initial_data](mod\_abi.md#encode_initial_data) – Encodes initial account data with initial values for the contract's static variables and owner's public key into a data BOC that can be passed to `encode_tvc` function afterwards.
 
-[decode\_initial\_data](mod_abi.md#decode_initial_data) – Decodes initial values of a contract's static variables and owner's public key from account initial data This operation is applicable only for initial account data (before deploy). If the contract is already deployed, its data doesn't contain this data section any more.
+[decode_initial_data](mod\_abi.md#decode_initial_data) – Decodes initial values of a contract's static variables and owner's public key from account initial data This operation is applicable only for initial account data (before deploy).
 
-[decode\_boc](mod_abi.md#decode_boc) – Decodes BOC into JSON as a set of provided parameters.
+[decode_boc](mod\_abi.md#decode_boc) – Decodes BOC into JSON as a set of provided parameters.
 
-[encode\_boc](mod_abi.md#encode_boc) – Encodes given parameters in JSON into a BOC using param types from ABI.
+[encode_boc](mod\_abi.md#encode_boc) – Encodes given parameters in JSON into a BOC using param types from ABI.
 
-[calc\_function\_id](mod_abi.md#calc_function_id) – Calculates contract function ID by contract ABI
+[calc_function_id](mod\_abi.md#calc_function_id) – Calculates contract function ID by contract ABI
 
-[get\_signature\_data](mod_abi.md#get_signature_data) – Extracts signature from message body and calculates hash to verify the signature
+[get_signature_data](mod\_abi.md#get_signature_data) – Extracts signature from message body and calculates hash to verify the signature
 
-### [boc](mod_boc.md) – BOC manipulation module.
+## [boc](mod\_boc.md) – BOC manipulation module.
 
-[decode\_tvc](mod_boc.md#decode_tvc) – Decodes tvc according to the tvc spec. Read more about tvc structure [here](https://github.com/tvmlabs/tvm-sdk/blob/00fd198e4f8f404d5f495c6a65d84b54fe76881b/tvm_struct/src/scheme/mod.rs#L31)
+[decode_tvc](mod\_boc.md#decode_tvc) – Decodes tvc according to the tvc spec. Read more about tvc structure here https://github.com/tonlabs/ever-struct/blob/main/src/scheme/mod.rs#L30
 
-[parse\_message](mod_boc.md#parse_message) – Parses message boc into a JSON
+[parse_message](mod\_boc.md#parse_message) – Parses message boc into a JSON
 
-[parse\_transaction](mod_boc.md#parse_transaction) – Parses transaction boc into a JSON
+[parse_transaction](mod\_boc.md#parse_transaction) – Parses transaction boc into a JSON
 
-[parse\_account](mod_boc.md#parse_account) – Parses account boc into a JSON
+[parse_account](mod\_boc.md#parse_account) – Parses account boc into a JSON
 
-[parse\_block](mod_boc.md#parse_block) – Parses block boc into a JSON
+[parse_block](mod\_boc.md#parse_block) – Parses block boc into a JSON
 
-[parse\_shardstate](mod_boc.md#parse_shardstate) – Parses shardstate boc into a JSON
+[parse_shardstate](mod\_boc.md#parse_shardstate) – Parses shardstate boc into a JSON
 
-[get\_blockchain\_config](mod_boc.md#get_blockchain_config) – Extract blockchain configuration from key block and also from zerostate.
+[get_blockchain_config](mod\_boc.md#get_blockchain_config) – Extract blockchain configuration from key block and also from zerostate.
 
-[get\_boc\_hash](mod_boc.md#get_boc_hash) – Calculates BOC root hash
+[get_boc_hash](mod\_boc.md#get_boc_hash) – Calculates BOC root hash
 
-[get\_boc\_depth](mod_boc.md#get_boc_depth) – Calculates BOC depth
+[get_boc_depth](mod\_boc.md#get_boc_depth) – Calculates BOC depth
 
-[get\_code\_from\_tvc](mod_boc.md#get_code_from_tvc) – Extracts code from TVC contract image
+[get_code_from_tvc](mod\_boc.md#get_code_from_tvc) – Extracts code from TVC contract image
 
-[cache\_get](mod_boc.md#cache_get) – Get BOC from cache
+[cache_get](mod\_boc.md#cache_get) – Get BOC from cache
 
-[cache\_set](mod_boc.md#cache_set) – Save BOC into cache or increase pin counter for existing pinned BOC
+[cache_set](mod\_boc.md#cache_set) – Save BOC into cache or increase pin counter for existing pinned BOC
 
-[cache\_unpin](mod_boc.md#cache_unpin) – Unpin BOCs with specified pin defined in the `cache_set`. Decrease pin reference counter for BOCs with specified pin defined in the `cache_set`. BOCs which have only 1 pin and its reference counter become 0 will be removed from cache
+[cache_unpin](mod\_boc.md#cache_unpin) – Unpin BOCs with specified pin defined in the `cache_set`. Decrease pin reference counter for BOCs with specified pin defined in the `cache_set`.
 
-[encode\_boc](mod_boc.md#encode_boc) – Encodes bag of cells (BOC) with builder operations. This method provides the same functionality as Solidity TvmBuilder. Resulting BOC of this method can be passed into Solidity and C++ contracts as TvmCell type.
+[encode_boc](mod\_boc.md#encode_boc) – Encodes bag of cells (BOC) with builder operations. This method provides the same functionality as Solidity TvmBuilder. Resulting BOC of this method can be passed into Solidity and C++ contracts as TvmCell type.
 
-[get\_code\_salt](mod_boc.md#get_code_salt) – Returns the contract code's salt if it is present.
+[get_code_salt](mod\_boc.md#get_code_salt) – Returns the contract code's salt if it is present.
 
-[set\_code\_salt](mod_boc.md#set_code_salt) – Sets new salt to contract code.
+[set_code_salt](mod\_boc.md#set_code_salt) – Sets new salt to contract code.
 
-[decode\_state\_init](mod_boc.md#decode_state_init) – Decodes contract's initial state into code, data, libraries and special options.
+[decode_state_init](mod\_boc.md#decode_state_init) – Decodes contract's initial state into code, data, libraries and special options.
 
-[encode\_state\_init](mod_boc.md#encode_state_init) – Encodes initial contract state from code, data, libraries ans special options (see input params)
+[encode_state_init](mod\_boc.md#encode_state_init) – Encodes initial contract state from code, data, libraries ans special options (see input params)
 
-[encode\_external\_in\_message](mod_boc.md#encode_external_in_message) – Encodes a message
+[encode_external_in_message](mod\_boc.md#encode_external_in_message) – Encodes a message
 
-[get\_compiler\_version](mod_boc.md#get_compiler_version) – Returns the compiler version used to compile the code.
+[get_compiler_version](mod\_boc.md#get_compiler_version) – Returns the compiler version used to compile the code.
 
-### [processing](mod_processing.md) – Message processing module.
+## [processing](mod\_processing.md) – Message processing module.
 
-[monitor\_messages](mod_processing.md#monitor_messages) – Starts monitoring for the processing results of the specified messages.
+[monitor_messages](mod\_processing.md#monitor_messages) – Starts monitoring for the processing results of the specified messages.
 
-[get\_monitor\_info](mod_processing.md#get_monitor_info) – Returns summary information about current state of the specified monitoring queue.
+[get_monitor_info](mod\_processing.md#get_monitor_info) – Returns summary information about current state of the specified monitoring queue.
 
-[fetch\_next\_monitor\_results](mod_processing.md#fetch_next_monitor_results) – Fetches next resolved results from the specified monitoring queue.
+[fetch_next_monitor_results](mod\_processing.md#fetch_next_monitor_results) – Fetches next resolved results from the specified monitoring queue.
 
-[cancel\_monitor](mod_processing.md#cancel_monitor) – Cancels all background activity and releases all allocated system resources for the specified monitoring queue.
+[cancel_monitor](mod\_processing.md#cancel_monitor) – Cancels all background activity and releases all allocated system resources for the specified monitoring queue.
 
-[send\_messages](mod_processing.md#send_messages) – Sends specified messages to the blockchain.
+[send_messages](mod\_processing.md#send_messages) – Sends specified messages to the blockchain.
 
-[send\_message](mod_processing.md#send_message) – Sends message to the network
+[send_message](mod\_processing.md#send_message) – Sends message to the network
 
-[wait\_for\_transaction](mod_processing.md#wait_for_transaction) – Performs monitoring of the network for the result transaction of the external inbound message processing.
+[wait_for_transaction](mod\_processing.md#wait_for_transaction) – Performs monitoring of the network for the result transaction of the external inbound message processing.
 
-[process\_message](mod_processing.md#process_message) – Creates message, sends it to the network and monitors its processing.
+[process_message](mod\_processing.md#process_message) – Creates message, sends it to the network and monitors its processing.
 
-### [utils](mod_utils.md) – Misc utility Functions.
+## [utils](mod\_utils.md) – Misc utility Functions.
 
-[convert\_address](mod_utils.md#convert_address) – Converts address from any TVM format to any TVM format
+[convert_address](mod\_utils.md#convert_address) – Converts address from any TON format to any TON format
 
-[get\_address\_type](mod_utils.md#get_address_type) – Validates and returns the type of any TVM address.
+[get_address_type](mod\_utils.md#get_address_type) – Validates and returns the type of any TON address.
 
-[calc\_storage\_fee](mod_utils.md#calc_storage_fee) – Calculates storage fee for an account over a specified time period
+[calc_storage_fee](mod\_utils.md#calc_storage_fee) – Calculates storage fee for an account over a specified time period
 
-[compress\_zstd](mod_utils.md#compress_zstd) – Compresses data using Zstandard algorithm
+[compress_zstd](mod\_utils.md#compress_zstd) – Compresses data using Zstandard algorithm
 
-[decompress\_zstd](mod_utils.md#decompress_zstd) – Decompresses data using Zstandard algorithm
+[decompress_zstd](mod\_utils.md#decompress_zstd) – Decompresses data using Zstandard algorithm
 
-### [tvm](mod_tvm.md)
+## [tvm](mod\_tvm.md)
 
-[run\_executor](mod_tvm.md#run_executor) – Emulates all the phases of contract execution locally
+[run_executor](mod\_tvm.md#run_executor) – Emulates all the phases of contract execution locally
 
-[run\_tvm](mod_tvm.md#run_tvm) – Executes get-methods of ABI-compatible contracts
+[run_tvm](mod\_tvm.md#run_tvm) – Executes get-methods of ABI-compatible contracts
 
-[run\_get](mod_tvm.md#run_get) – Executes a get-method of FIFT contract
+[run_get](mod\_tvm.md#run_get) – Executes a get-method of FIFT contract
 
-### [net](mod_net.md) – Network access.
+## [net](mod\_net.md) – Network access.
 
-[query](mod_net.md#query) – Performs DAppServer GraphQL query.
+[query](mod\_net.md#query) – Performs DAppServer GraphQL query.
 
-[batch\_query](mod_net.md#batch_query) – Performs multiple queries per single fetch.
+[batch_query](mod\_net.md#batch_query) – Performs multiple queries per single fetch.
 
-[query\_collection](mod_net.md#query_collection) – Queries collection data
+[query_collection](mod\_net.md#query_collection) – Queries collection data
 
-[aggregate\_collection](mod_net.md#aggregate_collection) – Aggregates collection data.
+[aggregate_collection](mod\_net.md#aggregate_collection) – Aggregates collection data.
 
-[wait\_for\_collection](mod_net.md#wait_for_collection) – Returns an object that fulfills the conditions or waits for its appearance
+[wait_for_collection](mod\_net.md#wait_for_collection) – Returns an object that fulfills the conditions or waits for its appearance
 
-[unsubscribe](mod_net.md#unsubscribe) – Cancels a subscription
+[unsubscribe](mod\_net.md#unsubscribe) – Cancels a subscription
 
-[subscribe\_collection](mod_net.md#subscribe_collection) – Creates a collection subscription
+[subscribe_collection](mod\_net.md#subscribe_collection) – Creates a collection subscription
 
-[subscribe](mod_net.md#subscribe) – Creates a subscription
+[subscribe](mod\_net.md#subscribe) – Creates a subscription (Deprecated)
 
-[suspend](mod_net.md#suspend) – Suspends network module to stop any network activity
+[suspend](mod\_net.md#suspend) – Suspends network module to stop any network activity
 
-[resume](mod_net.md#resume) – Resumes network module to enable network activity
+[resume](mod\_net.md#resume) – Resumes network module to enable network activity
 
-[find\_last\_shard\_block](mod_net.md#find_last_shard_block) – Returns ID of the last block in a specified account shard
+[find_last_shard_block](mod\_net.md#find_last_shard_block) – Returns ID of the last block in a specified account shard
 
-[fetch\_endpoints](mod_net.md#fetch_endpoints) – Requests the list of alternative endpoints from server
+[fetch_endpoints](mod\_net.md#fetch_endpoints) – Requests the list of alternative endpoints from server
 
-[set\_endpoints](mod_net.md#set_endpoints) – Sets the list of endpoints to use on reinit
+[set_endpoints](mod\_net.md#set_endpoints) – Sets the list of endpoints to use on reinit
 
-[get\_endpoints](mod_net.md#get_endpoints) – Requests the list of alternative endpoints from server
+[get_endpoints](mod\_net.md#get_endpoints) – Requests the list of alternative endpoints from server
 
-[query\_counterparties](mod_net.md#query_counterparties) – Allows to query and paginate through the list of accounts that the specified account has interacted with, sorted by the time of the last internal message between accounts
+[query_counterparties](mod\_net.md#query_counterparties) – Allows to query and paginate through the list of accounts that the specified account has interacted with, sorted by the time of the last internal message between accounts
 
-[query\_transaction\_tree](mod_net.md#query_transaction_tree) – Returns a tree of transactions triggered by a specific message.
+[query_transaction_tree](mod\_net.md#query_transaction_tree) – Returns a tree of transactions triggered by a specific message.
 
-[create\_block\_iterator](mod_net.md#create_block_iterator) – Creates block iterator.
+[create_block_iterator](mod\_net.md#create_block_iterator) – Creates block iterator.
 
-[resume\_block\_iterator](mod_net.md#resume_block_iterator) – Resumes block iterator.
+[resume_block_iterator](mod\_net.md#resume_block_iterator) – Resumes block iterator.
 
-[create\_transaction\_iterator](mod_net.md#create_transaction_iterator) – Creates transaction iterator.
+[create_transaction_iterator](mod\_net.md#create_transaction_iterator) – Creates transaction iterator.
 
-[resume\_transaction\_iterator](mod_net.md#resume_transaction_iterator) – Resumes transaction iterator.
+[resume_transaction_iterator](mod\_net.md#resume_transaction_iterator) – Resumes transaction iterator.
 
-[iterator\_next](mod_net.md#iterator_next) – Returns next available items.
+[iterator_next](mod\_net.md#iterator_next) – Returns next available items.
 
-[remove\_iterator](mod_net.md#remove_iterator) – Removes an iterator
+[remove_iterator](mod\_net.md#remove_iterator) – Removes an iterator
 
-[get\_signature\_id](mod_net.md#get_signature_id) – Returns signature ID for configured network if it should be used in messages signature
+[get_signature_id](mod\_net.md#get_signature_id) – Returns signature ID for configured network if it should be used in messages signature
 
+## [debot](mod\_debot.md) – [UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Module for working with debot.
 
+[init](mod\_debot.md#init) – [UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Creates and instance of DeBot.
+
+[start](mod\_debot.md#start) – [UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Starts the DeBot.
+
+[fetch](mod\_debot.md#fetch) – [UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Fetches DeBot metadata from blockchain.
+
+[execute](mod\_debot.md#execute) – [UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Executes debot action.
+
+[send](mod\_debot.md#send) – [UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Sends message to Debot.
+
+[remove](mod\_debot.md#remove) – [UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Destroys debot handle.
+
+## [proofs](mod\_proofs.md) – [UNSTABLE](UNSTABLE.md) [DEPRECATED](DEPRECATED.md) Module for proving data, retrieved from TONOS API.
+
+[proof_block_data](mod\_proofs.md#proof_block_data) – Proves that a given block's data, which is queried from TONOS API, can be trusted.
+
+[proof_transaction_data](mod\_proofs.md#proof_transaction_data) – Proves that a given transaction's data, which is queried from TONOS API, can be trusted.
+
+[proof_message_data](mod\_proofs.md#proof_message_data) – Proves that a given message's data, which is queried from TONOS API, can be trusted.
 

--- a/docs/acki-nacki-sdk/untitled.md
+++ b/docs/acki-nacki-sdk/untitled.md
@@ -178,7 +178,7 @@ Note that the build script generates binaries compatible with the platform used 
 Rebuild `api.json`:
 
 ```shell
-cd tvmcli
+cd tools/tvm_api_gen
 cargo run api -o ../tools
 ```
 

--- a/tools/api.json
+++ b/tools/api.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.18.5",
+  "version": "3.0.0",
   "modules": [
     {
       "name": "client",
@@ -268,28 +268,12 @@
         },
         {
           "name": "ClientError",
-          "type": "Struct",
-          "struct_fields": [
+          "type": "Generic",
+          "generic_name": "Box",
+          "generic_args": [
             {
-              "name": "code",
-              "type": "Number",
-              "number_type": "UInt",
-              "number_size": 32,
-              "summary": null,
-              "description": null
-            },
-            {
-              "name": "message",
-              "type": "String",
-              "summary": null,
-              "description": null
-            },
-            {
-              "name": "data",
               "type": "Ref",
-              "ref_name": "Value",
-              "summary": null,
-              "description": null
+              "ref_name": "ClientErrorInner"
             }
           ],
           "summary": null,
@@ -651,7 +635,7 @@
               "optional_inner": {
                 "type": "String"
               },
-              "summary": "Derivation path that will be used by default in crypto functions. If not specified `m/44'/396'/0'/0/0` will be used.",
+              "summary": "Derivation path that will be used by default in crypto functions. If not specified `m/44'/1331'/0'/0/0` will be used.",
               "description": null
             }
           ],
@@ -1328,9 +1312,15 @@
           "type": "Struct",
           "struct_fields": [
             {
-              "name": "address",
+              "name": "account_id",
               "type": "String",
-              "summary": null,
+              "summary": "Account ID as a 64-character hex string (no 0x, no workchain).",
+              "description": null
+            },
+            {
+              "name": "dapp_id",
+              "type": "String",
+              "summary": "Dapp ID as a 64-character hex string (no 0x). Required when the server supports the v3 API (info.version >= \"1.0.0\").",
               "description": null
             }
           ],
@@ -1343,6 +1333,29 @@
           "struct_fields": [
             {
               "name": "boc",
+              "type": "String",
+              "summary": null,
+              "description": null
+            },
+            {
+              "name": "dapp_id",
+              "type": "String",
+              "summary": null,
+              "description": null
+            },
+            {
+              "name": "state_timestamp",
+              "type": "Optional",
+              "optional_inner": {
+                "type": "BigInt",
+                "number_type": "UInt",
+                "number_size": 64
+              },
+              "summary": null,
+              "description": null
+            },
+            {
+              "name": "account_id",
               "type": "String",
               "summary": null,
               "description": null
@@ -1656,7 +1669,7 @@
               "optional_inner": {
                 "type": "String"
               },
-              "summary": "Derivation path, for instance \"m/44'/396'/0'/0/0\"",
+              "summary": "Derivation path, for instance \"m/44'/1331'/0'/0/0\"",
               "description": null
             },
             {
@@ -3003,7 +3016,7 @@
               "optional_inner": {
                 "type": "String"
               },
-              "summary": "Derivation path, for instance \"m/44'/396'/0'/0/0\"",
+              "summary": "Derivation path, for instance \"m/44'/1331'/0'/0/0\"",
               "description": null
             },
             {
@@ -3135,7 +3148,7 @@
             {
               "name": "path",
               "type": "String",
-              "summary": "Derivation path, for instance \"m/44'/396'/0'/0/0\"",
+              "summary": "Derivation path, for instance \"m/44'/1331'/0'/0/0\"",
               "description": null
             }
           ],
@@ -10005,6 +10018,13 @@
               "value": "517",
               "summary": null,
               "description": null
+            },
+            {
+              "name": "DappIdRequired",
+              "type": "Number",
+              "value": "518",
+              "summary": null,
+              "description": null
             }
           ],
           "summary": null,
@@ -10520,7 +10540,7 @@
               "type": "Number",
               "number_type": "Int",
               "number_size": 32,
-              "summary": "Compute phase exit code.",
+              "summary": null,
               "description": null
             }
           ],
@@ -10537,13 +10557,13 @@
               "optional_inner": {
                 "type": "String"
               },
-              "summary": "Hash of the transaction. Present if transaction was included into the blocks. When then transaction was emulated this field will be missing.",
+              "summary": null,
               "description": null
             },
             {
               "name": "aborted",
               "type": "Boolean",
-              "summary": "Aborted field of the transaction.",
+              "summary": null,
               "description": null
             },
             {
@@ -10553,7 +10573,7 @@
                 "type": "Ref",
                 "ref_name": "processing.MessageMonitoringTransactionCompute"
               },
-              "summary": "Optional information about the compute phase of the transaction.",
+              "summary": null,
               "description": null
             }
           ],
@@ -10568,7 +10588,7 @@
               "name": "message",
               "type": "Ref",
               "ref_name": "processing.MonitoredMessage",
-              "summary": "Monitored message identification. Can be provided as a message's BOC or (hash, address) pair. BOC is a preferable way because it helps to determine possible error reason (using TVM execution of the message).",
+              "summary": null,
               "description": null
             },
             {
@@ -10576,7 +10596,7 @@
               "type": "Number",
               "number_type": "UInt",
               "number_size": 32,
-              "summary": "Block time Must be specified as a UNIX timestamp in seconds",
+              "summary": null,
               "description": null
             },
             {
@@ -10586,7 +10606,7 @@
                 "type": "Ref",
                 "ref_name": "Value"
               },
-              "summary": "User defined data associated with this message. Helps to identify this message when user received `MessageMonitoringResult`.",
+              "summary": null,
               "description": null
             }
           ],
@@ -10600,14 +10620,14 @@
             {
               "name": "hash",
               "type": "String",
-              "summary": "Hash of the message.",
+              "summary": null,
               "description": null
             },
             {
               "name": "status",
               "type": "Ref",
               "ref_name": "processing.MessageMonitoringStatus",
-              "summary": "Processing status.",
+              "summary": null,
               "description": null
             },
             {
@@ -10617,7 +10637,7 @@
                 "type": "Ref",
                 "ref_name": "processing.MessageMonitoringTransaction"
               },
-              "summary": "In case of `Finalized` the transaction is extracted from the block. In case of `Timeout` the transaction is emulated using the last known account state.",
+              "summary": null,
               "description": null
             },
             {
@@ -10626,7 +10646,7 @@
               "optional_inner": {
                 "type": "String"
               },
-              "summary": "In case of `Timeout` contains possible error reason.",
+              "summary": null,
               "description": null
             },
             {
@@ -10636,7 +10656,7 @@
                 "type": "Ref",
                 "ref_name": "Value"
               },
-              "summary": "User defined data related to this message. This is the same value as passed before with `MessageMonitoringParams` or `SendMessageParams`.",
+              "summary": null,
               "description": null
             }
           ],
@@ -10650,13 +10670,13 @@
             {
               "name": "AtLeastOne",
               "type": "None",
-              "summary": "If there are no resolved results yet, then monitor awaits for the next resolved result.",
+              "summary": null,
               "description": null
             },
             {
               "name": "All",
               "type": "None",
-              "summary": "Monitor waits until all unresolved messages will be resolved. If there are no unresolved messages then monitor will wait.",
+              "summary": null,
               "description": null
             },
             {
@@ -10684,7 +10704,7 @@
                   "description": null
                 }
               ],
-              "summary": "BOC of the message.",
+              "summary": null,
               "description": null
             },
             {
@@ -10694,17 +10714,17 @@
                 {
                   "name": "hash",
                   "type": "String",
-                  "summary": "Hash of the message.",
+                  "summary": null,
                   "description": null
                 },
                 {
                   "name": "address",
                   "type": "String",
-                  "summary": "Destination address of the message.",
+                  "summary": null,
                   "description": null
                 }
               ],
-              "summary": "Message's hash and destination address.",
+              "summary": null,
               "description": null
             }
           ],
@@ -10718,20 +10738,20 @@
             {
               "name": "Finalized",
               "type": "None",
-              "summary": "Returned when the messages was processed and included into finalized block before `wait_until` block time.",
+              "summary": null,
               "description": null
             },
             {
               "name": "Timeout",
               "type": "None",
-              "summary": "Returned when the message was not processed until `wait_until` block time.",
+              "summary": null,
               "description": null
             },
             {
               "name": "Reserved",
               "type": "None",
-              "summary": "Reserved for future statuses.",
-              "description": "Is never returned. Application should wait for one of the `Finalized` or `Timeout`\nstatuses. All other statuses are intermediate."
+              "summary": null,
+              "description": null
             }
           ],
           "summary": null,
@@ -10816,7 +10836,7 @@
               "type": "Number",
               "number_type": "UInt",
               "number_size": 32,
-              "summary": "Count of the unresolved messages.",
+              "summary": null,
               "description": null
             },
             {
@@ -10824,7 +10844,7 @@
               "type": "Number",
               "number_type": "UInt",
               "number_size": 32,
-              "summary": "Count of resolved results.",
+              "summary": null,
               "description": null
             }
           ],
@@ -10969,6 +10989,15 @@
               },
               "summary": "Flag for requesting events sending. Default is `false`.",
               "description": null
+            },
+            {
+              "name": "dapp_id",
+              "type": "Optional",
+              "optional_inner": {
+                "type": "String"
+              },
+              "summary": "Destination dapp_id (64-character hex, no 0x). Required for v>=1.0.0 servers; for v<1.0.0 may be empty (sent as legacy `dst_dapp_id: null`).",
+              "description": null
             }
           ],
           "summary": null,
@@ -11061,6 +11090,24 @@
               },
               "summary": "The timestamp of generating this response.",
               "description": null
+            },
+            {
+              "name": "account_id",
+              "type": "Optional",
+              "optional_inner": {
+                "type": "String"
+              },
+              "summary": "Destination account_id (64-hex, no workchain).",
+              "description": "Always populated: taken from the server response on v>=1.0.0, derived locally\nfrom the message destination on v<1.0.0."
+            },
+            {
+              "name": "dapp_id",
+              "type": "Optional",
+              "optional_inner": {
+                "type": "String"
+              },
+              "summary": "Destination dapp_id (64-hex).",
+              "description": "Always populated: taken from the server response on v>=1.0.0, mirrored from the request on v<1.0.0."
             }
           ],
           "summary": null,
@@ -11088,9 +11135,12 @@
             },
             {
               "name": "shard_block_id",
-              "type": "String",
+              "type": "Optional",
+              "optional_inner": {
+                "type": "String"
+              },
               "summary": "The last generated block id of the destination account shard before the message was sent.",
-              "description": "You must provide the same value as the `send_message` has returned."
+              "description": "Deprecated: no longer used. Block walking has been removed."
             },
             {
               "name": "send_events",
@@ -11112,6 +11162,18 @@
               },
               "summary": "The list of endpoints to which the message was sent.",
               "description": "Use this field to get more informative errors.\nProvide the same value as the `send_message` has returned.\nIf the message was not delivered (expired), SDK will log the endpoint\nURLs, used for its sending."
+            },
+            {
+              "name": "tx_hash",
+              "type": "Optional",
+              "optional_inner": {
+                "type": "Optional",
+                "optional_inner": {
+                  "type": "String"
+                }
+              },
+              "summary": "Transaction hash returned by `send_message`. Used to poll for the transaction directly by hash.",
+              "description": null
             }
           ],
           "summary": null,
@@ -11135,6 +11197,15 @@
                 "type": "Boolean"
               },
               "summary": "Flag for requesting events sending. Default is `false`.",
+              "description": null
+            },
+            {
+              "name": "dapp_id",
+              "type": "Optional",
+              "optional_inner": {
+                "type": "String"
+              },
+              "summary": "Destination dapp_id (64-character hex, no 0x). Required for v>=1.0.0 servers; for v<1.0.0 may be empty.",
               "description": null
             }
           ],

--- a/tvm_cli/CHANGELOG.md
+++ b/tvm_cli/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.0.0] - 2026-06-05
+
+### Changed (breaking)
+- Default HD key derivation path changed from `m/44'/396'/0'/0/0` to `m/44'/1331'/0'/0/0`. Key and address generation that rely on the default path now derive different keys from the same seed phrase. To keep previous keys, pass the old path explicitly.
+- Address inputs now require the `dapp_id::account_id` form on all commands and against all nodes. Legacy `0:<hex>`, bare-hex, single-colon, and 128-hex address forms are no longer accepted.
+- `deploy` and `deployx` now always require `--dst-dapp-id`, including `--fee` mode. Pass all zeros for a self-rooted dapp.
+
+### Added
+- `genaddr` additionally prints the `dapp_id::account_id` self-rooted address form (`dapp_account` in JSON output).
+
+### Fixed
+- Address values are passed through internal re-parsing in full `dapp_id::account_id` form, preserving destination dapp information across commands.
+
+## [2.24.19] - 2026-04-17
+
+### Added
+- Support for extended address parsing via `SdkAddress::from_str`, including `dapp_id` extraction from user-provided addresses.
+
+### Changed
+- `call`, `callx`, and proposal commands now derive destination `dapp_id` from extended addresses.
+- `deploy`, `deployx`, and `send` commands now accept explicit `--dst-dapp-id` where the destination `dapp_id` can not be derived from an address.
+
+### Fixed
+- Fixed `dump accounts` address validation for the current `SdkAddress` API.
+
 ## [2.24.18] - 2026-04-13
 
 ### Added

--- a/tvm_cli/Cargo.toml
+++ b/tvm_cli/Cargo.toml
@@ -60,6 +60,7 @@ tvm_vm.workspace = true
 assert_cmd = "2"
 predicates = "3"
 string-error = "0.1"
+testdir = "0.9.3"
 
 [[bin]]
 name = "tvm-cli"

--- a/tvm_cli/src/account.rs
+++ b/tvm_cli/src/account.rs
@@ -9,6 +9,7 @@ use std::collections::BTreeMap;
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific TON DEV software governing permissions and
 // limitations under the License.
+use std::str::FromStr;
 use std::sync::Arc;
 
 use serde_json::Value;
@@ -111,8 +112,8 @@ pub async fn get_account(
     let client = crate::helpers::create_client(config)?;
     for address in addresses.iter() {
         // Temporary: full version-conditional logic lives in Task 8.
-        let sdk_address: crate::helpers::SdkAddress = address.parse().map_err(|e: String| e)?;
-        let account_id = crate::helpers::strip_workchain_lenient(&sdk_address.account_id);
+        let sdk_address = crate::helpers::SdkAddress::from_str(address)?;
+        let account_id = crate::helpers::strip_workchain(&sdk_address.account_id)?;
         let dapp_id = sdk_address.dapp_id.unwrap_or_default();
         let params = account::ParamsOfGetAccount { account_id, dapp_id };
 

--- a/tvm_cli/src/account.rs
+++ b/tvm_cli/src/account.rs
@@ -525,24 +525,21 @@ mod cli_tests {
     use std::str::FromStr;
 
     use crate::helpers::SdkAddress;
-    use crate::helpers::strip_workchain;
 
     const VALID_ACC: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
     const VALID_DAPP: &str = "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210";
 
     #[test]
-    fn cli_parses_dapp_id_double_colon_form() {
+    fn cli_rejects_dapp_id_double_colon_workchain_form() {
         let s = format!("{VALID_DAPP}::0:{VALID_ACC}");
-        let a = SdkAddress::from_str(&s).unwrap();
-        assert_eq!(a.dapp_id.as_deref(), Some(VALID_DAPP));
-        let acc = strip_workchain(&a.account_id).unwrap();
-        assert_eq!(acc, VALID_ACC);
+        let err = SdkAddress::from_str(&s).unwrap_err();
+        assert_eq!(err, "account_id must not include a workchain when dapp_id is specified");
     }
 
     #[test]
     fn cli_strips_workchain_from_bare_address() {
         let s = format!("0:{VALID_ACC}");
-        let acc = strip_workchain(&s).unwrap();
+        let acc = crate::helpers::strip_workchain(&s).unwrap();
         assert_eq!(acc, VALID_ACC);
     }
 }

--- a/tvm_cli/src/account.rs
+++ b/tvm_cli/src/account.rs
@@ -110,7 +110,11 @@ pub async fn get_account(
     let mut accounts = vec![];
     let client = crate::helpers::create_client(config)?;
     for address in addresses.iter() {
-        let params = account::ParamsOfGetAccount { address: address.to_string() };
+        // Temporary: full version-conditional logic lives in Task 8.
+        let sdk_address: crate::helpers::SdkAddress = address.parse().map_err(|e: String| e)?;
+        let account_id = crate::helpers::strip_workchain_lenient(&sdk_address.account_id);
+        let dapp_id = sdk_address.dapp_id.unwrap_or_default();
+        let params = account::ParamsOfGetAccount { account_id, dapp_id };
 
         let result_of_get_account = account::get_account(client.clone(), params)
             .await
@@ -223,7 +227,7 @@ pub async fn get_account(
                     );
                 }
 
-                let dapp_id = dapp_id.as_deref().unwrap_or("None");
+                let dapp_id = if dapp_id.is_empty() { "None" } else { dapp_id.as_str() };
 
                 let ecc_balance = acc
                     .balance()

--- a/tvm_cli/src/account.rs
+++ b/tvm_cli/src/account.rs
@@ -110,11 +110,24 @@ pub async fn get_account(
 
     let mut accounts = vec![];
     let client = crate::helpers::create_client(config)?;
+    let supports_v3 = crate::helpers::server_supports_dapp_id(&client)
+        .await
+        .map_err(|e| format!("failed to probe server version: {e}"))?;
+
     for address in addresses.iter() {
-        // Temporary: full version-conditional logic lives in Task 8.
-        let sdk_address = crate::helpers::SdkAddress::from_str(address)?;
+        let sdk_address = crate::helpers::SdkAddress::from_str(address)
+            .map_err(|e| format!("invalid address `{address}`: {e}"))?;
         let account_id = crate::helpers::strip_workchain(&sdk_address.account_id)?;
-        let dapp_id = sdk_address.dapp_id.unwrap_or_default();
+        let dapp_id = match sdk_address.dapp_id {
+            Some(d) => d,
+            None if !supports_v3 => String::new(),
+            None => {
+                return Err(format!(
+                    "address `{address}` is missing dapp_id; v>=1.0.0 servers \
+                     require the form `dapp_id::account_id` or `dapp_id:account_id`"
+                ));
+            }
+        };
         let params = account::ParamsOfGetAccount { account_id, dapp_id };
 
         let result_of_get_account = account::get_account(client.clone(), params)
@@ -122,13 +135,14 @@ pub async fn get_account(
             .map_err(|e| format!("failed to get account: {e}"))?;
 
         let boc_base64 = result_of_get_account.boc;
-        let dapp_id = result_of_get_account.dapp_id;
+        let dapp_id = result_of_get_account.dapp_id; // String, always populated
+        let account_id = result_of_get_account.account_id; // String, always populated
         let state_timestamp = result_of_get_account.state_timestamp;
 
         let account = Account::construct_from_base64(&boc_base64)
             .map_err(|e| format!("failed to construct account from boc: {e}"))?;
 
-        accounts.push((account, dapp_id, state_timestamp));
+        accounts.push((account, account_id, dapp_id, state_timestamp));
     }
 
     if !config.is_json {
@@ -139,9 +153,10 @@ pub async fn get_account(
 
     if !accounts.is_empty() {
         let mut json_res = json!({});
-        for (acc, dapp_id, state_timestamp) in accounts.iter() {
+        for (acc, account_id, dapp_id, state_timestamp) in accounts.iter() {
             let address = acc.get_id().unwrap().as_hex_string();
-            found_addresses.push(format!("0:{address}"));
+            // Store the bare 64-hex form so we can compare against normalised inputs below.
+            found_addresses.push(account_id.clone());
 
             let acc_type = match acc.status() {
                 AccountStatus::AccStateUninit => "Uninit".to_owned(),
@@ -228,8 +243,6 @@ pub async fn get_account(
                     );
                 }
 
-                let dapp_id = if dapp_id.is_empty() { "None" } else { dapp_id.as_str() };
-
                 let ecc_balance = acc
                     .balance()
                     .map(|balance| {
@@ -245,10 +258,15 @@ pub async fn get_account(
                     })
                     .unwrap_or(serde_json::Value::Null);
                 if config.is_json {
-                    json_res["dapp_id"] = json!(dapp_id);
+                    json_res["account_id"] = json!(account_id);
+                    json_res["dapp_id"] =
+                        if dapp_id.is_empty() { serde_json::Value::Null } else { json!(dapp_id) };
                     json_res["ecc_balance"] = ecc_balance;
                 } else {
-                    println!("dapp_id:         {}", dapp_id);
+                    let dapp_id_display =
+                        if dapp_id.is_empty() { "None" } else { dapp_id.as_str() };
+                    println!("account_id:      {}", account_id);
+                    println!("dapp_id:         {}", dapp_id_display);
                     println!("ecc:             {}", serde_json::to_string(&ecc_balance).unwrap());
                 }
             } else if config.is_json {
@@ -282,7 +300,14 @@ pub async fn get_account(
             }
         }
         for address in addresses.iter() {
-            if !found_addresses.contains(address) {
+            // Normalise the input to bare 64-hex so we can compare against
+            // the normalised values stored in `found_addresses`.
+            let normalized = crate::helpers::SdkAddress::from_str(address)
+                .ok()
+                .and_then(|sa| crate::helpers::strip_workchain(&sa.account_id).ok());
+            let is_found =
+                normalized.as_deref().map_or(false, |n| found_addresses.iter().any(|f| f == n));
+            if !is_found {
                 if config.is_json {
                     json_res = json!({
                        "address": address.clone(),
@@ -493,4 +518,31 @@ pub async fn wait_for_change(
         println!("{{}}");
     }
     res
+}
+
+#[cfg(test)]
+mod cli_tests {
+    use std::str::FromStr;
+
+    use crate::helpers::SdkAddress;
+    use crate::helpers::strip_workchain;
+
+    const VALID_ACC: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const VALID_DAPP: &str = "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210";
+
+    #[test]
+    fn cli_parses_dapp_id_double_colon_form() {
+        let s = format!("{VALID_DAPP}::0:{VALID_ACC}");
+        let a = SdkAddress::from_str(&s).unwrap();
+        assert_eq!(a.dapp_id.as_deref(), Some(VALID_DAPP));
+        let acc = strip_workchain(&a.account_id).unwrap();
+        assert_eq!(acc, VALID_ACC);
+    }
+
+    #[test]
+    fn cli_strips_workchain_from_bare_address() {
+        let s = format!("0:{VALID_ACC}");
+        let acc = strip_workchain(&s).unwrap();
+        assert_eq!(acc, VALID_ACC);
+    }
 }

--- a/tvm_cli/src/account.rs
+++ b/tvm_cli/src/account.rs
@@ -110,24 +110,14 @@ pub async fn get_account(
 
     let mut accounts = vec![];
     let client = crate::helpers::create_client(config)?;
-    let supports_v3 = crate::helpers::server_supports_dapp_id(&client)
-        .await
-        .map_err(|e| format!("failed to probe server version: {e}"))?;
 
     for address in addresses.iter() {
+        // The strict parser guarantees a dapp_id is present; the SDK drops
+        // it on the wire for legacy v2 servers.
         let sdk_address = crate::helpers::SdkAddress::from_str(address)
             .map_err(|e| format!("invalid address `{address}`: {e}"))?;
         let account_id = crate::helpers::strip_workchain(&sdk_address.account_id)?;
-        let dapp_id = match sdk_address.dapp_id {
-            Some(d) => d,
-            None if !supports_v3 => String::new(),
-            None => {
-                return Err(format!(
-                    "address `{address}` is missing dapp_id; v>=1.0.0 servers \
-                     require the form `dapp_id::account_id` or `dapp_id:account_id`"
-                ));
-            }
-        };
+        let dapp_id = sdk_address.dapp_id.unwrap_or_default();
         let params = account::ParamsOfGetAccount { account_id, dapp_id };
 
         let result_of_get_account = account::get_account(client.clone(), params)
@@ -533,7 +523,7 @@ mod cli_tests {
     fn cli_rejects_dapp_id_double_colon_workchain_form() {
         let s = format!("{VALID_DAPP}::0:{VALID_ACC}");
         let err = SdkAddress::from_str(&s).unwrap_err();
-        assert_eq!(err, "account_id must not include a workchain when dapp_id is specified");
+        assert!(err.contains("dapp_id::account_id"), "got: {err}");
     }
 
     #[test]

--- a/tvm_cli/src/call.rs
+++ b/tvm_cli/src/call.rs
@@ -189,7 +189,7 @@ pub async fn send_message_and_wait(
         ParamsOfSendMessage {
             message: msg.clone(),
             abi: abi.clone(),
-            dst_dapp_id: dst_dapp_id.map(ToString::to_string),
+            dapp_id: dst_dapp_id.map(String::from).unwrap_or_default(),
             ..Default::default()
         },
         callback,
@@ -220,7 +220,7 @@ pub async fn send_message(
             message: msg.clone(),
             abi,
             thread_id: thread_id.map(ToString::to_string),
-            dst_dapp_id: dst_dapp_id.map(ToString::to_string),
+            dapp_id: dst_dapp_id.map(String::from).unwrap_or_default(),
             ..Default::default()
         },
         callback,
@@ -248,13 +248,13 @@ pub async fn process_message(
             println!("MessageId: {}", message_id)
         }
     };
-    let dst_dapp_id = dst_dapp_id.map(ToString::to_string);
+    let dapp_id = dst_dapp_id.map(String::from).unwrap_or_default();
     let res = if !config.is_json {
         tvm_client::processing::process_message(
             ton.clone(),
             ParamsOfProcessMessage {
                 message_encode_params: msg.clone(),
-                dst_dapp_id: dst_dapp_id.clone(),
+                dapp_id: dapp_id.clone(),
                 ..Default::default()
             },
             callback,
@@ -266,7 +266,7 @@ pub async fn process_message(
             ParamsOfProcessMessage {
                 message_encode_params: msg.clone(),
                 send_events: true,
-                dst_dapp_id,
+                dapp_id,
             },
             |_| async move {},
         )

--- a/tvm_cli/src/crypto.rs
+++ b/tvm_cli/src/crypto.rs
@@ -204,11 +204,11 @@ mod tests {
         let keypair = generate_keypair_from_mnemonic(mnemonic).unwrap();
         assert_eq!(
             &keypair.public,
-            "757221fe3d4992e44632e75e700aaf205d799cb7373ee929273daf26adf29e56"
+            "04ad311dadcbf7fe4bc20d62e0fbfa195ab5f099009b40045632b997daf4b3b1"
         );
         assert_eq!(
             &keypair.secret,
-            "30e3bc5e67af2b0a72971bcc11256e83d052c6cb861a69a19a8af88922fadf3a"
+            "c4415c03aa9d824e89ff4555cd12497aef1d5123f839803b0268e27ba6052354"
         );
 
         let mnemonic =
@@ -216,11 +216,11 @@ mod tests {
         let keypair = generate_keypair_from_mnemonic(mnemonic).unwrap();
         assert_eq!(
             &keypair.public,
-            "8cf557aab2666867a1174e3147d89ddf28c2041a7322522276cd1cf1df47ae73"
+            "3d79dd47d7c09e38bdee00de578eb480142b8bb1456f1aa82e0ff0a85096a72d"
         );
         assert_eq!(
             &keypair.secret,
-            "f63d3d11e0dc91f730f22d5397f269e01f1a5f984879c8581ac87f099bfd3b3a"
+            "d50dc3fc9bea78b9b582573403905f3c4da3de85a6d1635ff40a77d770fb8864"
         );
     }
 

--- a/tvm_cli/src/debot/term_signing_box.rs
+++ b/tvm_cli/src/debot/term_signing_box.rs
@@ -123,8 +123,8 @@ mod tests {
 
     use super::*;
 
-    const PUBLIC: &str = "9711a04f0b19474272bc7bae5472a8fbbb6ef71ce9c193f5ec3f5af808069a41";
-    const PRIVATE: &str = "cdf2a820517fa783b9b6094d15e650af92d485084ab217fc2c859f02d49623f3";
+    const PUBLIC: &str = "1a45739a421eada273512fbbd6dc9dd813f1eb8f06260c3102286827a1e3c267";
+    const PRIVATE: &str = "0900aa3a7e5c37fe7ee8b85c34f11353537f6f2ff60cce88e17fac65ad8725b9";
     const SEED: &str =
         "episode polar pistol excite essence van cover fox visual gown yellow minute";
     const KEYS_FILE: &str = "./keys.json";

--- a/tvm_cli/src/debot/term_signing_box.rs
+++ b/tvm_cli/src/debot/term_signing_box.rs
@@ -121,13 +121,14 @@ where
 mod tests {
     use std::fs::File;
 
+    use testdir::testdir;
+
     use super::*;
 
     const PUBLIC: &str = "1a45739a421eada273512fbbd6dc9dd813f1eb8f06260c3102286827a1e3c267";
     const PRIVATE: &str = "0900aa3a7e5c37fe7ee8b85c34f11353537f6f2ff60cce88e17fac65ad8725b9";
     const SEED: &str =
         "episode polar pistol excite essence van cover fox visual gown yellow minute";
-    const KEYS_FILE: &str = "./keys.json";
 
     fn create_keypair_file(name: &str) {
         let mut file = File::create(name).unwrap();
@@ -146,10 +147,12 @@ mod tests {
 
     #[test]
     fn load_key_from_file() {
-        let mut in_data = KEYS_FILE.as_bytes();
-        let mut out_data = vec![];
+        let keys_file = testdir!().join("keys.json");
+        let keys_file = keys_file.to_str().unwrap();
+        create_keypair_file(keys_file);
 
-        create_keypair_file(KEYS_FILE);
+        let mut in_data = keys_file.as_bytes();
+        let mut out_data = vec![];
         let keys = input_keys(None, vec![], &mut in_data, &mut out_data, 1).unwrap();
         assert_eq!(keys.public, PUBLIC);
         assert_eq!(keys.secret, PRIVATE);

--- a/tvm_cli/src/decode.rs
+++ b/tvm_cli/src/decode.rs
@@ -8,6 +8,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific TON DEV software governing permissions and
 // limitations under the License.
+
+// 2022-2026 (c) Copyright Contributors to the GOSH DAO. All rights reserved.
+//
+
 use clap::Arg;
 use clap::ArgMatches;
 use clap::Command;
@@ -23,6 +27,7 @@ use tvm_client::abi::decode_account_data;
 use tvm_types::Cell;
 use tvm_types::SliceData;
 use tvm_types::base64_decode;
+use tvm_types::base64_encode;
 use tvm_types::read_single_root_boc;
 use tvm_types::write_boc;
 
@@ -432,10 +437,41 @@ async fn decode_body(
 }
 
 async fn decode_message(msg_boc: Vec<u8>, abi_path: Option<String>) -> Result<String, String> {
-    let tvm_msg = tvm_sdk::Contract::deserialize_message(&msg_boc[..])
-        .map_err(|e| format!("failed to deserialize message boc: {}", e))?;
+    let tvm_msg = match tvm_sdk::Contract::deserialize_message(&msg_boc[..]) {
+        Ok(tvm_msg) => tvm_msg,
+        Err(err) => {
+            if let Some(abi_path) = abi_path {
+                return decode_message_body_boc(msg_boc, abi_path, err.to_string()).await;
+            }
+            return Err(format!("failed to deserialize message boc: {}", err));
+        }
+    };
     let config = Config::default();
     let result = msg_printer::serialize_msg(&tvm_msg, abi_path, &config).await?;
+    serde_json::to_string_pretty(&result)
+        .map_err(|e| format!("Failed to serialize the result: {}", e))
+}
+
+async fn decode_message_body_boc(
+    body_boc: Vec<u8>,
+    abi_path: String,
+    message_decode_error: String,
+) -> Result<String, String> {
+    let config = Config::default();
+    let ton = create_client_local()?;
+    let body_call = msg_printer::serialize_body(body_boc.clone(), &abi_path, ton, &config)
+        .await
+        .map_err(|body_err| {
+            format!(
+                "failed to deserialize message boc: {}; failed to decode message body boc: {}",
+                message_decode_error, body_err
+            )
+        })?;
+    let result = json!({
+        "Body": base64_encode(&body_boc),
+        "BodyCall": body_call,
+    });
+
     serde_json::to_string_pretty(&result)
         .map_err(|e| format!("Failed to serialize the result: {}", e))
 }
@@ -693,5 +729,21 @@ mod tests {
         let body = "te6ccgEBAQEARAAAgwAAALqUCTqWL8OX7JivfJrAAzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMQAAAAAAAAAAAAAAAEeGjADA==";
         let config = Config::default();
         decode_body(body, "tests/samples/wallet.abi.json", true, &config).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_decode_msg_accepts_body_boc_json() {
+        let body = "te6ccgEBAwEAjwACo2+no2wyAkB+MuqZCHtRwDm2zVzLVxUTBnW5j2J7MuI0qdObuQAAAAGAGihtF2PLyyrMusIxaVDCQ/Kd68OR19zsIL5qSqSptrQgAAAAMAAAABwCAQAj0AAAAAAAAAAAAAAAAAAAADJAAEXQQAuAnkoeStxQDpGfxIWTebJgMbu91dZIJGZc7PwxEGJFeA==";
+        let body_boc = base64_decode(body).unwrap();
+        let out = decode_message(
+            body_boc,
+            Some("../docs/.gitbook/assets/PrivateNote.abi.json".to_owned()),
+        )
+        .await
+        .unwrap();
+        let json: serde_json::Value = serde_json::from_str(&out).unwrap();
+
+        assert_eq!(json["Body"], body);
+        assert!(json["BodyCall"]["PMPDeployed"].is_object());
     }
 }

--- a/tvm_cli/src/deploy.rs
+++ b/tvm_cli/src/deploy.rs
@@ -29,6 +29,7 @@ use crate::helpers::create_client_verbose;
 use crate::helpers::load_abi;
 use crate::helpers::now_ms;
 use crate::helpers::server_supports_dapp_id;
+use crate::helpers::strip_workchain;
 use crate::message::EncodedMessage;
 use crate::message::display_generated_message;
 
@@ -87,6 +88,13 @@ pub async fn deploy_contract(
         serde_json::from_value(result.clone())
             .map_err(|e| format!("failed to convert result: {e}"))?;
 
+    // For tvm-cli deploys the new contract roots its own dapp, so the
+    // dapp_id equals the account_id. Surface this in `deployed_at` using
+    // the extended `dapp_id::account_id` form (both halves are the same
+    // bare 64-hex account id, with the workchain prefix stripped).
+    let account_id = strip_workchain(&addr)?;
+    let deployed_at = format!("{account_id}::{account_id}");
+
     if !config.is_json {
         if !config.async_call {
             println!("Transaction succeeded.");
@@ -98,9 +106,9 @@ pub async fn deploy_contract(
                 println!("{k}: {v}");
             }
         });
-        println!("Contract deployed at address: {}", addr);
+        println!("Contract deployed at address: {}", deployed_at);
     } else {
-        map.insert("deployed_at".to_string(), serde_json::Value::String(addr.clone()));
+        map.insert("deployed_at".to_string(), serde_json::Value::String(deployed_at.clone()));
         print_json_result(serde_json::Value::Object(map), config)?;
     }
     if let Some(alias) = alias {

--- a/tvm_cli/src/deploy.rs
+++ b/tvm_cli/src/deploy.rs
@@ -112,7 +112,7 @@ pub async fn deploy_contract(
         print_json_result(serde_json::Value::Object(map), config)?;
     }
     if let Some(alias) = alias {
-        full_config.add_alias(alias, Some(addr), Some(abi.to_string()), keys_file)?;
+        full_config.add_alias(alias, Some(deployed_at), Some(abi.to_string()), keys_file)?;
     }
     Ok(())
 }

--- a/tvm_cli/src/deploy.rs
+++ b/tvm_cli/src/deploy.rs
@@ -28,7 +28,6 @@ use crate::helpers::create_client_local;
 use crate::helpers::create_client_verbose;
 use crate::helpers::load_abi;
 use crate::helpers::now_ms;
-use crate::helpers::server_supports_dapp_id;
 use crate::helpers::strip_workchain;
 use crate::message::EncodedMessage;
 use crate::message::display_generated_message;
@@ -47,19 +46,10 @@ pub async fn deploy_contract(
     let config = &full_config.config;
     let tvm_client = create_client_verbose(config)?;
 
-    // v>=1.0.0 servers reject empty dapp_id on /v2/messages. Probe up
-    // front so the user gets a clear, actionable message instead of an
-    // opaque "dapp_id is required" SDK error after submission setup.
-    if !is_fee && dst_dapp_id.unwrap_or("").is_empty() {
-        let supports_v3 = server_supports_dapp_id(&tvm_client)
-            .await
-            .map_err(|e| format!("failed to probe server version: {e}"))?;
-        if supports_v3 {
-            return Err("--dst-dapp-id is required when deploying to a v>=1.0.0 server \
-                 (pass a 64-character hex dapp_id; use all zeros for a self-rooted dapp)"
-                .to_string());
-        }
-    }
+    // dapp_id is always required on the CLI (including --fee). The SDK
+    // ignores it on the wire for legacy v2 servers, but it must be
+    // supplied explicitly here.
+    require_dst_dapp_id(dst_dapp_id)?;
 
     if !is_fee && !config.is_json {
         println!("Deploying...");
@@ -175,6 +165,17 @@ pub async fn prepare_deploy_message(
     .await
 }
 
+/// Validates that `--dst-dapp-id` was supplied as a 64-character hex
+/// dapp_id. Required for every deploy regardless of node version (use all
+/// zeros for a self-rooted dapp).
+fn require_dst_dapp_id(dst_dapp_id: Option<&str>) -> Result<String, String> {
+    let dapp_id = dst_dapp_id.unwrap_or("");
+    if !crate::helpers::is_hex64(dapp_id) {
+        return Err("--dst-dapp-id is required (pass a 64-character hex dapp_id)".to_string());
+    }
+    Ok(dapp_id.to_string())
+}
+
 pub async fn prepare_deploy_message_params(
     tvc_bytes: &[u8],
     abi: Abi,
@@ -220,4 +221,58 @@ pub async fn prepare_deploy_message_params(
         },
         address,
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::require_dst_dapp_id;
+
+    const VALID: &str = "0000000000000000000000000000000000000000000000000000000000000000";
+
+    #[test]
+    fn require_dst_dapp_id_accepts_64_hex() {
+        assert_eq!(require_dst_dapp_id(Some(VALID)).unwrap(), VALID);
+    }
+
+    #[test]
+    fn require_dst_dapp_id_accepts_uppercase_hex() {
+        let upper = "A".repeat(64);
+        assert_eq!(require_dst_dapp_id(Some(&upper)).unwrap(), upper);
+    }
+
+    #[test]
+    fn require_dst_dapp_id_rejects_missing() {
+        assert!(require_dst_dapp_id(None).is_err());
+    }
+
+    #[test]
+    fn require_dst_dapp_id_rejects_empty() {
+        assert!(require_dst_dapp_id(Some("")).is_err());
+    }
+
+    #[test]
+    fn require_dst_dapp_id_rejects_short() {
+        assert!(require_dst_dapp_id(Some("dead")).is_err());
+    }
+
+    #[test]
+    fn require_dst_dapp_id_rejects_non_hex() {
+        // Exactly 64 chars but non-hex content, so the hex check (not the
+        // length check) is what rejects it.
+        let bad = "z".repeat(64);
+        assert_eq!(bad.len(), 64);
+        assert!(require_dst_dapp_id(Some(&bad)).is_err());
+    }
+
+    #[test]
+    fn require_dst_dapp_id_rejects_63_chars() {
+        let short = "a".repeat(63);
+        assert!(require_dst_dapp_id(Some(&short)).is_err());
+    }
+
+    #[test]
+    fn require_dst_dapp_id_rejects_65_chars() {
+        let long = "a".repeat(65);
+        assert!(require_dst_dapp_id(Some(&long)).is_err());
+    }
 }

--- a/tvm_cli/src/deploy.rs
+++ b/tvm_cli/src/deploy.rs
@@ -28,6 +28,7 @@ use crate::helpers::create_client_local;
 use crate::helpers::create_client_verbose;
 use crate::helpers::load_abi;
 use crate::helpers::now_ms;
+use crate::helpers::server_supports_dapp_id;
 use crate::message::EncodedMessage;
 use crate::message::display_generated_message;
 
@@ -44,6 +45,20 @@ pub async fn deploy_contract(
 ) -> Result<(), String> {
     let config = &full_config.config;
     let tvm_client = create_client_verbose(config)?;
+
+    // v>=1.0.0 servers reject empty dapp_id on /v2/messages. Probe up
+    // front so the user gets a clear, actionable message instead of an
+    // opaque "dapp_id is required" SDK error after submission setup.
+    if !is_fee && dst_dapp_id.unwrap_or("").is_empty() {
+        let supports_v3 = server_supports_dapp_id(&tvm_client)
+            .await
+            .map_err(|e| format!("failed to probe server version: {e}"))?;
+        if supports_v3 {
+            return Err("--dst-dapp-id is required when deploying to a v>=1.0.0 server \
+                 (pass a 64-character hex dapp_id; use all zeros for a self-rooted dapp)"
+                .to_string());
+        }
+    }
 
     if !is_fee && !config.is_json {
         println!("Deploying...");

--- a/tvm_cli/src/genaddr.rs
+++ b/tvm_cli/src/genaddr.rs
@@ -20,6 +20,14 @@ use crate::helpers::load_abi;
 use crate::helpers::load_abi_str;
 use crate::helpers::read_keys;
 
+/// Builds the self-rooted `dapp_id::account_id` form from a freshly
+/// generated address. For a not-yet-deployed contract dapp_id == account_id,
+/// so both halves are the bare account hex (any workchain prefix dropped).
+fn self_rooted_form(addr: &str) -> String {
+    let account_hex = addr.split_once(':').map_or(addr, |(_, rest)| rest);
+    format!("{account_hex}::{account_hex}")
+}
+
 pub async fn generate_address(
     config: &Config,
     tvc: &str,
@@ -95,6 +103,7 @@ pub async fn generate_address(
             println!(r#"Seed phrase: "{}""#, phrase);
         }
         println!("Raw address: {}", addr);
+        println!("dapp::account: {}", self_rooted_form(&addr));
         println!("Succeeded");
     } else {
         let mut res = json!({});
@@ -102,6 +111,7 @@ pub async fn generate_address(
             res["seed_phrase"] = json!(phrase);
         }
         res["raw_address"] = json!(addr);
+        res["dapp_account"] = json!(self_rooted_form(&addr));
         println!("{:#}", res);
     }
     Ok(())
@@ -166,4 +176,26 @@ fn update_contract_state(
         .map_err(|e| format!("failed to update the tvc file: {}", e))?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::self_rooted_form;
+
+    const ACC: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    #[test]
+    fn self_rooted_form_strips_workchain_and_mirrors() {
+        assert_eq!(self_rooted_form(&format!("0:{ACC}")), format!("{ACC}::{ACC}"));
+    }
+
+    #[test]
+    fn self_rooted_form_handles_bare_hex() {
+        assert_eq!(self_rooted_form(ACC), format!("{ACC}::{ACC}"));
+    }
+
+    #[test]
+    fn self_rooted_form_handles_masterchain_prefix() {
+        assert_eq!(self_rooted_form(&format!("-1:{ACC}")), format!("{ACC}::{ACC}"));
+    }
 }

--- a/tvm_cli/src/helpers.rs
+++ b/tvm_cli/src/helpers.rs
@@ -55,6 +55,7 @@ use tvm_client::crypto::MnemonicDictionary;
 use tvm_client::error::ClientError;
 use tvm_client::net::NetworkConfig;
 use tvm_client::net::OrderBy;
+use tvm_client::net::ParamsOfQuery;
 use tvm_client::net::ParamsOfQueryCollection;
 use tvm_client::net::query_collection;
 use tvm_executor::BlockchainConfig;
@@ -316,7 +317,10 @@ impl Display for SdkAddress {
 mod tests {
     use std::str::FromStr;
 
+    use serde_json::json;
+
     use super::SdkAddress;
+    use super::extract_message_boc;
 
     const DAPP_ID: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
     const ACCOUNT_ID: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
@@ -371,6 +375,36 @@ mod tests {
         let err = SdkAddress::from_str(&format!("deadbeef::{RAW_ADDRESS}")).unwrap_err();
 
         assert_eq!(err, "dapp_id must be exactly 64 hex characters");
+    }
+
+    #[test]
+    fn extract_message_boc_reads_blockchain_message_response() {
+        let boc = extract_message_boc(json!({
+            "data": {
+                "blockchain": {
+                    "message": {
+                        "boc": "te6ccgEBAQEA"
+                    }
+                }
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(boc, "te6ccgEBAQEA");
+    }
+
+    #[test]
+    fn extract_message_boc_reports_missing_message() {
+        let err = extract_message_boc(json!({
+            "data": {
+                "blockchain": {
+                    "message": null
+                }
+            }
+        }))
+        .unwrap_err();
+
+        assert_eq!(err, "message with specified id was not found.");
     }
 }
 
@@ -527,24 +561,34 @@ pub async fn query_with_limit(
 }
 
 pub async fn query_message(ton: TonClient, message_id: &str) -> Result<String, String> {
-    let messages = query_with_limit(
-        ton.clone(),
-        "messages",
-        json!({ "id": { "eq": message_id } }),
-        "boc",
-        None,
-        Some(1),
+    let result = tvm_client::net::query(
+        ton,
+        ParamsOfQuery {
+            query: "query message($hash:String!){blockchain{message(hash:$hash){boc}}}".into(),
+            variables: Some(json!({
+                "hash": message_id,
+            })),
+        },
     )
     .await
-    .map_err(|e| format!("failed to query account data: {}", e))?;
-    if messages.is_empty() {
-        Err("message with specified id was not found.".to_string())
-    } else {
-        Ok(messages[0]["boc"]
-            .as_str()
-            .ok_or("Failed to obtain message boc.".to_string())?
-            .to_string())
+    .map_err(|e| format!("failed to query message: {}", e))?;
+
+    extract_message_boc(result.result)
+}
+
+fn extract_message_boc(mut response: Value) -> Result<String, String> {
+    let message = response
+        .pointer_mut("/data/blockchain/message")
+        .ok_or("Failed to obtain message from response.".to_string())?;
+
+    if message.is_null() {
+        return Err("message with specified id was not found.".to_string());
     }
+
+    message["boc"]
+        .as_str()
+        .ok_or("Failed to obtain message boc.".to_string())
+        .map(ToString::to_string)
 }
 
 pub async fn query_account_field(

--- a/tvm_cli/src/helpers.rs
+++ b/tvm_cli/src/helpers.rs
@@ -295,6 +295,11 @@ impl FromStr for SdkAddress {
         } else {
             (None, s.to_owned())
         };
+        if dapp_id.is_some() && account_id.contains(':') {
+            return Err(
+                "account_id must not include a workchain when dapp_id is specified".to_string()
+            );
+        }
         let _ = MsgAddressInt::from_str(&account_id).map_err(|e| {
             format!("Address is specified in the wrong format. Error description: {}", e)
         })?;
@@ -360,11 +365,18 @@ mod tests {
 
     #[test]
     fn sdk_address_from_str_parses_dapp_id_with_double_colon() {
-        let address = SdkAddress::from_str(&format!("{DAPP_ID}::{RAW_ADDRESS}")).unwrap();
+        let address = SdkAddress::from_str(&format!("{DAPP_ID}::{ACCOUNT_ID}")).unwrap();
 
         assert_eq!(address.dapp_id.as_deref(), Some(DAPP_ID));
-        assert_eq!(address.account_id, RAW_ADDRESS);
-        assert_eq!(address.to_string(), format!("{DAPP_ID}:{RAW_ADDRESS}"));
+        assert_eq!(address.account_id, ACCOUNT_ID);
+        assert_eq!(address.to_string(), format!("{DAPP_ID}:{ACCOUNT_ID}"));
+    }
+
+    #[test]
+    fn sdk_address_from_str_rejects_dapp_id_with_workchain_address() {
+        let err = SdkAddress::from_str(&format!("{DAPP_ID}::{RAW_ADDRESS}")).unwrap_err();
+
+        assert_eq!(err, "account_id must not include a workchain when dapp_id is specified");
     }
 
     #[test]

--- a/tvm_cli/src/helpers.rs
+++ b/tvm_cli/src/helpers.rs
@@ -274,7 +274,7 @@ impl SdkAddress {
 // Format:
 // dapp_hex64::account_hex64
 
-fn is_hex64(s: &str) -> bool {
+pub(crate) fn is_hex64(s: &str) -> bool {
     s.len() == 64 && s.bytes().all(|b| b.is_ascii_hexdigit())
 }
 
@@ -327,14 +327,6 @@ pub fn strip_workchain(s: &str) -> Result<String, String> {
         return Err(format!("account_id must be a 64-character hex string, got: {account}"));
     }
     Ok(account.to_string())
-}
-
-/// Resolves the GraphQL endpoint (forcing a connection if needed) and
-/// returns whether the server speaks the v3 dapp_id REST format.
-pub async fn server_supports_dapp_id(
-    client: &Arc<ClientContext>,
-) -> tvm_client::error::ClientResult<bool> {
-    client.supports_dapp_id().await
 }
 
 #[cfg(test)]

--- a/tvm_cli/src/helpers.rs
+++ b/tvm_cli/src/helpers.rs
@@ -313,14 +313,27 @@ impl Display for SdkAddress {
     }
 }
 
-/// Strips a leading workchain prefix (`<int>:`) from an account string.
-/// Returns the input unchanged if no `:` is present. No validation of
-/// workchain value or hex digits — full validation is added in Task 8.
-pub fn strip_workchain_lenient(s: &str) -> String {
-    match s.split_once(':') {
-        Some((_, rest)) => rest.to_string(),
-        None => s.to_string(),
+/// Strips a leading `0:` workchain prefix from an account string and
+/// validates that the remainder is a 64-character hex string.
+/// Returns the account_id (no workchain, no 0x).
+pub fn strip_workchain(s: &str) -> Result<String, String> {
+    let account = match s.split_once(':') {
+        Some(("0", rest)) => rest,
+        Some((wc, _)) => return Err(format!("non-zero workchain not supported: {wc}")),
+        None => s,
+    };
+    if account.len() != 64 || !account.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(format!("account_id must be a 64-character hex string, got: {account}"));
     }
+    Ok(account.to_string())
+}
+
+/// Resolves the GraphQL endpoint (forcing a connection if needed) and
+/// returns whether the server speaks the v3 dapp_id REST format.
+pub async fn server_supports_dapp_id(
+    client: &Arc<ClientContext>,
+) -> tvm_client::error::ClientResult<bool> {
+    client.supports_dapp_id().await
 }
 
 #[cfg(test)]
@@ -415,6 +428,41 @@ mod tests {
         .unwrap_err();
 
         assert_eq!(err, "message with specified id was not found.");
+    }
+
+    use super::strip_workchain;
+
+    #[test]
+    fn strip_workchain_removes_zero_workchain() {
+        assert_eq!(
+            strip_workchain("0:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+                .unwrap(),
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        );
+    }
+
+    #[test]
+    fn strip_workchain_accepts_bare_hex() {
+        let bare = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        assert_eq!(strip_workchain(bare).unwrap(), bare);
+    }
+
+    #[test]
+    fn strip_workchain_rejects_non_zero_workchain() {
+        let s = "1:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        assert!(strip_workchain(s).is_err());
+    }
+
+    #[test]
+    fn strip_workchain_rejects_bad_length() {
+        let s = "0:abc";
+        assert!(strip_workchain(s).is_err());
+    }
+
+    #[test]
+    fn strip_workchain_rejects_non_hex_account() {
+        let s = "0:zzzz456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        assert!(strip_workchain(s).is_err());
     }
 }
 
@@ -608,7 +656,7 @@ pub async fn query_account_field(
 ) -> Result<String, String> {
     let sdk_address =
         SdkAddress::from_str(address).map_err(|e| format!("invalid address `{address}`: {e}"))?;
-    let account_id = strip_workchain_lenient(&sdk_address.account_id);
+    let account_id = strip_workchain(&sdk_address.account_id)?;
     let dapp_id = sdk_address.dapp_id.unwrap_or_default();
     let params = account::ParamsOfGetAccount { account_id, dapp_id };
     let result_of_get_acc = account::get_account(ton, params)
@@ -968,7 +1016,7 @@ pub async fn load_account(
 
             let sdk_address = SdkAddress::from_str(source)
                 .map_err(|e| format!("invalid address `{source}`: {e}"))?;
-            let account_id = strip_workchain_lenient(&sdk_address.account_id);
+            let account_id = strip_workchain(&sdk_address.account_id)?;
             let dapp_id = sdk_address.dapp_id.unwrap_or_default();
             let ResultOfGetAccount { boc, state_timestamp, .. } = account::get_account(
                 ton_client,

--- a/tvm_cli/src/helpers.rs
+++ b/tvm_cli/src/helpers.rs
@@ -71,7 +71,7 @@ use crate::debug::debug_level_from_env;
 use crate::replay::CONFIG_ADDR;
 use crate::replay::construct_blockchain_config;
 use crate::resolve_net_name;
-pub const HD_PATH: &str = "m/44'/396'/0'/0/0";
+pub const HD_PATH: &str = "m/44'/1331'/0'/0/0";
 pub const WORD_COUNT: u8 = 12;
 
 const DEPRECATED_CONFIG_BASE_NAME: &str = "tonos-cli.conf.json";

--- a/tvm_cli/src/helpers.rs
+++ b/tvm_cli/src/helpers.rs
@@ -259,6 +259,9 @@ pub fn read_keys(filename: &str) -> Result<KeyPair, String> {
 
 #[derive(Debug)]
 pub struct SdkAddress {
+    /// Invariant: always `Some` after `from_str` (the strict parser
+    /// requires a dapp_id). The `Option` is retained only to avoid churn
+    /// in call sites that still pattern-match on it.
     pub dapp_id: Option<String>,
     pub account_id: String,
 }
@@ -270,48 +273,41 @@ impl SdkAddress {
 }
 // Format:
 // dapp_hex64::account_hex64
-// dapp_hex64:account_hex64
-// wc_int:account_hex64
-// account_hex64
+
+fn is_hex64(s: &str) -> bool {
+    s.len() == 64 && s.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+fn strict_address_error(input: &str) -> String {
+    format!(
+        "address `{input}` must be in the form `dapp_id::account_id` \
+         (two 64-character hex ids, no 0x, no workchain); legacy `0:…`, \
+         bare-hex, single-colon and 128-hex forms are no longer accepted"
+    )
+}
 
 impl FromStr for SdkAddress {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let (dapp_id, account_id) = if let Some((dapp, account)) = s.split_once("::") {
-            if dapp.len() != 64 || !dapp.chars().all(|c| c.is_ascii_hexdigit()) {
-                return Err("dapp_id must be exactly 64 hex characters".to_string());
-            }
-            (Some(dapp.to_owned()), account.to_owned())
-        } else if let Some((dapp_or_wc, account)) = s.split_once(":") {
-            if dapp_or_wc.len() == 64 && dapp_or_wc.chars().all(|c| c.is_ascii_hexdigit()) {
-                (Some(dapp_or_wc.to_owned()), account.to_owned())
-            } else {
-                (None, s.to_owned())
-            }
-        } else if s.len() == 128 && s.chars().all(|c| c.is_ascii_hexdigit()) {
-            let (dapp, account) = s.split_at(64);
-            (Some(dapp.to_owned()), account.to_owned())
-        } else {
-            (None, s.to_owned())
-        };
-        if dapp_id.is_some() && account_id.contains(':') {
-            return Err(
-                "account_id must not include a workchain when dapp_id is specified".to_string()
-            );
+        let (dapp, account) = s.split_once("::").ok_or_else(|| strict_address_error(s))?;
+        if !is_hex64(dapp) || !is_hex64(account) {
+            return Err(strict_address_error(s));
         }
-        let _ = MsgAddressInt::from_str(&account_id).map_err(|e| {
+        // Defensive: the account half must be a valid internal address.
+        // A bare 64-hex id resolves to workchain 0.
+        let _ = MsgAddressInt::from_str(account).map_err(|e| {
             format!("Address is specified in the wrong format. Error description: {}", e)
         })?;
-        Ok(Self { dapp_id, account_id })
+        Ok(Self { dapp_id: Some(dapp.to_owned()), account_id: account.to_owned() })
     }
 }
 
 impl Display for SdkAddress {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         if let Some(dapp_id) = &self.dapp_id {
-            f.write_str(&dapp_id)?;
-            f.write_str(":")?;
+            f.write_str(dapp_id)?;
+            f.write_str("::")?;
         }
         f.write_str(&self.account_id)?;
         Ok(())
@@ -350,66 +346,78 @@ mod tests {
     use super::SdkAddress;
     use super::extract_message_boc;
 
-    const DAPP_ID: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-    const ACCOUNT_ID: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const DAPP_ID: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const ACCOUNT_ID: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
     const RAW_ADDRESS: &str = "0:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
     #[test]
-    fn sdk_address_from_str_parses_raw_address() {
-        let address = SdkAddress::from_str(RAW_ADDRESS).unwrap();
-
-        assert_eq!(address.dapp_id, None);
-        assert_eq!(address.account_id, RAW_ADDRESS);
-        assert_eq!(address.to_string(), RAW_ADDRESS);
-    }
-
-    #[test]
-    fn sdk_address_from_str_parses_dapp_id_with_double_colon() {
+    fn sdk_address_from_str_accepts_dapp_double_colon_account() {
         let address = SdkAddress::from_str(&format!("{DAPP_ID}::{ACCOUNT_ID}")).unwrap();
 
         assert_eq!(address.dapp_id.as_deref(), Some(DAPP_ID));
         assert_eq!(address.account_id, ACCOUNT_ID);
-        assert_eq!(address.to_string(), format!("{DAPP_ID}:{ACCOUNT_ID}"));
+        // Display round-trips back through the strict parser (double colon).
+        assert_eq!(address.to_string(), format!("{DAPP_ID}::{ACCOUNT_ID}"));
+        assert!(SdkAddress::from_str(&address.to_string()).is_ok());
     }
 
     #[test]
-    fn sdk_address_from_str_rejects_dapp_id_with_workchain_address() {
+    fn sdk_address_from_str_accepts_mixed_case_hex() {
+        let dapp = DAPP_ID.to_uppercase();
+        let address = SdkAddress::from_str(&format!("{dapp}::{ACCOUNT_ID}")).unwrap();
+
+        assert_eq!(address.dapp_id.as_deref(), Some(dapp.as_str()));
+        assert_eq!(address.account_id, ACCOUNT_ID);
+    }
+
+    #[test]
+    fn sdk_address_from_str_rejects_workchain_form() {
+        let err = SdkAddress::from_str(RAW_ADDRESS).unwrap_err();
+        assert!(err.contains("dapp_id::account_id"), "got: {err}");
+    }
+
+    #[test]
+    fn sdk_address_from_str_rejects_masterchain_form() {
+        let masterchain = format!("-1:{ACCOUNT_ID}");
+        let err = SdkAddress::from_str(&masterchain).unwrap_err();
+        assert!(err.contains("dapp_id::account_id"), "got: {err}");
+    }
+
+    #[test]
+    fn sdk_address_from_str_rejects_bare_hex() {
+        let err = SdkAddress::from_str(ACCOUNT_ID).unwrap_err();
+        assert!(err.contains("dapp_id::account_id"), "got: {err}");
+    }
+
+    #[test]
+    fn sdk_address_from_str_rejects_single_colon() {
+        let err = SdkAddress::from_str(&format!("{DAPP_ID}:{ACCOUNT_ID}")).unwrap_err();
+        assert!(err.contains("dapp_id::account_id"), "got: {err}");
+    }
+
+    #[test]
+    fn sdk_address_from_str_rejects_concatenated_128_hex() {
+        let err = SdkAddress::from_str(&format!("{DAPP_ID}{ACCOUNT_ID}")).unwrap_err();
+        assert!(err.contains("dapp_id::account_id"), "got: {err}");
+    }
+
+    #[test]
+    fn sdk_address_from_str_rejects_workchain_in_account_half() {
+        // dapp::0:acc — the account half carries a workchain, which is invalid.
         let err = SdkAddress::from_str(&format!("{DAPP_ID}::{RAW_ADDRESS}")).unwrap_err();
-
-        assert_eq!(err, "account_id must not include a workchain when dapp_id is specified");
+        assert!(err.contains("dapp_id::account_id"), "got: {err}");
     }
 
     #[test]
-    fn sdk_address_from_str_parses_dapp_id_with_single_colon() {
-        let address = SdkAddress::from_str(&format!("{DAPP_ID}:{ACCOUNT_ID}")).unwrap();
-
-        assert_eq!(address.dapp_id.as_deref(), Some(DAPP_ID));
-        assert_eq!(address.account_id, ACCOUNT_ID);
-        assert_eq!(address.to_string(), format!("{DAPP_ID}:{ACCOUNT_ID}"));
+    fn sdk_address_from_str_rejects_short_dapp_id() {
+        let err = SdkAddress::from_str(&format!("deadbeef::{ACCOUNT_ID}")).unwrap_err();
+        assert!(err.contains("dapp_id::account_id"), "got: {err}");
     }
 
     #[test]
-    fn sdk_address_from_str_parses_concatenated_dapp_id_and_account_id() {
-        let address = SdkAddress::from_str(&format!("{DAPP_ID}{ACCOUNT_ID}")).unwrap();
-
-        assert_eq!(address.dapp_id.as_deref(), Some(DAPP_ID));
-        assert_eq!(address.account_id, ACCOUNT_ID);
-        assert_eq!(address.to_string(), format!("{DAPP_ID}:{ACCOUNT_ID}"));
-    }
-
-    #[test]
-    fn sdk_address_from_str_keeps_workchain_address_without_dapp_id() {
-        let address = SdkAddress::from_str(RAW_ADDRESS).unwrap();
-
-        assert_eq!(address.dapp_id, None);
-        assert_eq!(address.account_id, RAW_ADDRESS);
-    }
-
-    #[test]
-    fn sdk_address_from_str_rejects_invalid_dapp_id_length_for_double_colon() {
-        let err = SdkAddress::from_str(&format!("deadbeef::{RAW_ADDRESS}")).unwrap_err();
-
-        assert_eq!(err, "dapp_id must be exactly 64 hex characters");
+    fn sdk_address_from_str_rejects_empty_double_colon() {
+        let err = SdkAddress::from_str("::").unwrap_err();
+        assert!(err.contains("dapp_id::account_id"), "got: {err}");
     }
 
     #[test]

--- a/tvm_cli/src/helpers.rs
+++ b/tvm_cli/src/helpers.rs
@@ -313,6 +313,16 @@ impl Display for SdkAddress {
     }
 }
 
+/// Strips a leading workchain prefix (`<int>:`) from an account string.
+/// Returns the input unchanged if no `:` is present. No validation of
+/// workchain value or hex digits — full validation is added in Task 8.
+pub fn strip_workchain_lenient(s: &str) -> String {
+    match s.split_once(':') {
+        Some((_, rest)) => rest.to_string(),
+        None => s.to_string(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
@@ -596,7 +606,11 @@ pub async fn query_account_field(
     address: &str,
     field: &str,
 ) -> Result<String, String> {
-    let params = account::ParamsOfGetAccount { address: address.to_owned() };
+    let sdk_address =
+        SdkAddress::from_str(address).map_err(|e| format!("invalid address `{address}`: {e}"))?;
+    let account_id = strip_workchain_lenient(&sdk_address.account_id);
+    let dapp_id = sdk_address.dapp_id.unwrap_or_default();
+    let params = account::ParamsOfGetAccount { account_id, dapp_id };
     let result_of_get_acc = account::get_account(ton, params)
         .await
         .map_err(|e| format!("failed to get account: {e}"))?;
@@ -952,9 +966,13 @@ pub async fn load_account(
                 None => create_client(config)?,
             };
 
+            let sdk_address = SdkAddress::from_str(source)
+                .map_err(|e| format!("invalid address `{source}`: {e}"))?;
+            let account_id = strip_workchain_lenient(&sdk_address.account_id);
+            let dapp_id = sdk_address.dapp_id.unwrap_or_default();
             let ResultOfGetAccount { boc, state_timestamp, .. } = account::get_account(
                 ton_client,
-                account::ParamsOfGetAccount { address: source.to_string() },
+                account::ParamsOfGetAccount { account_id, dapp_id },
             )
             .await
             .map_err(|e| format!("Failed to get account: {e}"))?;

--- a/tvm_cli/src/main.rs
+++ b/tvm_cli/src/main.rs
@@ -1308,8 +1308,6 @@ async fn call_command(matches: &ArgMatches, config: &Config, call: CallType) -> 
         .map(|s| s.to_string())
         .or(config.keys_path.clone());
 
-    let thread_id = matches.value_of("THREAD");
-
     let params = Some(load_params(params.unwrap())?);
     if !config.is_json {
         print_args!(address, method, params, abi, keys, lifetime, output);
@@ -1318,10 +1316,17 @@ async fn call_command(matches: &ArgMatches, config: &Config, call: CallType) -> 
 
     match call {
         CallType::Call | CallType::Fee => {
+            // The `message` subcommand does not define a THREAD argument, so
+            // only read it on the call/fee path (clap panics on an unknown id).
+            let thread_id = matches.value_of("THREAD");
             let is_fee = matches!(call, CallType::Fee);
             call_contract(
                 config,
-                &sdk_addr.account_id,
+                // Pass the full round-trippable `dapp_id::account_id` form:
+                // call_contract re-parses the address via SdkAddress::from_str
+                // (prepare_message_params / emulate_locally), which rejects the
+                // bare account_id.
+                &sdk_addr.to_string(),
                 &abi.unwrap(),
                 method.unwrap(),
                 &params.unwrap(),
@@ -1349,7 +1354,9 @@ async fn call_command(matches: &ArgMatches, config: &Config, call: CallType) -> 
                 .transpose()?;
             generate_message(
                 config,
-                &sdk_addr.account_id,
+                // generate_message re-parses the address via
+                // SdkAddress::from_str; pass the full dapp_id::account_id form.
+                &sdk_addr.to_string(),
                 &abi.unwrap(),
                 method.unwrap(),
                 &params.unwrap(),
@@ -1386,7 +1393,9 @@ async fn callx_command(matches: &ArgMatches, full_config: &FullConfig) -> Result
 
     call_contract(
         config,
-        &sdk_addr.account_id,
+        // call_contract re-parses the address via SdkAddress::from_str; pass
+        // the full dapp_id::account_id form.
+        &sdk_addr.to_string(),
         &abi.unwrap(),
         method.unwrap(),
         &params.unwrap(),
@@ -1641,8 +1650,11 @@ async fn dump_accounts_command(matches: &ArgMatches, config: &Config) -> Result<
     let addresses_list = matches.values_of("ADDRESS").unwrap().collect::<Vec<_>>();
     let mut formatted_list = vec![];
     for address in addresses_list.iter() {
-        let formatted = SdkAddress::validate(address)?;
-        formatted_list.push(formatted);
+        // dump_accounts uses the address directly in a raw GraphQL
+        // `accounts.id` filter and compares it against the server `id`
+        // (`0:<hex>`), so the `dapp_id::account_id` form never matches.
+        let sdk_addr = SdkAddress::from_str(address)?;
+        formatted_list.push(format!("0:{}", sdk_addr.account_id));
     }
     let path = matches.value_of("PATH");
     let addresses = Some(formatted_list.join(", "));
@@ -1654,7 +1666,11 @@ async fn dump_accounts_command(matches: &ArgMatches, config: &Config) -> Result<
 
 async fn account_wait_command(matches: &ArgMatches, config: &Config) -> Result<(), String> {
     let address = matches.value_of("ADDRESS").unwrap();
-    let address = SdkAddress::validate(address)?;
+    // wait_for_change uses the address directly in a raw GraphQL `accounts.id`
+    // filter and compares it against the server `id` (`0:<hex>`), so the
+    // `dapp_id::account_id` form never matches.
+    let sdk_addr = SdkAddress::from_str(address)?;
+    let address = format!("0:{}", sdk_addr.account_id);
     let timeout = matches
         .value_of("TIMEOUT")
         .unwrap_or("30")
@@ -1703,7 +1719,10 @@ async fn proposal_create_command(matches: &ArgMatches, config: &Config) -> Resul
 
     create_proposal(
         config,
-        &sdk_addr.account_id,
+        // create_proposal forwards the address to generate_message /
+        // call_contract, both of which re-parse via SdkAddress::from_str;
+        // pass the full dapp_id::account_id form.
+        &sdk_addr.to_string(),
         sdk_addr.dapp_id.as_deref(),
         keys,
         dest.unwrap(),
@@ -1728,7 +1747,10 @@ async fn proposal_vote_command(matches: &ArgMatches, config: &Config) -> Result<
 
     vote(
         config,
-        &sdk_addr.account_id,
+        // vote forwards the address to generate_message / call_contract, both
+        // of which re-parse via SdkAddress::from_str; pass the full
+        // dapp_id::account_id form.
+        &sdk_addr.to_string(),
         sdk_addr.dapp_id.as_deref(),
         keys,
         id.unwrap(),
@@ -1747,7 +1769,10 @@ async fn proposal_decode_command(matches: &ArgMatches, config: &Config) -> Resul
         print_args!(address, id);
     }
     let sdk_addr = SdkAddress::from_str(address.unwrap())?;
-    decode_proposal(config, &sdk_addr.account_id, sdk_addr.dapp_id.as_deref(), id.unwrap()).await
+    // decode_proposal forwards the address to call_contract_with_result, which
+    // re-parses via SdkAddress::from_str; pass the full dapp_id::account_id
+    // form.
+    decode_proposal(config, &sdk_addr.to_string(), sdk_addr.dapp_id.as_deref(), id.unwrap()).await
 }
 
 async fn getconfig_command(matches: &ArgMatches, config: &Config) -> Result<(), String> {

--- a/tvm_cli/src/message.rs
+++ b/tvm_cli/src/message.rs
@@ -80,9 +80,17 @@ pub fn prepare_message_params(
     let call_set =
         Some(CallSet { function_name: method.into(), input: Some(params), header: header.clone() });
 
+    // Accept the extended dapp_id::account_id form used by tvm-cli and
+    // collapse it to the standard <workchain>:<hex> address expected by
+    // the SDK's message encoder. The dapp_id is consumed only by the
+    // SDK call layer; the on-chain destination address never carries it.
+    let sdk = SdkAddress::from_str(addr).map_err(|e| format!("invalid address `{addr}`: {e}"))?;
+    let dst =
+        if sdk.account_id.contains(':') { sdk.account_id } else { format!("0:{}", sdk.account_id) };
+
     Ok(ParamsOfEncodeMessage {
         abi,
-        address: Some(addr.to_owned()),
+        address: Some(dst),
         call_set,
         signer: if let Some(keys) = keys { Signer::Keys { keys } } else { Signer::None },
         ..Default::default()

--- a/tvm_cli/src/message.rs
+++ b/tvm_cli/src/message.rs
@@ -85,8 +85,8 @@ pub fn prepare_message_params(
     // the SDK's message encoder. The dapp_id is consumed only by the
     // SDK call layer; the on-chain destination address never carries it.
     let sdk = SdkAddress::from_str(addr).map_err(|e| format!("invalid address `{addr}`: {e}"))?;
-    let dst =
-        if sdk.account_id.contains(':') { sdk.account_id } else { format!("0:{}", sdk.account_id) };
+    // The strict parser guarantees account_id is bare 64-hex; prepend workchain 0.
+    let dst = format!("0:{}", sdk.account_id);
 
     Ok(ParamsOfEncodeMessage {
         abi,
@@ -240,4 +240,50 @@ pub fn display_generated_message(
         println!("}}");
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use tvm_client::abi::Abi;
+
+    use super::prepare_message_params;
+
+    const DAPP_ID: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const ACCOUNT_ID: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    // Minimal valid ABI JSON. prepare_message_params only stores the Abi and
+    // does not parse it (the encoder, which we never call here, would), so a
+    // trivial document is sufficient and keeps the test free of file/network IO.
+    const MINIMAL_ABI: &str = r#"{"ABI version":2,"functions":[],"events":[],"data":[]}"#;
+
+    #[test]
+    fn prepare_message_params_collapses_dapp_account_to_workchain_address() {
+        let addr = format!("{DAPP_ID}::{ACCOUNT_ID}");
+        let params = prepare_message_params(
+            &addr,
+            Abi::Json(MINIMAL_ABI.to_string()),
+            "method",
+            "{}",
+            None,
+            None,
+        )
+        .expect("dapp_id::account_id form must be accepted by the strict parser");
+
+        // The dapp_id is dropped; the on-chain destination is `0:<account_id>`.
+        assert_eq!(params.address.as_deref(), Some(format!("0:{ACCOUNT_ID}").as_str()));
+    }
+
+    #[test]
+    fn prepare_message_params_rejects_bare_account_id() {
+        let err = prepare_message_params(
+            ACCOUNT_ID,
+            Abi::Json(MINIMAL_ABI.to_string()),
+            "method",
+            "{}",
+            None,
+            None,
+        )
+        .unwrap_err();
+        assert!(err.contains("dapp_id::account_id"), "got: {err}");
+    }
 }

--- a/tvm_cli/src/multisig.rs
+++ b/tvm_cli/src/multisig.rs
@@ -308,9 +308,14 @@ impl MultisigArgs {
             .ok_or("sign key is not defined".to_string())?;
         let v2 = matches.is_present("V2");
 
-        let sdk_addr = SdkAddress::from_str(&address).map_err(|e| e)?;
-        let addr = sdk_addr.account_id;
-        let dapp_id = sdk_addr.dapp_id;
+        let sdk_addr = SdkAddress::from_str(&address)?;
+        // `execute()` forwards this address to call_contract_with_result, which
+        // re-parses it via SdkAddress::from_str (prepare_message_params /
+        // emulate_locally). Store the full round-trippable dapp_id::account_id
+        // form so the strict parser accepts it; the dapp_id is also kept
+        // separately for the SDK send layer.
+        let dapp_id = sdk_addr.dapp_id.clone();
+        let addr = sdk_addr.to_string();
         let mut abi = serde_json::from_str::<AbiContract>(MSIG_ABI).unwrap_or_default();
         if v2 {
             abi.version = Some("2.3".to_owned());

--- a/tvm_client/src/account/mod.rs
+++ b/tvm_client/src/account/mod.rs
@@ -51,28 +51,47 @@ pub async fn get_account(
     validate_hex_id("account_id", &params.account_id)?;
 
     let server_link = context.get_server_link()?;
-    // Force GraphQL endpoint resolution so server_version is populated
-    // before we choose v2 vs v3 wire format.
-    server_link.state().get_query_endpoint().await?;
-    let is_v3 = server_link.supports_dapp_id().await;
+    let base = server_link.state().get_rest_api_endpoint().await;
+    let account_url = |query: String| {
+        let mut url = base.clone();
+        url.set_path(&format!("{API_VERSION}/account"));
+        url.set_query(Some(&query));
+        url
+    };
 
-    // dapp_id is only required (and sent) in v3 mode.
-    if is_v3 {
-        validate_hex_id("dapp_id", &params.dapp_id)?;
+    // Primary signal: the GraphQL `info.version` probe. It is best-effort and
+    // fail-fast (single attempt, no reconnect retry loop) — if GraphQL is
+    // unavailable we do NOT hang or fail; we fall back to the legacy v2 REST
+    // form and, if the server rejects it, retry the v3 form. This keeps working
+    // both on legacy v2 nodes and on REST-only v3 nodes that expose no GraphQL.
+    // (Transitional: drop the v2->v3 fallback once all nodes serve v3.)
+    let graphql_ok = server_link.state().try_resolve_query_endpoint().await.is_ok();
+    let graphql_says_v3 = graphql_ok && server_link.supports_dapp_id().await;
+
+    if !graphql_says_v3 {
+        // GraphQL reported a v2 (< 1.0.0) server, or GraphQL is unavailable.
+        match server_link.http_get(account_url(format!("address=0:{}", params.account_id))).await {
+            Ok(value) => return parse_get_account_response(value, &params),
+            Err(v2_err) => {
+                // An authoritative v2 verdict is trusted: the error is genuine.
+                if graphql_ok {
+                    return Err(v2_err);
+                }
+                // GraphQL was unavailable — the node may actually be v3, so
+                // fall through and retry with the v3 form
+                // below.
+            }
+        }
     }
 
-    let mut url = server_link.state().get_rest_api_endpoint().await;
-    url.set_path(&format!("{API_VERSION}/account"));
-    if is_v3 {
-        url.set_query(Some(&format!(
+    // v3 form: GraphQL says v3, or GraphQL was unavailable and v2 was rejected.
+    validate_hex_id("dapp_id", &params.dapp_id)?;
+    let value = server_link
+        .http_get(account_url(format!(
             "account_id={}&dapp_id={}",
-            params.account_id, params.dapp_id,
-        )));
-    } else {
-        url.set_query(Some(&format!("address=0:{}", params.account_id)));
-    }
-
-    let value = server_link.http_get(url).await?;
+            params.account_id, params.dapp_id
+        )))
+        .await?;
     parse_get_account_response(value, &params)
 }
 

--- a/tvm_client/src/account/mod.rs
+++ b/tvm_client/src/account/mod.rs
@@ -16,6 +16,9 @@ pub struct ResultOfGetAccount {
     pub state_timestamp: Option<u64>,
 }
 
+mod validate;
+pub use validate::validate_hex_id;
+
 #[cfg(test)]
 mod tests;
 

--- a/tvm_client/src/account/mod.rs
+++ b/tvm_client/src/account/mod.rs
@@ -64,7 +64,10 @@ pub async fn get_account(
     let mut url = server_link.state().get_rest_api_endpoint().await;
     url.set_path(&format!("{API_VERSION}/account"));
     if is_v3 {
-        url.set_query(Some(&format!("address={}&dapp_id={}", params.account_id, params.dapp_id,)));
+        url.set_query(Some(&format!(
+            "account_id={}&dapp_id={}",
+            params.account_id, params.dapp_id,
+        )));
     } else {
         url.set_query(Some(&format!("address=0:{}", params.account_id)));
     }

--- a/tvm_client/src/account/mod.rs
+++ b/tvm_client/src/account/mod.rs
@@ -1,20 +1,11 @@
 use std::sync::Arc;
 
+use serde::Deserialize;
+use serde_json::Value;
+
 use crate::ClientContext;
 use crate::error::ClientError;
 use crate::error::ClientResult;
-
-#[derive(Serialize, Deserialize, ApiType, Default, Clone)]
-pub struct ParamsOfGetAccount {
-    pub address: String,
-}
-
-#[derive(Serialize, Deserialize, ApiType, Default, Clone)]
-pub struct ResultOfGetAccount {
-    pub boc: String,
-    pub dapp_id: Option<String>,
-    pub state_timestamp: Option<u64>,
-}
 
 mod validate;
 pub use validate::validate_hex_id;
@@ -24,23 +15,79 @@ mod tests;
 
 const API_VERSION: &str = "v2";
 
+#[derive(Serialize, Deserialize, ApiType, Default, Clone, Debug)]
+pub struct ParamsOfGetAccount {
+    /// Account ID as a 64-character hex string (no 0x, no workchain).
+    pub account_id: String,
+    /// Dapp ID as a 64-character hex string (no 0x).
+    /// Required when the server supports the v3 API (info.version >= "1.0.0").
+    pub dapp_id: String,
+}
+
+#[derive(Serialize, Deserialize, ApiType, Default, Clone, Debug)]
+pub struct ResultOfGetAccount {
+    pub boc: String,
+    pub dapp_id: String,
+    pub state_timestamp: Option<u64>,
+    pub account_id: String,
+}
+
+#[derive(Deserialize)]
+struct RawAccountResponse {
+    boc: String,
+    #[serde(default)]
+    dapp_id: Option<String>,
+    #[serde(default)]
+    state_timestamp: Option<u64>,
+    #[serde(default)]
+    account_id: Option<String>,
+}
+
 #[api_function]
 pub async fn get_account(
     context: Arc<ClientContext>,
     params: ParamsOfGetAccount,
 ) -> ClientResult<ResultOfGetAccount> {
-    let server_link = context.get_server_link()?;
-    let mut url = server_link.state().get_rest_api_endpoint().await;
+    validate_hex_id("account_id", &params.account_id)?;
 
+    let server_link = context.get_server_link()?;
+    let is_v3 = server_link.supports_dapp_id().await;
+
+    // dapp_id is only required (and sent) in v3 mode.
+    if is_v3 {
+        validate_hex_id("dapp_id", &params.dapp_id)?;
+    }
+
+    let mut url = server_link.state().get_rest_api_endpoint().await;
     url.set_path(&format!("{API_VERSION}/account"));
-    url.set_query(Some(&format!("address={}", params.address)));
+    if is_v3 {
+        url.set_query(Some(&format!("address={}&dapp_id={}", params.account_id, params.dapp_id,)));
+    } else {
+        url.set_query(Some(&format!("address=0:{}", params.account_id)));
+    }
 
     let value = server_link.http_get(url).await?;
+    parse_get_account_response(value, &params)
+}
 
-    serde_json::from_value::<ResultOfGetAccount>(value).map_err(|_| {
+fn parse_get_account_response(
+    value: Value,
+    params: &ParamsOfGetAccount,
+) -> ClientResult<ResultOfGetAccount> {
+    let raw: RawAccountResponse = serde_json::from_value(value).map_err(|_| {
         ClientError::with_code_message(
             crate::net::ErrorCode::InvalidServerResponse as u32,
             "Server response can not be parsed".to_string(),
         )
+    })?;
+
+    Ok(ResultOfGetAccount {
+        boc: raw.boc,
+        state_timestamp: raw.state_timestamp,
+        account_id: raw
+            .account_id
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| params.account_id.clone()),
+        dapp_id: raw.dapp_id.filter(|s| !s.is_empty()).unwrap_or_else(|| params.dapp_id.clone()),
     })
 }

--- a/tvm_client/src/account/mod.rs
+++ b/tvm_client/src/account/mod.rs
@@ -51,6 +51,9 @@ pub async fn get_account(
     validate_hex_id("account_id", &params.account_id)?;
 
     let server_link = context.get_server_link()?;
+    // Force GraphQL endpoint resolution so server_version is populated
+    // before we choose v2 vs v3 wire format.
+    server_link.state().get_query_endpoint().await?;
     let is_v3 = server_link.supports_dapp_id().await;
 
     // dapp_id is only required (and sent) in v3 mode.

--- a/tvm_client/src/account/tests.rs
+++ b/tvm_client/src/account/tests.rs
@@ -77,7 +77,7 @@ async fn mock_v2_server(port: u16) -> JoinHandle<()> {
 async fn mock_v3_server(port: u16) -> JoinHandle<()> {
     #[derive(Deserialize)]
     struct Params {
-        address: String,
+        account_id: String,
         dapp_id: String,
     }
     let app = Router::new()
@@ -87,8 +87,8 @@ async fn mock_v3_server(port: u16) -> JoinHandle<()> {
             "/v2/account",
             get(|headers: HeaderMap, Query(p): Query<Params>| async move {
                 let auth = headers.get("Authorization").map(|v| v.to_str().unwrap_or(""));
-                // New server: expects no workchain in address; requires dapp_id.
-                match (p.address.as_str(), p.dapp_id.as_str(), auth) {
+                // New server: expects account_id (no workchain) and dapp_id.
+                match (p.account_id.as_str(), p.dapp_id.as_str(), auth) {
                     (a, d, Some("Bearer secret")) if a == ACC_HEX && d == DAPP_HEX =>
                         Json(json!({
                             "boc": "te6ccAAS",

--- a/tvm_client/src/account/tests.rs
+++ b/tvm_client/src/account/tests.rs
@@ -24,9 +24,10 @@ use crate::net::NetworkConfig;
 
 const ACC_HEX: &str = "1111111111111111111111111111111111111111111111111111111111111111";
 const DAPP_HEX: &str = "2222222222222222222222222222222222222222222222222222222222222222";
+const OTHER_HEX: &str = "3333333333333333333333333333333333333333333333333333333333333333";
 
-/// A minimal GraphQL /graphql handler that returns the given server version
-/// string, satisfying the `Endpoint::resolve` info-query.
+/// A minimal GraphQL `/graphql` handler returning the given server version,
+/// satisfying the `Endpoint::resolve` info-query so the probe succeeds.
 fn graphql_info_handler(version: &'static str) -> axum::routing::MethodRouter {
     get(move || async move {
         Json(json!({
@@ -42,64 +43,68 @@ fn graphql_info_handler(version: &'static str) -> axum::routing::MethodRouter {
     })
 }
 
-async fn mock_v2_server(port: u16) -> JoinHandle<()> {
+/// Legacy v2 server. `with_graphql` controls whether it exposes a `/graphql`
+/// endpoint reporting version 0.9.0 (so the probe resolves to a v2 verdict).
+async fn mock_v2_server(port: u16, with_graphql: bool) -> JoinHandle<()> {
     #[derive(Deserialize)]
     struct Params {
         address: String,
     }
-    let app = Router::new()
-        // GraphQL info endpoint so Endpoint::resolve succeeds (version < 1.0.0).
-        .route("/graphql", graphql_info_handler("0.9.0"))
-        .route(
-            "/v2/account",
-            get(|headers: HeaderMap, Query(p): Query<Params>| async move {
-                let auth = headers.get("Authorization").map(|v| v.to_str().unwrap_or(""));
-                // Legacy server: expects workchain-prefixed address; response
-                // contains optional dapp_id and no account_id.
-                match (p.address.as_str(), auth) {
-                    (addr, Some("Bearer secret")) if addr == format!("0:{}", ACC_HEX) =>
-                        Json(json!({ "boc": "te6ccAAS", "dapp_id": null, "state_timestamp": null }))
-                            .into_response(),
-                    (_, Some("Bearer secret")) =>
-                        (StatusCode::NOT_FOUND, "not found").into_response(),
-                    _ => (StatusCode::UNAUTHORIZED, "Unauthorized").into_response(),
+    let mut app = Router::new().route(
+        "/v2/account",
+        get(|headers: HeaderMap, Query(p): Query<Params>| async move {
+            let auth = headers.get("Authorization").map(|v| v.to_str().unwrap_or(""));
+            // Legacy server: expects a workchain-prefixed address; response
+            // contains an optional dapp_id and no account_id.
+            match (p.address.as_str(), auth) {
+                (addr, Some("Bearer secret")) if addr == format!("0:{}", ACC_HEX) => {
+                    Json(json!({ "boc": "te6ccAAS", "dapp_id": null, "state_timestamp": null }))
+                        .into_response()
                 }
-            }),
-        );
-    let listener = tokio::net::TcpListener::bind(("0.0.0.0", port)).await.unwrap();
-    let handle = tokio::spawn(async move {
-        axum::serve(listener, app).await.unwrap();
-    });
-    tokio::time::sleep(Duration::from_secs(1)).await;
-    handle
+                (_, Some("Bearer secret")) => (StatusCode::NOT_FOUND, "not found").into_response(),
+                _ => (StatusCode::UNAUTHORIZED, "Unauthorized").into_response(),
+            }
+        }),
+    );
+    if with_graphql {
+        app = app.route("/graphql", graphql_info_handler("0.9.0"));
+    }
+    spawn_server(port, app).await
 }
 
-async fn mock_v3_server(port: u16) -> JoinHandle<()> {
+/// New v3 server. `with_graphql` controls whether it exposes a `/graphql`
+/// endpoint reporting version 1.0.0. Its `/v2/account` handler deserializes
+/// `account_id`+`dapp_id`, so a legacy `?address=...` request is rejected with
+/// 400 — which drives the v2->v3 fallback when GraphQL is unavailable.
+async fn mock_v3_server(port: u16, with_graphql: bool) -> JoinHandle<()> {
     #[derive(Deserialize)]
     struct Params {
         account_id: String,
         dapp_id: String,
     }
-    let app = Router::new()
-        // GraphQL info endpoint so Endpoint::resolve succeeds (version >= 1.0.0).
-        .route("/graphql", graphql_info_handler("1.0.0"))
-        .route(
-            "/v2/account",
-            get(|headers: HeaderMap, Query(p): Query<Params>| async move {
-                let auth = headers.get("Authorization").map(|v| v.to_str().unwrap_or(""));
-                // New server: expects account_id (no workchain) and dapp_id.
-                match (p.account_id.as_str(), p.dapp_id.as_str(), auth) {
-                    (a, d, Some("Bearer secret")) if a == ACC_HEX && d == DAPP_HEX =>
-                        Json(json!({
-                            "boc": "te6ccAAS",
-                            "dapp_id": DAPP_HEX,
-                            "state_timestamp": 1700000000u64,
-                            "account_id": ACC_HEX,
-                        })).into_response(),
-                    _ => (StatusCode::NOT_FOUND, "not found").into_response(),
-                }
-            }),
-        );
+    let mut app = Router::new().route(
+        "/v2/account",
+        get(|headers: HeaderMap, Query(p): Query<Params>| async move {
+            let auth = headers.get("Authorization").map(|v| v.to_str().unwrap_or(""));
+            match (p.account_id.as_str(), p.dapp_id.as_str(), auth) {
+                (a, d, Some("Bearer secret")) if a == ACC_HEX && d == DAPP_HEX => Json(json!({
+                    "boc": "te6ccAAS",
+                    "dapp_id": DAPP_HEX,
+                    "state_timestamp": 1700000000u64,
+                    "account_id": ACC_HEX,
+                }))
+                .into_response(),
+                _ => (StatusCode::NOT_FOUND, "not found").into_response(),
+            }
+        }),
+    );
+    if with_graphql {
+        app = app.route("/graphql", graphql_info_handler("1.0.0"));
+    }
+    spawn_server(port, app).await
+}
+
+async fn spawn_server(port: u16, app: Router) -> JoinHandle<()> {
     let listener = tokio::net::TcpListener::bind(("0.0.0.0", port)).await.unwrap();
     let handle = tokio::spawn(async move {
         axum::serve(listener, app).await.unwrap();
@@ -120,22 +125,11 @@ fn make_client(port: u16) -> Arc<ClientContext> {
     Arc::new(ClientContext::new(config).unwrap())
 }
 
-/// Triggers endpoint resolution so the server version gets populated from the
-/// /graphql info response before any REST calls are made.
-async fn resolve_endpoint_version(client: &Arc<ClientContext>) {
-    let sl = client.get_server_link().unwrap();
-    // Ignore the result — we just want the side effect of populating the
-    // query_endpoint slot with its server_version.
-    let _ = sl.state().get_query_endpoint().await;
-}
-
 #[tokio::test]
-async fn get_account_v2_returns_account_id_and_dapp_id_from_params() -> ClientResult<()> {
-    let handle = mock_v2_server(18610).await;
+async fn get_account_uses_v2_when_graphql_reports_v2() -> ClientResult<()> {
+    // GraphQL reports 0.9.0 (< 1.0.0) -> authoritative v2; the v2 form is used.
+    let handle = mock_v2_server(18610, true).await;
     let client = make_client(18610);
-    // Resolve endpoint — the mock server reports version 0.9.0 (< 1.0.0),
-    // so supports_dapp_id() will return false and v2 wire format is used.
-    resolve_endpoint_version(&client).await;
 
     let params =
         ParamsOfGetAccount { account_id: ACC_HEX.to_string(), dapp_id: DAPP_HEX.to_string() };
@@ -151,12 +145,11 @@ async fn get_account_v2_returns_account_id_and_dapp_id_from_params() -> ClientRe
 }
 
 #[tokio::test]
-async fn get_account_v3_returns_server_account_id_and_dapp_id() -> ClientResult<()> {
-    let handle = mock_v3_server(18611).await;
+async fn get_account_uses_v3_when_graphql_reports_v3() -> ClientResult<()> {
+    // GraphQL reports 1.0.0 -> authoritative v3; the v3 form is used directly
+    // (the v2 form is never attempted — this mock would 400 it).
+    let handle = mock_v3_server(18611, true).await;
     let client = make_client(18611);
-    // Resolve endpoint — the mock server reports version 1.0.0 (>= 1.0.0),
-    // so supports_dapp_id() will return true and v3 wire format is used.
-    resolve_endpoint_version(&client).await;
 
     let params =
         ParamsOfGetAccount { account_id: ACC_HEX.to_string(), dapp_id: DAPP_HEX.to_string() };
@@ -172,8 +165,82 @@ async fn get_account_v3_returns_server_account_id_and_dapp_id() -> ClientResult<
 }
 
 #[tokio::test]
-async fn get_account_rejects_account_id_with_workchain() {
+async fn get_account_falls_back_to_v2_when_graphql_unavailable() -> ClientResult<()> {
+    // No GraphQL: the probe fails, so we default to v2; the legacy node accepts
+    // the v2 form on the first try.
+    let handle = mock_v2_server(18612, false).await;
     let client = make_client(18612);
+
+    let params =
+        ParamsOfGetAccount { account_id: ACC_HEX.to_string(), dapp_id: DAPP_HEX.to_string() };
+    let res = account::get_account(client.clone(), params).await?;
+
+    assert_eq!(res.boc, "te6ccAAS");
+    assert_eq!(res.account_id, ACC_HEX);
+
+    handle.abort();
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_account_falls_back_to_v3_when_graphql_unavailable_and_v2_rejected() -> ClientResult<()>
+{
+    // No GraphQL + v3-only node: the probe fails, the v2 form is rejected (400),
+    // so get_account retries the v3 form and succeeds.
+    let handle = mock_v3_server(18613, false).await;
+    let client = make_client(18613);
+
+    let params =
+        ParamsOfGetAccount { account_id: ACC_HEX.to_string(), dapp_id: DAPP_HEX.to_string() };
+    let res = account::get_account(client.clone(), params).await?;
+
+    assert_eq!(res.boc, "te6ccAAS");
+    assert_eq!(res.account_id, ACC_HEX);
+    assert_eq!(res.dapp_id, DAPP_HEX);
+    assert_eq!(res.state_timestamp, Some(1700000000));
+
+    handle.abort();
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_account_trusts_graphql_v2_verdict_and_does_not_retry_v3() {
+    // GraphQL says v2; a v2 error (account not found) is genuine and must be
+    // returned as-is, NOT retried as v3.
+    let handle = mock_v2_server(18614, true).await;
+    let client = make_client(18614);
+
+    let params =
+        ParamsOfGetAccount { account_id: OTHER_HEX.to_string(), dapp_id: DAPP_HEX.to_string() };
+    let err = account::get_account(client, params).await.unwrap_err();
+    // The v2 endpoint returns 404 "not found"; a wrong v3 retry would instead
+    // hit a 400 from the v2 mock's Query extractor.
+    assert!(err.message().contains("not found"), "got: {}", err.message());
+
+    handle.abort();
+}
+
+#[tokio::test]
+async fn get_account_v2_works_without_dapp_id() -> ClientResult<()> {
+    // A v2-only caller may leave dapp_id empty: GraphQL says v2, the v2 form
+    // carries no dapp_id, and no fallback is needed.
+    let handle = mock_v2_server(18615, true).await;
+    let client = make_client(18615);
+
+    let params = ParamsOfGetAccount { account_id: ACC_HEX.to_string(), dapp_id: String::new() };
+    let res = account::get_account(client.clone(), params).await?;
+
+    assert_eq!(res.boc, "te6ccAAS");
+    assert_eq!(res.account_id, ACC_HEX);
+    assert_eq!(res.dapp_id, ""); // none from server, empty from params
+
+    handle.abort();
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_account_rejects_account_id_with_workchain() {
+    let client = make_client(18616);
     let params = ParamsOfGetAccount {
         account_id: format!("0:{}", &ACC_HEX[..62]), // contains ':'
         dapp_id: DAPP_HEX.to_string(),
@@ -183,11 +250,11 @@ async fn get_account_rejects_account_id_with_workchain() {
 }
 
 #[tokio::test]
-async fn get_account_rejects_empty_dapp_id() {
-    // Use a v3 server so that dapp_id validation is triggered.
-    let handle = mock_v3_server(18613).await;
-    let client = make_client(18613);
-    resolve_endpoint_version(&client).await; // resolves to 1.0.0 → v3 mode
+async fn get_account_rejects_empty_dapp_id_on_v3() {
+    // GraphQL says v3, so a dapp_id is required up front; an empty one is
+    // reported with a dapp_id validation error.
+    let handle = mock_v3_server(18617, true).await;
+    let client = make_client(18617);
 
     let params = ParamsOfGetAccount { account_id: ACC_HEX.to_string(), dapp_id: String::new() };
     let err = account::get_account(client, params).await.unwrap_err();

--- a/tvm_client/src/account/tests.rs
+++ b/tvm_client/src/account/tests.rs
@@ -22,101 +22,175 @@ use crate::account::ParamsOfGetAccount;
 use crate::error::ClientResult;
 use crate::net::NetworkConfig;
 
-async fn mock_server() -> JoinHandle<()> {
+const ACC_HEX: &str = "1111111111111111111111111111111111111111111111111111111111111111";
+const DAPP_HEX: &str = "2222222222222222222222222222222222222222222222222222222222222222";
+
+/// A minimal GraphQL /graphql handler that returns the given server version
+/// string, satisfying the `Endpoint::resolve` info-query.
+fn graphql_info_handler(version: &'static str) -> axum::routing::MethodRouter {
+    get(move || async move {
+        Json(json!({
+            "data": {
+                "info": {
+                    "version": version,
+                    "time": 1700000000_i64,
+                    "latency": 1_i64,
+                    "rempEnabled": false
+                }
+            }
+        }))
+    })
+}
+
+async fn mock_v2_server(port: u16) -> JoinHandle<()> {
     #[derive(Deserialize)]
     struct Params {
         address: String,
     }
-
-    let app = Router::new().route(
-        "/v2/account",
-        get(|headers: HeaderMap, Query(params): Query<Params>| async move {
-            let auth = headers.get("Authorization").map(|v| v.to_str().unwrap_or(""));
-
-            match (params.address.as_str(), auth) {
-                ("0:11111", Some("Bearer secret")) => {
-                    Json(json!({ "boc": "te6ccAAS" })).into_response()
+    let app = Router::new()
+        // GraphQL info endpoint so Endpoint::resolve succeeds (version < 1.0.0).
+        .route("/graphql", graphql_info_handler("0.9.0"))
+        .route(
+            "/v2/account",
+            get(|headers: HeaderMap, Query(p): Query<Params>| async move {
+                let auth = headers.get("Authorization").map(|v| v.to_str().unwrap_or(""));
+                // Legacy server: expects workchain-prefixed address; response
+                // contains optional dapp_id and no account_id.
+                match (p.address.as_str(), auth) {
+                    (addr, Some("Bearer secret")) if addr == format!("0:{}", ACC_HEX) =>
+                        Json(json!({ "boc": "te6ccAAS", "dapp_id": null, "state_timestamp": null }))
+                            .into_response(),
+                    (_, Some("Bearer secret")) =>
+                        (StatusCode::NOT_FOUND, "not found").into_response(),
+                    _ => (StatusCode::UNAUTHORIZED, "Unauthorized").into_response(),
                 }
-                ("0:55555", Some("Bearer secret")) => {
-                    (StatusCode::INTERNAL_SERVER_ERROR, "Internal Server Error").into_response()
-                }
-                (_, Some("Bearer secret")) => (StatusCode::NOT_FOUND, "not found").into_response(),
-                (_, _) => (StatusCode::UNAUTHORIZED, "Unauthorized").into_response(),
-            }
-        }),
-    );
-
-    let listener = tokio::net::TcpListener::bind("0.0.0.0:18600").await.unwrap();
+            }),
+        );
+    let listener = tokio::net::TcpListener::bind(("0.0.0.0", port)).await.unwrap();
     let handle = tokio::spawn(async move {
         axum::serve(listener, app).await.unwrap();
     });
-    // Allow the Axum server to start before continuing testing.
     tokio::time::sleep(Duration::from_secs(1)).await;
     handle
 }
 
-#[tokio::test]
-async fn test_get_account() -> ClientResult<()> {
-    let handle = mock_server().await;
-    let contract_boc = "te6ccAAS";
+async fn mock_v3_server(port: u16) -> JoinHandle<()> {
+    #[derive(Deserialize)]
+    struct Params {
+        address: String,
+        dapp_id: String,
+    }
+    let app = Router::new()
+        // GraphQL info endpoint so Endpoint::resolve succeeds (version >= 1.0.0).
+        .route("/graphql", graphql_info_handler("1.0.0"))
+        .route(
+            "/v2/account",
+            get(|headers: HeaderMap, Query(p): Query<Params>| async move {
+                let auth = headers.get("Authorization").map(|v| v.to_str().unwrap_or(""));
+                // New server: expects no workchain in address; requires dapp_id.
+                match (p.address.as_str(), p.dapp_id.as_str(), auth) {
+                    (a, d, Some("Bearer secret")) if a == ACC_HEX && d == DAPP_HEX =>
+                        Json(json!({
+                            "boc": "te6ccAAS",
+                            "dapp_id": DAPP_HEX,
+                            "state_timestamp": 1700000000u64,
+                            "account_id": ACC_HEX,
+                        })).into_response(),
+                    _ => (StatusCode::NOT_FOUND, "not found").into_response(),
+                }
+            }),
+        );
+    let listener = tokio::net::TcpListener::bind(("0.0.0.0", port)).await.unwrap();
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    handle
+}
 
-    let mut config = ClientConfig {
+fn make_client(port: u16) -> Arc<ClientContext> {
+    let config = ClientConfig {
         network: NetworkConfig {
-            endpoints: Some(vec!["http://127.0.0.1:18600".to_string()]),
+            endpoints: Some(vec![format!("http://127.0.0.1:{port}")]),
             api_token: Some("secret".to_string()),
             ..Default::default()
         },
         ..Default::default()
     };
-    let client = Arc::new(ClientContext::new(config.clone()).unwrap());
+    Arc::new(ClientContext::new(config).unwrap())
+}
 
-    // Correct request
-    let params = ParamsOfGetAccount { address: "0:11111".to_string() };
-    let boc = account::get_account(client.clone(), params).await?.boc;
-    assert_eq!(boc, contract_boc);
+/// Triggers endpoint resolution so the server version gets populated from the
+/// /graphql info response before any REST calls are made.
+async fn resolve_endpoint_version(client: &Arc<ClientContext>) {
+    let sl = client.get_server_link().unwrap();
+    // Ignore the result — we just want the side effect of populating the
+    // query_endpoint slot with its server_version.
+    let _ = sl.state().get_query_endpoint().await;
+}
 
-    // Not found address
-    let params = ParamsOfGetAccount { address: "0:12344567890".to_string() };
-    match account::get_account(client.clone(), params).await {
-        Ok(_) => panic!("Expected an error but got Ok"),
-        Err(e) => {
-            assert_eq!(e.code(), crate::net::ErrorCode::NotFound as u32);
-        }
-    }
+#[tokio::test]
+async fn get_account_v2_returns_account_id_and_dapp_id_from_params() -> ClientResult<()> {
+    let handle = mock_v2_server(18610).await;
+    let client = make_client(18610);
+    // Resolve endpoint — the mock server reports version 0.9.0 (< 1.0.0),
+    // so supports_dapp_id() will return false and v2 wire format is used.
+    resolve_endpoint_version(&client).await;
 
-    // Internal error
-    let params = ParamsOfGetAccount { address: "0:55555".to_string() };
-    match account::get_account(client.clone(), params).await {
-        Ok(_) => panic!("Expected an error but got Ok"),
-        Err(e) => {
-            assert_eq!(e.code(), crate::net::ErrorCode::InvalidServerResponse as u32);
-        }
-    }
+    let params =
+        ParamsOfGetAccount { account_id: ACC_HEX.to_string(), dapp_id: DAPP_HEX.to_string() };
+    let res = account::get_account(client.clone(), params).await?;
 
-    // Request with wrong authorization
-    config.network.api_token = Some("wrong_token".to_string());
-    let client = Arc::new(ClientContext::new(config.clone()).unwrap());
-    let params = ParamsOfGetAccount { address: "0:12232323".to_string() };
-    let response = account::get_account(client.clone(), params).await;
-    match response {
-        Ok(_) => panic!("Expected an error but got Ok"),
-        Err(e) => {
-            assert_eq!(e.code(), crate::net::ErrorCode::Unauthorized as u32);
-        }
-    };
+    assert_eq!(res.boc, "te6ccAAS");
+    assert_eq!(res.account_id, ACC_HEX); // derived from params (server returned none)
+    assert_eq!(res.dapp_id, DAPP_HEX); // derived from params (server returned null)
+    assert!(res.state_timestamp.is_none());
 
-    // Request without authorization
-    config.network.api_token = None;
-    let client = Arc::new(ClientContext::new(config).unwrap());
-    let params = ParamsOfGetAccount { address: "0:12232323".to_string() };
-    let response = account::get_account(client.clone(), params).await;
-    match response {
-        Ok(_) => panic!("Expected an error but got Ok"),
-        Err(e) => {
-            assert_eq!(e.code(), crate::net::ErrorCode::Unauthorized as u32);
-        }
-    };
     handle.abort();
-
     Ok(())
+}
+
+#[tokio::test]
+async fn get_account_v3_returns_server_account_id_and_dapp_id() -> ClientResult<()> {
+    let handle = mock_v3_server(18611).await;
+    let client = make_client(18611);
+    // Resolve endpoint — the mock server reports version 1.0.0 (>= 1.0.0),
+    // so supports_dapp_id() will return true and v3 wire format is used.
+    resolve_endpoint_version(&client).await;
+
+    let params =
+        ParamsOfGetAccount { account_id: ACC_HEX.to_string(), dapp_id: DAPP_HEX.to_string() };
+    let res = account::get_account(client.clone(), params).await?;
+
+    assert_eq!(res.boc, "te6ccAAS");
+    assert_eq!(res.account_id, ACC_HEX);
+    assert_eq!(res.dapp_id, DAPP_HEX);
+    assert_eq!(res.state_timestamp, Some(1700000000));
+
+    handle.abort();
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_account_rejects_account_id_with_workchain() {
+    let client = make_client(18612);
+    let params = ParamsOfGetAccount {
+        account_id: format!("0:{}", &ACC_HEX[..62]), // contains ':'
+        dapp_id: DAPP_HEX.to_string(),
+    };
+    let err = account::get_account(client, params).await.unwrap_err();
+    assert!(err.message().contains("account_id"));
+}
+
+#[tokio::test]
+async fn get_account_rejects_empty_dapp_id() {
+    // Use a v3 server so that dapp_id validation is triggered.
+    let handle = mock_v3_server(18613).await;
+    let client = make_client(18613);
+    resolve_endpoint_version(&client).await; // resolves to 1.0.0 → v3 mode
+
+    let params = ParamsOfGetAccount { account_id: ACC_HEX.to_string(), dapp_id: String::new() };
+    let err = account::get_account(client, params).await.unwrap_err();
+    assert!(err.message().contains("dapp_id"));
+    handle.abort();
 }

--- a/tvm_client/src/account/validate.rs
+++ b/tvm_client/src/account/validate.rs
@@ -1,0 +1,66 @@
+use crate::error::ClientResult;
+use crate::processing::Error as ProcessingError;
+
+/// Validates that the value is a 64-character lowercase or mixed-case hex
+/// string with no `0x` prefix and no workchain. Used for `account_id` and
+/// `dapp_id` fields in the v3 dapp_id API.
+pub fn validate_hex_id(field: &str, value: &str) -> ClientResult<()> {
+    if value.len() != 64 || !value.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(ProcessingError::invalid_data(format!(
+            "`{}` must be a 64-character hex string (no 0x prefix, no workchain)",
+            field
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_hex_id;
+
+    const VALID: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    #[test]
+    fn accepts_64_lowercase_hex() {
+        assert!(validate_hex_id("account_id", VALID).is_ok());
+    }
+
+    #[test]
+    fn accepts_64_uppercase_hex() {
+        assert!(validate_hex_id("dapp_id", &VALID.to_uppercase()).is_ok());
+    }
+
+    #[test]
+    fn rejects_short() {
+        assert!(validate_hex_id("dapp_id", "abc").is_err());
+    }
+
+    #[test]
+    fn rejects_long() {
+        let too_long = format!("{}f", VALID);
+        assert!(validate_hex_id("dapp_id", &too_long).is_err());
+    }
+
+    #[test]
+    fn rejects_0x_prefix() {
+        let prefixed = format!("0x{}", &VALID[..62]);
+        assert!(validate_hex_id("dapp_id", &prefixed).is_err());
+    }
+
+    #[test]
+    fn rejects_workchain_colon() {
+        let with_wc = format!("0:{}", &VALID[..62]);
+        assert!(validate_hex_id("account_id", &with_wc).is_err());
+    }
+
+    #[test]
+    fn rejects_non_hex_char() {
+        let bad: String = std::iter::once('z').chain(VALID.chars().skip(1)).collect();
+        assert!(validate_hex_id("dapp_id", &bad).is_err());
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(validate_hex_id("dapp_id", "").is_err());
+    }
+}

--- a/tvm_client/src/client/client.rs
+++ b/tvm_client/src/client/client.rs
@@ -109,6 +109,14 @@ impl ClientContext {
         self.net.get_server_link()
     }
 
+    /// Forces a GraphQL endpoint connection (if not already resolved) and
+    /// returns whether the server speaks the v3 dapp_id REST format.
+    pub async fn supports_dapp_id(&self) -> ClientResult<bool> {
+        let sl = self.get_server_link()?;
+        sl.state().get_query_endpoint().await?;
+        Ok(sl.supports_dapp_id().await)
+    }
+
     pub async fn set_timer(&self, ms: u64) -> ClientResult<()> {
         self.env.set_timer(ms).await
     }

--- a/tvm_client/src/crypto/boxes/encryption_box/mod.rs
+++ b/tvm_client/src/crypto/boxes/encryption_box/mod.rs
@@ -36,7 +36,7 @@ impl From<u32> for EncryptionBoxHandle {
 /// Encryption box information.
 #[derive(Serialize, Deserialize, Clone, Debug, ApiType, Default, PartialEq)]
 pub struct EncryptionBoxInfo {
-    /// Derivation path, for instance "m/44'/396'/0'/0/0"
+    /// Derivation path, for instance "m/44'/1331'/0'/0/0"
     pub hdpath: Option<String>,
     /// Cryptographic algorithm, used by this encryption box
     pub algorithm: Option<String>,

--- a/tvm_client/src/crypto/hdkey.rs
+++ b/tvm_client/src/crypto/hdkey.rs
@@ -155,7 +155,7 @@ pub fn hdkey_derive_from_xprv(
 pub struct ParamsOfHDKeyDeriveFromXPrvPath {
     /// Serialized extended private key
     pub xprv: String,
-    /// Derivation path, for instance "m/44'/396'/0'/0/0"
+    /// Derivation path, for instance "m/44'/1331'/0'/0/0"
     pub path: String,
 }
 

--- a/tvm_client/src/crypto/mnemonic.rs
+++ b/tvm_client/src/crypto/mnemonic.rs
@@ -202,7 +202,7 @@ pub fn mnemonic_verify(
 pub struct ParamsOfMnemonicDeriveSignKeys {
     /// Phrase
     pub phrase: String,
-    /// Derivation path, for instance "m/44'/396'/0'/0/0"
+    /// Derivation path, for instance "m/44'/1331'/0'/0/0"
     pub path: Option<String>,
     /// Dictionary identifier
     pub dictionary: Option<MnemonicDictionary>,

--- a/tvm_client/src/crypto/mod.rs
+++ b/tvm_client/src/crypto/mod.rs
@@ -183,7 +183,7 @@ pub fn default_mnemonic_word_count() -> u8 {
 }
 
 pub fn default_hdkey_derivation_path() -> String {
-    "m/44'/396'/0'/0/0".into()
+    "m/44'/1331'/0'/0/0".into()
 }
 
 fn deserialize_mnemonic_dictionary<'de, D: Deserializer<'de>>(
@@ -224,7 +224,7 @@ pub struct CryptoConfig {
     pub mnemonic_word_count: u8,
 
     /// Derivation path that will be used by default in crypto functions.
-    /// If not specified `m/44'/396'/0'/0/0` will be used.
+    /// If not specified `m/44'/1331'/0'/0/0` will be used.
     #[serde(
         default = "default_hdkey_derivation_path",
         deserialize_with = "deserialize_hdkey_derivation_path"

--- a/tvm_client/src/crypto/tests.rs
+++ b/tvm_client/src/crypto/tests.rs
@@ -458,7 +458,7 @@ fn mnemonic() {
 
     let result: KeyPair = client.request("crypto.mnemonic_derive_sign_keys", ParamsOfMnemonicDeriveSignKeys {
         phrase: "unit follow zone decline glare flower crisp vocal adapt magic much mesh cherry teach mechanic rain float vicious solution assume hedgehog rail sort chuckle".into(),
-        path: None,
+        path: Some("m/44'/396'/0'/0/0".into()),
         dictionary: Some(MnemonicDictionary::Ton),
         word_count: Some(24),
     }).unwrap();
@@ -489,7 +489,7 @@ fn mnemonic() {
             phrase:
                 "abandon math mimic master filter design carbon crystal rookie group knife young"
                     .into(),
-            path: None,
+            path: Some("m/44'/396'/0'/0/0".into()),
             dictionary: None,
             word_count: None,
         })
@@ -548,7 +548,7 @@ fn mnemonic() {
             "crypto.mnemonic_derive_sign_keys",
             ParamsOfMnemonicDeriveSignKeys {
                 phrase: result.phrase,
-                path: None,
+                path: Some("m/44'/396'/0'/0/0".into()),
                 dictionary: None,
                 word_count: None,
             },

--- a/tvm_client/src/debot/dengine.rs
+++ b/tvm_client/src/debot/dengine.rs
@@ -776,7 +776,7 @@ impl DEngine {
             ParamsOfProcessMessage {
                 message_encode_params: call_params,
                 send_events: true,
-                dst_dapp_id: None,
+                dapp_id: String::new(),
             },
             callback,
         )

--- a/tvm_client/src/net/server_link.rs
+++ b/tvm_client/src/net/server_link.rs
@@ -1187,6 +1187,22 @@ impl ServerLink {
     pub async fn invalidate_querying_endpoint(&self) {
         self.state.invalidate_querying_endpoint().await
     }
+
+    /// Version of the currently selected GraphQL query endpoint, packed as
+    /// major*1_000_000 + minor*1_000 + patch. Returns 0 when no endpoint
+    /// has been resolved yet (treated as pre-1.0.0).
+    pub async fn server_version(&self) -> u32 {
+        match self.state.query_endpoint().await {
+            Some(ep) => ep.server_version.load(Ordering::Relaxed),
+            None => 0,
+        }
+    }
+
+    /// Returns true when the connected server speaks the v3 dapp_id REST
+    /// format (`info.version >= "1.0.0"`).
+    pub async fn supports_dapp_id(&self) -> bool {
+        self.server_version().await >= 1_000_000
+    }
 }
 
 fn ensure_address(err_data: &mut Value, dst: Value) {
@@ -1235,3 +1251,29 @@ fn test_construct_rest_endpoint() {
 // #[cfg(test)]
 // #[path = "tests/test_server_link.rs"]
 // mod tests;
+
+#[cfg(test)]
+mod server_version_tests {
+    use crate::ClientConfig;
+    use crate::ClientContext;
+    use crate::net::NetworkConfig;
+
+    fn make_client_context() -> ClientContext {
+        let config = ClientConfig {
+            network: NetworkConfig {
+                endpoints: Some(vec!["http://127.0.0.1:0".to_string()]),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        ClientContext::new(config).unwrap()
+    }
+
+    #[tokio::test]
+    async fn server_version_returns_zero_when_no_endpoint_resolved() {
+        let ctx = make_client_context();
+        let sl = ctx.get_server_link().unwrap();
+        assert_eq!(sl.server_version().await, 0);
+        assert!(!sl.supports_dapp_id().await);
+    }
+}

--- a/tvm_client/src/net/server_link.rs
+++ b/tvm_client/src/net/server_link.rs
@@ -364,6 +364,35 @@ impl NetworkState {
         Ok(fastest)
     }
 
+    /// Best-effort, single-attempt query-endpoint resolution for fast version
+    /// detection. Unlike `get_query_endpoint`, it does NOT enter the reconnect
+    /// retry loop (`max_reconnect_timeout`), so it fails fast when no GraphQL
+    /// endpoint is reachable. On success it populates the cache, so a later
+    /// `get_query_endpoint`/`server_version` reuses the resolved endpoint.
+    pub async fn try_resolve_query_endpoint(
+        self: &Arc<NetworkState>,
+    ) -> ClientResult<Arc<Endpoint>> {
+        if let Some(endpoint) = &*self.query_endpoint.read().await {
+            return Ok(endpoint.clone());
+        }
+        let mut locked_query_endpoint = self.query_endpoint.write().await;
+        if let Some(endpoint) = &*locked_query_endpoint {
+            return Ok(endpoint.clone());
+        }
+        let addresses = self.endpoint_addresses.read().await.clone();
+        let mut last_err = crate::client::Error::net_module_not_init();
+        for address in &addresses {
+            match self.resolve_endpoint(address).await {
+                Ok(endpoint) => {
+                    *locked_query_endpoint = Some(endpoint.clone());
+                    return Ok(endpoint);
+                }
+                Err(err) => last_err = err,
+            }
+        }
+        Err(last_err)
+    }
+
     pub async fn get_all_endpoint_addresses(&self) -> ClientResult<Vec<String>> {
         Ok(self.endpoint_addresses.read().await.clone())
     }

--- a/tvm_client/src/net/server_link.rs
+++ b/tvm_client/src/net/server_link.rs
@@ -35,6 +35,7 @@ use url::Url;
 
 use super::ErrorCode;
 use super::tvm_gql::ExtMessageV2;
+use super::tvm_gql::ExtMessageV3;
 use crate::client::ClientEnv;
 use crate::client::FetchMethod;
 use crate::error::AddNetworkUrl;
@@ -987,7 +988,7 @@ impl ServerLink {
         msg_body: &[u8],
         thread_id: ThreadIdentifier,
         dst: MsgAddressInt,
-        dst_dapp_id: Option<String>,
+        dapp_id: String,
     ) -> ClientResult<Value> {
         // This helper function adds "resource" part to the URL
         fn ensure_resource(url: &Url) -> Url {
@@ -998,21 +999,80 @@ impl ServerLink {
                 url.join(ENDPOINT_MESSAGES).unwrap_or(url.clone())
             }
         }
-        let mut attempts = 0;
 
+        // Sample version once for the whole send attempt (including retries).
+        // All retries here go to nodes in the same cluster, so a mid-attempt
+        // version flip is not expected; we deliberately don't re-probe.
+        let is_v3 = self.supports_dapp_id().await;
         let network_state = self.state();
-        let mut message = ExtMessageV2 {
-            id: msg_id.to_string(),
-            body: base64_encode(msg_body),
-            expire_at: None,
-            thread_id: Some(thread_id.to_string()),
-            ext_message_token: network_state.get_bm_token().await,
-            dst_dapp_id,
+
+        if is_v3 && dapp_id.is_empty() {
+            return Err(crate::processing::Error::dapp_id_required());
+        }
+        if !dapp_id.is_empty() {
+            crate::account::validate_hex_id("dapp_id", &dapp_id)?;
+        }
+
+        // Wire-version-aware wrapper so the retry loop can mutate the
+        // mutable fields (`thread_id`, `ext_message_token`) and re-serialize
+        // without caring which wire format the connected server speaks.
+        enum WireMsg {
+            V2(ExtMessageV2),
+            V3(ExtMessageV3),
+        }
+        impl WireMsg {
+            fn set_thread_id(&mut self, t: Option<String>) {
+                match self {
+                    WireMsg::V2(m) => m.set_thread_id(t),
+                    WireMsg::V3(m) => m.set_thread_id(t),
+                }
+            }
+
+            fn set_ext_message_token(&mut self, token: Option<Value>) {
+                match self {
+                    WireMsg::V2(m) => m.ext_message_token = token,
+                    WireMsg::V3(m) => m.ext_message_token = token,
+                }
+            }
+
+            fn serialize_array(&self) -> ClientResult<String> {
+                match self {
+                    WireMsg::V2(m) => {
+                        serde_json::to_string(&[m]).map_err(crate::processing::Error::invalid_data)
+                    }
+                    WireMsg::V3(m) => {
+                        serde_json::to_string(&[m]).map_err(crate::processing::Error::invalid_data)
+                    }
+                }
+            }
+        }
+
+        let account_id_hex = dst.address().as_hex_string();
+        let mut message = if is_v3 {
+            WireMsg::V3(ExtMessageV3 {
+                id: msg_id.to_string(),
+                body: base64_encode(msg_body),
+                expire_at: None,
+                thread_id: Some(thread_id.to_string()),
+                ext_message_token: network_state.get_bm_token().await,
+                dapp_id: dapp_id.clone(),
+                account_id: account_id_hex,
+            })
+        } else {
+            WireMsg::V2(ExtMessageV2 {
+                id: msg_id.to_string(),
+                body: base64_encode(msg_body),
+                expire_at: None,
+                thread_id: Some(thread_id.to_string()),
+                ext_message_token: network_state.get_bm_token().await,
+                dst_dapp_id: (!dapp_id.is_empty()).then(|| dapp_id.clone()),
+            })
         };
 
+        let mut attempts = 0;
         let mut endpoint = network_state.select_send_message_endpoint().await;
 
-        let query = json!([message]).to_string();
+        let mut query = message.serialize_array()?;
         log::debug!(
             "send_message: id={}, dst={}, endpoint={}, body={}",
             msg_id,
@@ -1042,7 +1102,7 @@ impl ServerLink {
 
             if let Some(Value::Object(_)) = err.data().get("ext_message_token") {
                 network_state.update_bm_data(&err.data()["ext_message_token"]).await;
-                message.ext_message_token = network_state.get_bm_token().await;
+                message.set_ext_message_token(network_state.get_bm_token().await);
             }
 
             let Some(ext) = err.data().get("node_error").and_then(|e| e.get("extensions")) else {
@@ -1086,7 +1146,7 @@ impl ServerLink {
                 network_state.update_bk_send_message_endpoint(Some(bk_endpoint)).await;
                 endpoint = network_state.select_send_message_endpoint().await;
             }
-            let query = json!([message]).to_string();
+            query = message.serialize_array()?;
             log::debug!(
                 "send_message retry: id={}, attempt={}, endpoint={}, body={}",
                 msg_id,

--- a/tvm_client/src/net/server_link.rs
+++ b/tvm_client/src/net/server_link.rs
@@ -34,7 +34,7 @@ use tvm_types::base64_encode;
 use url::Url;
 
 use super::ErrorCode;
-use super::tvm_gql::ExtMessage;
+use super::tvm_gql::ExtMessageV2;
 use crate::client::ClientEnv;
 use crate::client::FetchMethod;
 use crate::error::AddNetworkUrl;
@@ -1001,7 +1001,7 @@ impl ServerLink {
         let mut attempts = 0;
 
         let network_state = self.state();
-        let mut message = ExtMessage {
+        let mut message = ExtMessageV2 {
             id: msg_id.to_string(),
             body: base64_encode(msg_body),
             expire_at: None,

--- a/tvm_client/src/net/server_link.rs
+++ b/tvm_client/src/net/server_link.rs
@@ -1000,9 +1000,12 @@ impl ServerLink {
             }
         }
 
-        // Sample version once for the whole send attempt (including retries).
-        // All retries here go to nodes in the same cluster, so a mid-attempt
-        // version flip is not expected; we deliberately don't re-probe.
+        // Force GraphQL endpoint resolution so server_version is populated
+        // before we choose v2 vs v3 wire format. Sample version once for
+        // the whole send attempt (including retries). All retries here go
+        // to nodes in the same cluster, so a mid-attempt version flip is
+        // not expected; we deliberately don't re-probe.
+        self.state.get_query_endpoint().await?;
         let is_v3 = self.supports_dapp_id().await;
         let network_state = self.state();
 
@@ -1047,6 +1050,11 @@ impl ServerLink {
             }
         }
 
+        // NOTE: account_id_hex assumes a 256-bit MsgAddressInt::AddrStd
+        // destination. For MsgAddressInt::AddrVar with non-aligned bit
+        // lengths the v3 wire format may fail server-side validation.
+        // Mainnet currently uses AddrStd; revisit if AddrVar becomes
+        // common on v>=1.0.0 nodes (NODE-3500 follow-up).
         let account_id_hex = dst.address().as_hex_string();
         let mut message = if is_v3 {
             WireMsg::V3(ExtMessageV3 {

--- a/tvm_client/src/net/tests.rs
+++ b/tvm_client/src/net/tests.rs
@@ -568,7 +568,7 @@ async fn subscribe_for_transactions_with_addresses() {
             ParamsOfProcessMessage {
                 message_encode_params: deploy_params,
                 send_events: false,
-                dst_dapp_id: None,
+                dapp_id: String::new(),
             },
             TestClient::default_callback,
         )
@@ -603,7 +603,7 @@ async fn subscribe_for_transactions_with_addresses() {
                     ..Default::default()
                 },
                 send_events: false,
-                dst_dapp_id: None,
+                dapp_id: String::new(),
             },
             TestClient::default_callback,
         )

--- a/tvm_client/src/net/tvm_gql.rs
+++ b/tvm_client/src/net/tvm_gql.rs
@@ -69,7 +69,7 @@ pub struct PostRequest {
 
 #[derive(Debug, Clone, Serialize)]
 #[allow(non_snake_case)]
-pub struct ExtMessage {
+pub struct ExtMessageV2 {
     pub id: String,
     pub body: String,
     pub expire_at: Option<f64>,
@@ -80,7 +80,26 @@ pub struct ExtMessage {
     pub dst_dapp_id: Option<String>,
 }
 
-impl ExtMessage {
+impl ExtMessageV2 {
+    pub fn set_thread_id(&mut self, thread_id: Option<String>) {
+        self.thread_id = thread_id;
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[allow(non_snake_case)]
+pub struct ExtMessageV3 {
+    pub id: String,
+    pub body: String,
+    pub expire_at: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<String>,
+    pub ext_message_token: Option<Value>,
+    pub dapp_id: String,
+    pub account_id: String,
+}
+
+impl ExtMessageV3 {
     pub fn set_thread_id(&mut self, thread_id: Option<String>) {
         self.thread_id = thread_id;
     }
@@ -536,4 +555,61 @@ pub enum GraphQLQueryEvent {
     Error(ClientError),
     Complete,
     Started,
+}
+
+#[cfg(test)]
+mod ext_message_tests {
+    use serde_json::json;
+
+    use super::ExtMessageV2;
+    use super::ExtMessageV3;
+
+    #[test]
+    fn v2_serializes_with_dst_dapp_id() {
+        let m = ExtMessageV2 {
+            id: "abc".into(),
+            body: "Zm9v".into(),
+            expire_at: None,
+            thread_id: Some("ttt".into()),
+            ext_message_token: None,
+            dst_dapp_id: Some("dd".into()),
+        };
+        let v = serde_json::to_value(&m).unwrap();
+        assert_eq!(v["id"], json!("abc"));
+        assert_eq!(v["dst_dapp_id"], json!("dd"));
+        assert!(v.get("dapp_id").is_none());
+        assert!(v.get("account_id").is_none());
+    }
+
+    #[test]
+    fn v2_skips_dst_dapp_id_when_none() {
+        let m = ExtMessageV2 {
+            id: "abc".into(),
+            body: "Zm9v".into(),
+            expire_at: None,
+            thread_id: None,
+            ext_message_token: None,
+            dst_dapp_id: None,
+        };
+        let v = serde_json::to_value(&m).unwrap();
+        assert!(v.get("dst_dapp_id").is_none());
+        assert!(v.get("thread_id").is_none());
+    }
+
+    #[test]
+    fn v3_serializes_with_dapp_id_and_account_id() {
+        let m = ExtMessageV3 {
+            id: "abc".into(),
+            body: "Zm9v".into(),
+            expire_at: None,
+            thread_id: Some("ttt".into()),
+            ext_message_token: None,
+            dapp_id: "dapp_hex".into(),
+            account_id: "acc_hex".into(),
+        };
+        let v = serde_json::to_value(&m).unwrap();
+        assert_eq!(v["dapp_id"], json!("dapp_hex"));
+        assert_eq!(v["account_id"], json!("acc_hex"));
+        assert!(v.get("dst_dapp_id").is_none());
+    }
 }

--- a/tvm_client/src/processing/errors.rs
+++ b/tvm_client/src/processing/errors.rs
@@ -38,6 +38,7 @@ pub enum ErrorCode {
     InvalidRempStatus = 515,
     NextRempStatusTimeout = 516,
     InvalidThread = 517,
+    DappIdRequired = 518,
 }
 
 pub struct Error;
@@ -231,5 +232,12 @@ impl Error {
 
     pub fn invalid_thread<E: std::fmt::Display>(err: E) -> ClientError {
         error(ErrorCode::InvalidThread, format!("Invalid thread id: {}", err))
+    }
+
+    pub fn dapp_id_required() -> ClientError {
+        error(
+            ErrorCode::DappIdRequired,
+            "`dapp_id` is required when connected to a v>=1.0.0 server".into(),
+        )
     }
 }

--- a/tvm_client/src/processing/process_message.rs
+++ b/tvm_client/src/processing/process_message.rs
@@ -24,8 +24,10 @@ pub struct ParamsOfProcessMessage {
     #[serde(default)]
     pub send_events: bool,
 
+    /// Destination dapp_id (64-character hex, no 0x).
+    /// Required for v>=1.0.0 servers; for v<1.0.0 may be empty.
     #[serde(default)]
-    pub dst_dapp_id: Option<String>,
+    pub dapp_id: String,
 }
 
 pub async fn process_message<F: futures::Future<Output = ()> + Send>(
@@ -50,7 +52,7 @@ pub async fn process_message<F: futures::Future<Output = ()> + Send>(
                 abi: Some(abi.clone()),
                 thread_id: None,
                 send_events: params.send_events,
-                dst_dapp_id: params.dst_dapp_id.clone(),
+                dapp_id: params.dapp_id.clone(),
             },
             &callback,
         )

--- a/tvm_client/src/processing/send_message.rs
+++ b/tvm_client/src/processing/send_message.rs
@@ -62,8 +62,11 @@ pub struct ParamsOfSendMessage {
     /// Default is `false`.
     #[serde(default)]
     pub send_events: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub dst_dapp_id: Option<String>,
+    /// Destination dapp_id (64-character hex, no 0x).
+    /// Required for v>=1.0.0 servers; for v<1.0.0 may be empty
+    /// (sent as legacy `dst_dapp_id: null`).
+    #[serde(default)]
+    pub dapp_id: String,
 }
 
 #[derive(Serialize, Deserialize, ApiType, Default, PartialEq, Debug)]
@@ -107,6 +110,17 @@ pub struct ResultOfSendMessage {
 
     /// The timestamp of generating this response.
     pub current_time: Option<String>,
+
+    /// Destination account_id (64-hex, no workchain). Always populated:
+    /// taken from the server response on v>=1.0.0, derived locally
+    /// from the message destination on v<1.0.0.
+    #[serde(default)]
+    pub account_id: String,
+
+    /// Destination dapp_id (64-hex). Always populated: taken from the
+    /// server response on v>=1.0.0, mirrored from the request on v<1.0.0.
+    #[serde(default)]
+    pub dapp_id: String,
 }
 
 #[derive(Clone)]
@@ -117,7 +131,7 @@ struct SendingMessage {
     id: String,
     body: Vec<u8>,
     dst: MsgAddressInt,
-    dst_dapp_id: Option<String>,
+    dapp_id: String,
     thread_id: ThreadIdentifier,
 }
 
@@ -127,7 +141,7 @@ impl SendingMessage {
         serialized: &str,
         abi: Option<&Abi>,
         thread_id: Option<String>,
-        dst_dapp_id: Option<String>,
+        dapp_id: String,
     ) -> ClientResult<Self> {
         // Check message
         let deserialized = deserialize_object_from_boc::<Message>(context, serialized, "message")?;
@@ -153,7 +167,7 @@ impl SendingMessage {
             id,
             body,
             dst,
-            dst_dapp_id,
+            dapp_id,
             thread_id,
         })
     }
@@ -166,7 +180,7 @@ impl SendingMessage {
                 &self.body,
                 self.thread_id,
                 self.dst.clone(),
-                self.dst_dapp_id.clone(),
+                self.dapp_id.clone(),
             )
             .await
     }
@@ -182,7 +196,7 @@ pub async fn send_message<F: futures::Future<Output = ()> + Send>(
         &params.message,
         params.abi.as_ref(),
         params.thread_id,
-        params.dst_dapp_id,
+        params.dapp_id.clone(),
     )?;
 
     let raw_result = message.send(&context).await?;
@@ -191,6 +205,15 @@ pub async fn send_message<F: futures::Future<Output = ()> + Send>(
         Some(result_value) if !result_value.is_null() => {
             let mut res: ResultOfSendMessage =
                 serde_json::from_value(result_value.clone()).map_err(Error::invalid_data)?;
+
+            // Always-populated fields: derive locally if the server (v<1.0.0)
+            // didn't return them.
+            if res.account_id.is_empty() {
+                res.account_id = message.dst.address().as_hex_string();
+            }
+            if res.dapp_id.is_empty() {
+                res.dapp_id = params.dapp_id.clone();
+            }
 
             if let Some(abi) = params.abi {
                 if let Ok(ext_out_msgs) = result_value.get_array("ext_out_msgs") {
@@ -262,17 +285,22 @@ mod test {
     use axum::Json;
     use axum::Router;
     use axum::body::Body;
+    use axum::body::to_bytes;
     use axum::response::IntoResponse;
+    use axum::routing::get;
     use axum::routing::post;
     use if_addrs::get_if_addrs;
     use serde_json::json;
+    use tokio::sync::Mutex;
     use tokio::task::JoinHandle;
 
     use crate::ClientConfig;
     use crate::ClientContext;
     use crate::error::ClientError;
     use crate::net::NetworkConfig;
+    use crate::processing::ParamsOfSendMessage;
     use crate::processing::send_message::SendingMessage;
+    use crate::processing::send_message::send_message as public_send_message;
 
     // This helper function gets the external IP address of the host, for example
     // 192.168.1.20. For our test, we can use this address in addition to the
@@ -342,7 +370,7 @@ mod test {
 
     fn create_message(context: &Arc<ClientContext>) -> Result<SendingMessage, ClientError> {
         let boc = "te6ccgEBBQEA3gABRYgB0sAot7nO81FRdsdro5q5hNKjB6k6k6N0XXZSSbXxTUoMAQHh4AxQHiMp1/uMXYuNfGnJTSsq1DVvVlzApSGJkiF2orMR7b4l5EDxyH+tSUgEiCa+PjBmLMDnpf5H6LU1nLxSAcWYRhwySlz8mR2+azk8IhaQSMlY/kcFs4BX0+ppdawTwAAAZf1xorQaHASN34I/2WACAmWAHADCv78M71zAKAvf+gThFn5J+iUYEGTkeR5uVkByCnogAAAAAAAAAAAAAAAAAAAAEAwEAwAAABGgAAAAAhg9CQQ=";
-        SendingMessage::new(context, boc, None, None, None)
+        SendingMessage::new(context, boc, None, None, String::new())
     }
 
     #[tokio::test]
@@ -418,5 +446,221 @@ mod test {
         handle_0.abort();
         handle_1.abort();
         handle_2.abort();
+    }
+
+    // ------------------------------------------------------------------
+    // v3 wire-format and local-derivation tests for the public
+    // `send_message` API.
+    // ------------------------------------------------------------------
+
+    /// A minimal GraphQL /graphql handler that returns the given server version
+    /// string, satisfying the `Endpoint::resolve` info-query.
+    fn graphql_info_handler(version: &'static str) -> axum::routing::MethodRouter {
+        get(move || async move {
+            Json(json!({
+                "data": {
+                    "info": {
+                        "version": version,
+                        "time": 1700000000_i64,
+                        "latency": 1_i64,
+                        "rempEnabled": false
+                    }
+                }
+            }))
+        })
+    }
+
+    /// Triggers endpoint resolution so the server version gets populated from
+    /// the /graphql info response before any REST calls are made.
+    async fn resolve_endpoint_version(client: &Arc<ClientContext>) {
+        let sl = client.get_server_link().unwrap();
+        let _ = sl.state().get_query_endpoint().await;
+    }
+
+    async fn start_capturing_mock(
+        port: u16,
+        version: &'static str,
+        response: serde_json::Value,
+    ) -> (JoinHandle<()>, Arc<Mutex<Option<serde_json::Value>>>) {
+        let captured: Arc<Mutex<Option<serde_json::Value>>> = Arc::new(Mutex::new(None));
+        let captured_handle = captured.clone();
+        let response = Arc::new(response);
+        let app = Router::new().route("/graphql", graphql_info_handler(version)).route(
+            "/v2/messages",
+            post(move |body: Body| {
+                let captured = captured_handle.clone();
+                let response = response.clone();
+                async move {
+                    let bytes = to_bytes(body, usize::MAX).await.unwrap();
+                    let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+                    *captured.lock().await = Some(v);
+                    Json((*response).clone()).into_response()
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", port)).await.unwrap();
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        (handle, captured)
+    }
+
+    // Same BOC as `create_message` above.
+    const TEST_MSG_BOC: &str = "te6ccgEBBQEA3gABRYgB0sAot7nO81FRdsdro5q5hNKjB6k6k6N0XXZSSbXxTUoMAQHh4AxQHiMp1/uMXYuNfGnJTSsq1DVvVlzApSGJkiF2orMR7b4l5EDxyH+tSUgEiCa+PjBmLMDnpf5H6LU1nLxSAcWYRhwySlz8mR2+azk8IhaQSMlY/kcFs4BX0+ppdawTwAAAZf1xorQaHASN34I/2WACAmWAHADCv78M71zAKAvf+gThFn5J+iUYEGTkeR5uVkByCnogAAAAAAAAAAAAAAAAAAAAEAwEAwAAABGgAAAAAhg9CQQ=";
+
+    #[tokio::test]
+    async fn send_message_v3_sends_dapp_id_and_account_id() {
+        let (handle, captured) = start_capturing_mock(
+            18621,
+            "1.0.0",
+            json!({
+                "result": {
+                    "message_hash": "deadbeef",
+                    "thread_id": null,
+                    "producers": [],
+                    "account_id": "aaaa",
+                    "dapp_id": "bbbb"
+                },
+                "error": null,
+                "ext_message_token": null
+            }),
+        )
+        .await;
+
+        let config = ClientConfig {
+            network: NetworkConfig {
+                endpoints: Some(vec!["http://127.0.0.1:18621".to_string()]),
+                api_token: Some("secret".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let client = Arc::new(ClientContext::new(config).unwrap());
+        resolve_endpoint_version(&client).await;
+
+        let dapp_hex = "2".repeat(64);
+        let res = public_send_message(
+            client,
+            ParamsOfSendMessage {
+                message: TEST_MSG_BOC.to_string(),
+                abi: None,
+                thread_id: None,
+                send_events: false,
+                dapp_id: dapp_hex.clone(),
+            },
+            |_| async {},
+        )
+        .await
+        .unwrap();
+
+        let body = captured.lock().await.clone().expect("body captured");
+        let item = &body[0];
+        assert_eq!(item["dapp_id"], serde_json::Value::String(dapp_hex));
+        assert!(
+            !item["account_id"].as_str().unwrap_or("").is_empty(),
+            "account_id must be non-empty in v3 wire"
+        );
+        assert!(item.get("dst_dapp_id").is_none());
+
+        // Result fields populated from server response:
+        assert_eq!(res.account_id, "aaaa");
+        assert_eq!(res.dapp_id, "bbbb");
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn send_message_v2_sends_dst_dapp_id_and_derives_result_locally() {
+        let (handle, captured) = start_capturing_mock(
+            18622,
+            "0.9.0",
+            json!({
+                "result": {
+                    "message_hash": "deadbeef",
+                    "thread_id": null,
+                    "producers": []
+                },
+                "error": null,
+                "ext_message_token": null
+            }),
+        )
+        .await;
+
+        let config = ClientConfig {
+            network: NetworkConfig {
+                endpoints: Some(vec!["http://127.0.0.1:18622".to_string()]),
+                api_token: Some("secret".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let client = Arc::new(ClientContext::new(config).unwrap());
+        resolve_endpoint_version(&client).await;
+
+        let dapp_hex = "3".repeat(64);
+        let res = public_send_message(
+            client,
+            ParamsOfSendMessage {
+                message: TEST_MSG_BOC.to_string(),
+                abi: None,
+                thread_id: None,
+                send_events: false,
+                dapp_id: dapp_hex.clone(),
+            },
+            |_| async {},
+        )
+        .await
+        .unwrap();
+
+        let body = captured.lock().await.clone().expect("body captured");
+        let item = &body[0];
+        assert_eq!(item["dst_dapp_id"], serde_json::Value::String(dapp_hex.clone()));
+        assert!(item.get("dapp_id").is_none());
+        assert!(item.get("account_id").is_none());
+
+        // Result fields derived locally from request:
+        assert!(!res.account_id.is_empty(), "account_id should be derived from message dst");
+        assert_eq!(res.dapp_id, dapp_hex);
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn send_message_v3_rejects_empty_dapp_id() {
+        let (handle, _captured) = start_capturing_mock(
+            18623,
+            "1.0.0",
+            json!({ "result": null, "error": null, "ext_message_token": null }),
+        )
+        .await;
+
+        let config = ClientConfig {
+            network: NetworkConfig {
+                endpoints: Some(vec!["http://127.0.0.1:18623".to_string()]),
+                api_token: Some("secret".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let client = Arc::new(ClientContext::new(config).unwrap());
+        resolve_endpoint_version(&client).await;
+
+        let err = public_send_message(
+            client,
+            ParamsOfSendMessage {
+                message: TEST_MSG_BOC.to_string(),
+                abi: None,
+                thread_id: None,
+                send_events: false,
+                dapp_id: String::new(),
+            },
+            |_| async {},
+        )
+        .await
+        .unwrap_err();
+        assert!(err.message().contains("dapp_id"));
+
+        handle.abort();
     }
 }

--- a/tvm_client/src/processing/send_message.rs
+++ b/tvm_client/src/processing/send_message.rs
@@ -17,6 +17,19 @@ use std::sync::Arc;
 
 use serde::Deserialize;
 use serde_json::Value;
+
+/// Deserializes both a missing key (via `#[serde(default)]`) and an explicit
+/// JSON `null` as the type's `Default` value.  Without this, a server that
+/// returns `"account_id": null` would cause deserialization failure even
+/// though `#[serde(default)]` only handles the absent-key case.
+fn deserialize_null_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    T: Default + Deserialize<'de>,
+    D: serde::Deserializer<'de>,
+{
+    let opt = Option::<T>::deserialize(deserializer)?;
+    Ok(opt.unwrap_or_default())
+}
 use tvm_block::Message;
 use tvm_block::MsgAddressInt;
 
@@ -114,12 +127,12 @@ pub struct ResultOfSendMessage {
     /// Destination account_id (64-hex, no workchain). Always populated:
     /// taken from the server response on v>=1.0.0, derived locally
     /// from the message destination on v<1.0.0.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_default")]
     pub account_id: String,
 
     /// Destination dapp_id (64-hex). Always populated: taken from the
     /// server response on v>=1.0.0, mirrored from the request on v<1.0.0.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_default")]
     pub dapp_id: String,
 }
 
@@ -325,39 +338,43 @@ mod test {
 
     async fn mock_server(socket_addr: SocketAddr) -> JoinHandle<()> {
         let socket_addr_clone = socket_addr.to_string();
-        let app = Router::new().route(
-            "/v2/messages",
-            post(|_body: Body| async move {
-                if socket_addr_clone == "127.0.0.1:9000" {
-                    let resp_json =  json!({
-                        "result": null,
-                        "error": {
-                            "code": "WRONG_PRODUCER",
-                            "message": "Resend message to the active Block Producer",
-                            "data": {
-                                "producers": vec![format!("{}:18600", get_ext_ip().unwrap().to_string())],
-                                "message_hash": "77ac2790a7a20d90572c3c27c7725d0e0195440664d6bd7925a19fbe23ff3315",
-                                "exit_code": null,
-                                "current_time": "1748084498461",
-                                "thread_id": "00000000000000000000000000000000000000000000000000000000000000000000"
+        let app = Router::new()
+            // Serve a /graphql info endpoint so endpoint resolution succeeds
+            // and the server is identified as pre-1.0.0 (v2 wire format).
+            .route("/graphql", graphql_info_handler("0.54.0"))
+            .route(
+                "/v2/messages",
+                post(|_body: Body| async move {
+                    if socket_addr_clone == "127.0.0.1:9000" {
+                        let resp_json = json!({
+                            "result": null,
+                            "error": {
+                                "code": "WRONG_PRODUCER",
+                                "message": "Resend message to the active Block Producer",
+                                "data": {
+                                    "producers": vec![format!("{}:18600", get_ext_ip().unwrap().to_string())],
+                                    "message_hash": "77ac2790a7a20d90572c3c27c7725d0e0195440664d6bd7925a19fbe23ff3315",
+                                    "exit_code": null,
+                                    "current_time": "1748084498461",
+                                    "thread_id": "00000000000000000000000000000000000000000000000000000000000000000000"
+                                }
+                            },
+                            "block_manager": {
+                                "license_address": "0:8e8dad0462a4d5c528e18251846f24bc5c04cd1871115fb1e9b00c9741f60800",
+                                "token": {
+                                    "unsigned": "1748084798476",
+                                    "signature": "c0c4fc73a9bab0f9d648eb1c2402d21a44559bf2a4b24f735f55a384d3a3914cbe2c9d1ed403ef548dded51c62510581b0dad96891ac6fa16af8687c7586b901",
+                                    "verifying_key": "e2c9d4be54d342d3f0e6394a7738fc39b93d4fe3fdba317aa699f7305566de2b"
+                                }
                             }
-                        },
-                        "block_manager": {
-                            "license_address": "0:8e8dad0462a4d5c528e18251846f24bc5c04cd1871115fb1e9b00c9741f60800",
-                            "token": {
-                                "unsigned": "1748084798476",
-                                "signature": "c0c4fc73a9bab0f9d648eb1c2402d21a44559bf2a4b24f735f55a384d3a3914cbe2c9d1ed403ef548dded51c62510581b0dad96891ac6fa16af8687c7586b901",
-                                "verifying_key": "e2c9d4be54d342d3f0e6394a7738fc39b93d4fe3fdba317aa699f7305566de2b"
-                            }
-                        }
-                    });
+                        });
 
-                    Json(resp_json).into_response()
-                } else {
-                    Json(json!({"my_addr": socket_addr_clone})).into_response()
-                }
-            }),
-        );
+                        Json(resp_json).into_response()
+                    } else {
+                        Json(json!({"my_addr": socket_addr_clone})).into_response()
+                    }
+                }),
+            );
 
         let listener = tokio::net::TcpListener::bind(socket_addr).await.unwrap();
         let handle = tokio::spawn(async move {
@@ -402,10 +419,12 @@ mod test {
         }
 
         // 2. external_ip:18600.
+        // Use explicit http:// so endpoint resolution doesn't try HTTPS on the
+        // plain HTTP mock server.
         {
             let config = ClientConfig {
                 network: NetworkConfig {
-                    endpoints: Some(vec![format!("{external_ip}:18600")]),
+                    endpoints: Some(vec![format!("http://{external_ip}:18600")]),
                     api_token: Some("secret".to_string()),
                     ..Default::default()
                 },
@@ -423,11 +442,13 @@ mod test {
         }
 
         // 3. Localhost ip, specific port.
-        // This server must redirect the client to external_ip:18600
+        // This server must redirect the client to external_ip:18600.
+        // Use explicit http:// for both the initial endpoint and the redirect
+        // target so endpoint resolution doesn't try HTTPS.
         {
             let config = ClientConfig {
                 network: NetworkConfig {
-                    endpoints: Some(vec!["127.0.0.1:9000".to_string()]),
+                    endpoints: Some(vec!["http://127.0.0.1:9000".to_string()]),
                     api_token: Some("secret".to_string()),
                     ..Default::default()
                 },

--- a/tvm_client/src/processing/tests.rs
+++ b/tvm_client/src/processing/tests.rs
@@ -160,7 +160,7 @@ async fn test_wait_message() {
                 message: encoded.message.clone(),
                 thread_id: None,
                 send_events: true,
-                dst_dapp_id: None,
+                dapp_id: String::new(),
             },
             callback.clone(),
         )
@@ -230,7 +230,7 @@ async fn test_process_message() {
             ParamsOfProcessMessage {
                 message_encode_params: encode_params,
                 send_events: true,
-                dst_dapp_id: None,
+                dapp_id: String::new(),
             },
             callback,
         )
@@ -270,7 +270,7 @@ async fn test_process_message() {
                     ..Default::default()
                 },
                 send_events: true,
-                dst_dapp_id: None,
+                dapp_id: String::new(),
             },
             callback,
         )
@@ -361,7 +361,7 @@ async fn test_error_resolving() {
             ParamsOfProcessMessage {
                 message_encode_params: deploy_params.clone(),
                 send_events: false,
-                dst_dapp_id: None,
+                dapp_id: String::new(),
             },
             TestClient::default_callback,
         )
@@ -384,7 +384,7 @@ async fn test_error_resolving() {
             ParamsOfProcessMessage {
                 message_encode_params: deploy_params.clone(),
                 send_events: false,
-                dst_dapp_id: None,
+                dapp_id: String::new(),
             },
             TestClient::default_callback,
         )
@@ -414,7 +414,7 @@ async fn test_error_resolving() {
             ParamsOfProcessMessage {
                 message_encode_params: run_params.clone(),
                 send_events: false,
-                dst_dapp_id: None,
+                dapp_id: String::new(),
             },
             TestClient::default_callback,
         )
@@ -435,7 +435,7 @@ async fn test_error_resolving() {
             ParamsOfProcessMessage {
                 message_encode_params: deploy_params.clone(),
                 send_events: false,
-                dst_dapp_id: None,
+                dapp_id: String::new(),
             },
             TestClient::default_callback,
         )
@@ -449,7 +449,7 @@ async fn test_error_resolving() {
             ParamsOfProcessMessage {
                 message_encode_params: run_params.clone(),
                 send_events: false,
-                dst_dapp_id: None,
+                dapp_id: String::new(),
             },
             TestClient::default_callback,
         )
@@ -523,7 +523,7 @@ async fn test_retries() {
                             ..Default::default()
                         },
                         send_events: false,
-                        dst_dapp_id: None,
+                        dapp_id: String::new(),
                     },
                     TestClient::default_callback,
                 )
@@ -591,7 +591,7 @@ async fn test_fees() {
             ParamsOfProcessMessage {
                 message_encode_params: params,
                 send_events: false,
-                dst_dapp_id: None,
+                dapp_id: String::new(),
             },
             TestClient::default_callback,
         )
@@ -662,7 +662,7 @@ async fn test_deploy_from_tvc_v1() {
             ParamsOfProcessMessage {
                 message_encode_params: encode_params,
                 send_events: false,
-                dst_dapp_id: None,
+                dapp_id: String::new(),
             },
             |_: ProcessingEvent, _: ProcessingResponseType| async {},
         )
@@ -685,7 +685,7 @@ async fn test_deploy_from_tvc_v1() {
                     ..Default::default()
                 },
                 send_events: false,
-                dst_dapp_id: None,
+                dapp_id: String::new(),
             },
             move |_: ProcessingEvent, _: ProcessingResponseType| async {},
         )
@@ -750,7 +750,7 @@ fn test_process_message_sync() {
         .process_message_sync(ParamsOfProcessMessage {
             message_encode_params: encode_params,
             send_events: true,
-            dst_dapp_id: None,
+            dapp_id: String::new(),
         })
         .unwrap();
 
@@ -773,7 +773,7 @@ fn test_process_message_sync() {
                 ..Default::default()
             },
             send_events: true,
-            dst_dapp_id: None,
+            dapp_id: String::new(),
         })
         .unwrap();
     assert_eq!(output.out_messages.len(), 2);

--- a/tvm_client/src/tests/mod.rs
+++ b/tvm_client/src/tests/mod.rs
@@ -682,7 +682,7 @@ impl TestClient {
                     ..Default::default()
                 },
                 send_events: false,
-                dst_dapp_id: None,
+                dapp_id: String::new(),
             },
             Self::default_callback,
         )
@@ -793,7 +793,7 @@ impl TestClient {
                 ParamsOfProcessMessage {
                     message_encode_params: params,
                     send_events: false,
-                    dst_dapp_id: None,
+                    dapp_id: String::new(),
                 },
                 Self::default_callback,
             )


### PR DESCRIPTION
  Adds dapp_id support to the `tvm_client` SDK and `tvm-cli` for the v3 BM/BK REST API (`/v2/account`, `/v2/messages`) while keeping compatibility with pre-1.0.0 servers. The wire format is selected at runtime from the server's GraphQL `info.version`:

  - `version >= "1.0.0"` → new fields `account_id` and `dapp_id` are sent and returned.
  - `version <  "1.0.0"` → legacy `address` / `dst_dapp_id` shape is used.

  The selection happens transparently inside the SDK after a one-time GraphQL endpoint resolution; callers always work with the new types.

  ## Breaking changes

  - Default HD key derivation path changed from `m/44'/396'/0'/0/0` to `m/44'/1331'/0'/0/0`. Crypto functions (`tvm_client`) and key/address generation (`tvm_cli`) that rely on the default path now derive different keys from the same seed phrase. To keep previous keys, pass the old path explicitly.
  - `ParamsOfGetAccount`: `address` → `account_id` (strict 64-char hex, no `0x`, no workchain). New required `dapp_id` field.
  - `ResultOfGetAccount`: `dapp_id` is now `String` (not `Option`). New `account_id` field.
  - `ParamsOfSendMessage`: `dst_dapp_id: Option<String>` → `dapp_id: String` (empty allowed only against pre-1.0.0 servers).
  - `ResultOfSendMessage`: now exposes `account_id` and `dapp_id`, always populated (server response on v>=1.0.0, locally derived from request on legacy servers).
  - `ParamsOfProcessMessage`: `dst_dapp_id` → `dapp_id: String`.

  The `tvm-cli` flag `--dst-dapp-id` is preserved — only the SDK field name changes.

  ## tvm-cli behavior

  The `account` command now requires a dapp_id when connected to a v>=1.0.0 server. Provide it as part of the address:

  tvm-cli account ::
  tvm-cli account :

  On older servers the legacy single-address form continues to work; the CLI auto-detects which mode applies based on the server's reported version.