### PR TITLE
Added DataCell::reset_unique_bloom() to clear the per-thread Bloom filter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+
+## [3.0.1] - 2026-06-08
+
+### Fixed
+- `tvm_types`/`tvm_executor`: use a fixed seed for the per-thread unique-cell Bloom filter, reset it before and after transaction execution, and manage executor cell size limits with an RAII guard so Bloom state and TLS limits are always cleared, including early error paths such as `MaxBOCSizeExceeded`. This makes transaction cell/tree size accounting deterministic and prevents producer/verifier divergence caused by stale warm Bloom state.
+- `tvm_cli`: fixed `decode::tests::test_decode_body_json` to use an existing manifest-relative wallet ABI fixture instead of a missing `tests/samples/wallet.abi.json` path.
+- `tvm_debugger`: fixed the test `RunArgs` initializer to include `block_seq_no`.
+
 ## [3.0.0] - 2026-06-05
 
 > **Upgrading from 2.x?** See [`docs/MIGRATION-3.0.md`](docs/MIGRATION-3.0.md)

--- a/tvm_cli/src/decode.rs
+++ b/tvm_cli/src/decode.rs
@@ -728,7 +728,11 @@ mod tests {
     async fn test_decode_body_json() {
         let body = "te6ccgEBAQEARAAAgwAAALqUCTqWL8OX7JivfJrAAzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMQAAAAAAAAAAAAAAAEeGjADA==";
         let config = Config::default();
-        decode_body(body, "tests/samples/wallet.abi.json", true, &config).await.unwrap();
+        let abi_path = format!(
+            "{}/../tvm_client/src/tests/contracts/abi_v2/Wallet.abi.json",
+            env!("CARGO_MANIFEST_DIR")
+        );
+        decode_body(body, &abi_path, true, &config).await.unwrap();
     }
 
     #[tokio::test]

--- a/tvm_debugger/src/main.rs
+++ b/tvm_debugger/src/main.rs
@@ -300,6 +300,7 @@ mod tests {
             json: true,
             trace: false,
             replace_code: None,
+            block_seq_no: None,
         }
     }
 

--- a/tvm_executor/src/transaction_executor.rs
+++ b/tvm_executor/src/transaction_executor.rs
@@ -206,6 +206,27 @@ impl Default for ExecuteParams {
     }
 }
 
+struct CellLimitGuard;
+
+impl CellLimitGuard {
+    fn new() -> Self {
+        tvm_types::DataCell::reset_unique_bloom();
+        tvm_types::DataCell::UNIQUE_MAX_ALLOWED_CELL_DEPTH.with_borrow_mut(|x| *x = Some(800));
+        tvm_types::DataCell::UNIQUE_MAX_ALLOWED_NESTED_CELL_BIT_COUNT
+            .with_borrow_mut(|x| *x = Some(1398101 * 1024));
+        Self
+    }
+}
+
+impl Drop for CellLimitGuard {
+    fn drop(&mut self) {
+        tvm_types::DataCell::reset_unique_bloom();
+        tvm_types::DataCell::UNIQUE_MAX_ALLOWED_CELL_DEPTH.with_borrow_mut(|x| *x = None);
+        tvm_types::DataCell::UNIQUE_MAX_ALLOWED_NESTED_CELL_BIT_COUNT
+            .with_borrow_mut(|x| *x = None);
+    }
+}
+
 pub trait TransactionExecutor {
     fn execute_with_params(
         &self,
@@ -221,10 +242,7 @@ pub trait TransactionExecutor {
         account_root: &mut Cell,
         params: ExecuteParams,
     ) -> Result<(Transaction, i128)> {
-        // set exec cell depth limit with threadlocal
-        tvm_types::DataCell::UNIQUE_MAX_ALLOWED_CELL_DEPTH.with_borrow_mut(|x| *x = Some(800));
-        tvm_types::DataCell::UNIQUE_MAX_ALLOWED_NESTED_CELL_BIT_COUNT
-            .with_borrow_mut(|x| *x = Some(1398101 * 1024));
+        let _cell_limit_guard = CellLimitGuard::new();
         let old_hash = account_root.repr_hash();
         let minted_shell: &mut i128 = &mut 0;
         let mut account = Account::construct_from_cell(account_root.clone())?;
@@ -241,10 +259,6 @@ pub trait TransactionExecutor {
         log::trace!(target: "executor", "acc state {:?}, previous_state {:?}, minted_shell {:?}", account.state(), is_previous_state_active, minted_shell);
         *account_root = account.serialize()?;
         let new_hash = account_root.repr_hash();
-        // unset exec cell depth limit with thread local
-        tvm_types::DataCell::UNIQUE_MAX_ALLOWED_CELL_DEPTH.with_borrow_mut(|x| *x = None);
-        tvm_types::DataCell::UNIQUE_MAX_ALLOWED_NESTED_CELL_BIT_COUNT
-            .with_borrow_mut(|x| *x = None);
         transaction.write_state_update(&HashUpdate::with_hashes(old_hash, new_hash))?;
         // let cell = account
         //     .clone()
@@ -2145,6 +2159,8 @@ mod tests {
     use tvm_block::TransactionDescr;
     use tvm_types::BuilderData;
     use tvm_types::Cell;
+    use tvm_types::DataCell;
+    use tvm_types::DataCellError;
     use tvm_types::Result;
     use tvm_types::SliceData;
     use tvm_types::UInt256;
@@ -2197,6 +2213,83 @@ mod tests {
         }
     }
 
+    struct FailingExecutor {
+        config: BlockchainConfig,
+    }
+
+    impl FailingExecutor {
+        fn new() -> Self {
+            Self { config: BlockchainConfig::default() }
+        }
+    }
+
+    impl TransactionExecutor for FailingExecutor {
+        fn execute_with_params(
+            &self,
+            _in_msg: Option<&Message>,
+            _account: &mut Account,
+            _params: ExecuteParams,
+            _minted_shell: &mut i128,
+        ) -> Result<Transaction> {
+            fail!("intentional executor failure")
+        }
+
+        fn ordinary_transaction(&self) -> bool {
+            false
+        }
+
+        fn config(&self) -> &BlockchainConfig {
+            &self.config
+        }
+
+        fn build_stack(&self, _in_msg: Option<&Message>, _account: &Account) -> Stack {
+            Stack::new()
+        }
+    }
+
+    struct BloomProbeExecutor {
+        config: BlockchainConfig,
+        leaf: Cell,
+    }
+
+    impl BloomProbeExecutor {
+        fn new(leaf: Cell) -> Self {
+            Self { config: BlockchainConfig::default(), leaf }
+        }
+    }
+
+    impl TransactionExecutor for BloomProbeExecutor {
+        fn execute_with_params(
+            &self,
+            _in_msg: Option<&Message>,
+            account: &mut Account,
+            _params: ExecuteParams,
+            minted_shell: &mut i128,
+        ) -> Result<Transaction> {
+            let bloom_was_cold = bloom_limited_parent_result(&self.leaf).is_err();
+            *minted_shell = i128::from(bloom_was_cold);
+            let mut tx = Transaction::with_address_and_status(
+                account.get_id().unwrap(),
+                AccountStatus::AccStateUninit,
+            );
+            tx.set_now(if bloom_was_cold { 21 } else { 22 });
+            tx.write_state_update(&HashUpdate::default())?;
+            Ok(tx)
+        }
+
+        fn ordinary_transaction(&self) -> bool {
+            false
+        }
+
+        fn config(&self) -> &BlockchainConfig {
+            &self.config
+        }
+
+        fn build_stack(&self, _in_msg: Option<&Message>, _account: &Account) -> Stack {
+            Stack::new()
+        }
+    }
+
     fn address(byte: u8) -> MsgAddressInt {
         MsgAddressInt::with_standart(None, 0, UInt256::with_array([byte; 32]).into()).unwrap()
     }
@@ -2207,6 +2300,52 @@ mod tests {
 
     fn byte_cell(byte: u8) -> Cell {
         BuilderData::with_raw(vec![byte], 8).unwrap().into_cell().unwrap()
+    }
+
+    fn assert_numeric_cell_limits_cleared() {
+        DataCell::UNIQUE_MAX_ALLOWED_CELL_DEPTH.with_borrow(|x| assert!(x.is_none()));
+        DataCell::UNIQUE_MAX_ALLOWED_NESTED_CELL_BIT_COUNT.with_borrow(|x| assert!(x.is_none()));
+    }
+
+    fn reset_cell_tls() {
+        DataCell::reset_unique_bloom();
+        DataCell::UNIQUE_MAX_ALLOWED_CELL_DEPTH.with_borrow_mut(|x| *x = None);
+        DataCell::UNIQUE_MAX_ALLOWED_NESTED_CELL_BIT_COUNT.with_borrow_mut(|x| *x = None);
+    }
+
+    fn bloom_test_leaf() -> Cell {
+        byte_cell(0xA5)
+    }
+
+    fn build_bloom_test_parent(leaf: &Cell) -> Result<Cell> {
+        BuilderData::with_raw_and_refs(vec![0x5A], 8, [leaf.clone()])?.into_cell()
+    }
+
+    fn warm_unique_bloom_with_leaf(leaf: &Cell) {
+        let old_depth = DataCell::UNIQUE_MAX_ALLOWED_CELL_DEPTH.with_borrow(|x| *x);
+        let old_bits = DataCell::UNIQUE_MAX_ALLOWED_NESTED_CELL_BIT_COUNT.with_borrow(|x| *x);
+        DataCell::UNIQUE_MAX_ALLOWED_CELL_DEPTH.with_borrow_mut(|x| *x = None);
+        DataCell::UNIQUE_MAX_ALLOWED_NESTED_CELL_BIT_COUNT.with_borrow_mut(|x| *x = None);
+        build_bloom_test_parent(leaf).unwrap();
+        DataCell::UNIQUE_MAX_ALLOWED_CELL_DEPTH.with_borrow_mut(|x| *x = old_depth);
+        DataCell::UNIQUE_MAX_ALLOWED_NESTED_CELL_BIT_COUNT.with_borrow_mut(|x| *x = old_bits);
+    }
+
+    fn bloom_limited_parent_result(leaf: &Cell) -> Result<Cell> {
+        let old_depth = DataCell::UNIQUE_MAX_ALLOWED_CELL_DEPTH.with_borrow(|x| *x);
+        let old_bits = DataCell::UNIQUE_MAX_ALLOWED_NESTED_CELL_BIT_COUNT.with_borrow(|x| *x);
+        DataCell::UNIQUE_MAX_ALLOWED_CELL_DEPTH.with_borrow_mut(|x| *x = None);
+        DataCell::UNIQUE_MAX_ALLOWED_NESTED_CELL_BIT_COUNT
+            .with_borrow_mut(|x| *x = Some(leaf.tree_bits_count()));
+        let result = build_bloom_test_parent(leaf);
+        DataCell::UNIQUE_MAX_ALLOWED_CELL_DEPTH.with_borrow_mut(|x| *x = old_depth);
+        DataCell::UNIQUE_MAX_ALLOWED_NESTED_CELL_BIT_COUNT.with_borrow_mut(|x| *x = old_bits);
+        result
+    }
+
+    fn assert_max_boc_size_exceeded(result: Result<Cell>) {
+        let err = result.expect_err("cold Bloom must count the referenced child");
+        assert!(err.downcast_ref::<DataCellError>().is_some(), "{err:?}");
     }
 
     fn storage_prices() -> ConfigParam18 {
@@ -2369,9 +2508,85 @@ mod tests {
         let updated = Account::construct_from_cell(account_root).unwrap();
         assert!(updated.storage_info().is_some());
         assert_eq!(updated.get_id().unwrap(), address(7).address());
-        tvm_types::DataCell::UNIQUE_MAX_ALLOWED_CELL_DEPTH.with_borrow(|x| assert!(x.is_none()));
-        tvm_types::DataCell::UNIQUE_MAX_ALLOWED_NESTED_CELL_BIT_COUNT
-            .with_borrow(|x| assert!(x.is_none()));
+        assert_numeric_cell_limits_cleared();
+    }
+
+    #[test]
+    fn execute_with_libs_and_params_clears_numeric_tls_on_error_path() {
+        reset_cell_tls();
+        let executor = FailingExecutor::new();
+        let account = active_account(31);
+        let mut account_root = account.serialize().unwrap();
+
+        let result = executor.execute_with_libs_and_params(
+            None,
+            &mut account_root,
+            ExecuteParams::default(),
+        );
+
+        assert!(result.is_err());
+        assert_numeric_cell_limits_cleared();
+        reset_cell_tls();
+    }
+
+    #[test]
+    fn execute_with_libs_and_params_resets_bloom_before_transaction_execution() {
+        reset_cell_tls();
+        let leaf = bloom_test_leaf();
+        warm_unique_bloom_with_leaf(&leaf);
+        let executor = BloomProbeExecutor::new(leaf);
+        let account = active_account(32);
+        let mut account_root = account.serialize().unwrap();
+
+        let (tx, minted_shell) = executor
+            .execute_with_libs_and_params(None, &mut account_root, ExecuteParams::default())
+            .unwrap();
+
+        assert_eq!(minted_shell, 1);
+        assert_eq!(tx.now(), 21);
+        assert_numeric_cell_limits_cleared();
+        reset_cell_tls();
+    }
+
+    #[test]
+    fn execute_with_libs_and_params_resets_bloom_after_transaction_execution() {
+        reset_cell_tls();
+        let leaf = bloom_test_leaf();
+        let executor = BloomProbeExecutor::new(leaf.clone());
+        let account = active_account(33);
+        let mut account_root = account.serialize().unwrap();
+
+        executor
+            .execute_with_libs_and_params(None, &mut account_root, ExecuteParams::default())
+            .unwrap();
+
+        assert_max_boc_size_exceeded(bloom_limited_parent_result(&leaf));
+        assert_numeric_cell_limits_cleared();
+        reset_cell_tls();
+    }
+
+    #[test]
+    fn execute_with_libs_and_params_result_is_independent_of_prior_bloom_state() {
+        reset_cell_tls();
+        let leaf = bloom_test_leaf();
+        let executor = BloomProbeExecutor::new(leaf.clone());
+        let mut cold_account_root = active_account(34).serialize().unwrap();
+        let (cold_tx, cold_minted_shell) = executor
+            .execute_with_libs_and_params(None, &mut cold_account_root, ExecuteParams::default())
+            .unwrap();
+
+        reset_cell_tls();
+        warm_unique_bloom_with_leaf(&leaf);
+        let mut warm_account_root = active_account(34).serialize().unwrap();
+        let (warm_tx, warm_minted_shell) = executor
+            .execute_with_libs_and_params(None, &mut warm_account_root, ExecuteParams::default())
+            .unwrap();
+
+        assert_eq!(cold_minted_shell, warm_minted_shell);
+        assert_eq!(cold_tx.now(), warm_tx.now());
+        assert_eq!(cold_tx.logical_time(), warm_tx.logical_time());
+        assert_numeric_cell_limits_cleared();
+        reset_cell_tls();
     }
 
     #[test]

--- a/tvm_types/src/cell/data_cell.rs
+++ b/tvm_types/src/cell/data_cell.rs
@@ -62,6 +62,10 @@ impl DataCell {
         pub static UNIQUE_MAX_ALLOWED_NESTED_CELL_BIT_COUNT: RefCell<Option<u64>> = const { RefCell::new(None) };
     }
 
+    pub fn reset_unique_bloom() {
+        UNIQUE_BLOOM.with_borrow_mut(|bloom| bloom.clear());
+    }
+
     pub fn new() -> Self {
         Self::with_refs_and_data(smallvec![], &[0x80]).unwrap()
     }

--- a/tvm_types/src/cell/data_cell.rs
+++ b/tvm_types/src/cell/data_cell.rs
@@ -53,7 +53,8 @@ pub enum DataCellError {
 }
 
 thread_local! {
-    static UNIQUE_BLOOM: RefCell<BloomFilter> = RefCell::new(BloomFilter::with_false_pos(0.00001).expected_items(1000000));
+    static UNIQUE_BLOOM: RefCell<BloomFilter> =
+        RefCell::new(BloomFilter::with_false_pos(0.00001).seed(&0u128).expected_items(1000000));
 }
 
 impl DataCell {


### PR DESCRIPTION
  UNIQUE_BLOOM was thread-local, private, and persistent across transactions. If a producer’s thread had a warm Bloom, repeated cells could be undercounted during
  size checks, while a verifier with a colder Bloom could count them and hit MaxBOCSizeExceeded. Also, executor TLS limits were cleared only on the success path, so
  early errors could leave stale limits/Bloom state behind.

  What Changed

  - Added DataCell::reset_unique_bloom() to clear the per-thread Bloom filter.
  - Added CellLimitGuard in the transaction executor:
      - resets Bloom before each transaction
      - sets transaction cell limits - clears Bloom and numeric TLS limits on drop, including error paths
  - Replaced manual TLS cleanup in execute_with_libs_and_params() with the RAII guard.