### PR TITLE
v3.0.1-rc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+
+## [3.0.1] - 2026-06-08
+
+### Fixed
+- `tvm_types`/`tvm_executor`: use a fixed seed for the per-thread unique-cell Bloom filter, reset it before and after transaction execution, and manage executor cell size limits with an RAII guard so Bloom state and TLS limits are always cleared, including early error paths such as `MaxBOCSizeExceeded`. This makes transaction cell/tree size accounting deterministic and prevents producer/verifier divergence caused by stale warm Bloom state.
+- `tvm_cli`: fixed `decode::tests::test_decode_body_json` to use an existing manifest-relative wallet ABI fixture instead of a missing `tests/samples/wallet.abi.json` path.
+- `tvm_debugger`: fixed the test `RunArgs` initializer to include `block_seq_no`.
+
 ## [3.0.0] - 2026-06-05
 
 > **Upgrading from 2.x?** See [`docs/MIGRATION-3.0.md`](docs/MIGRATION-3.0.md)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api_derive"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "api_info",
  "proc-macro2",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "api_info"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "serde",
  "serde_derive",
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "api_test"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "api_derive",
  "api_info",
@@ -5991,7 +5991,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tl_code_gen"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "serde_json",
  "tvm_tl_codegen",
@@ -6271,7 +6271,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_abi"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6287,7 +6287,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_api"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -6305,7 +6305,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_assembler"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "clap 4.6.0",
@@ -6326,7 +6326,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_block"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -6347,7 +6347,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_block_json"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "hex",
@@ -6368,7 +6368,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_cli"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -6410,7 +6410,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_client"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "aes",
  "anyhow",
@@ -6485,7 +6485,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_client_processing"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "api_derive",
  "api_info",
@@ -6504,7 +6504,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_common"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "log",
  "log4rs",
@@ -6515,7 +6515,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_debugger"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -6533,7 +6533,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_executor"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -6549,7 +6549,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_sdk"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "api_derive",
@@ -6573,7 +6573,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_struct"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "thiserror 2.0.18",
  "tvm_block",
@@ -6582,7 +6582,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_tl_codegen"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "crc",
  "pom",
@@ -6595,7 +6595,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_types"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "aes",
  "anyhow",
@@ -6627,7 +6627,7 @@ dependencies = [
 
 [[package]]
 name = "tvm_vm"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "ark-bls12-381",
@@ -6778,7 +6778,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "update_trusted_blocks"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "bincode",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
   "tvm_vm",
 ]
 [workspace.package]
-version = "3.0.0"
+version = "3.0.1"
 
 rust-version = "1.76.0"
 

--- a/tvm_cli/src/decode.rs
+++ b/tvm_cli/src/decode.rs
@@ -728,7 +728,11 @@ mod tests {
     async fn test_decode_body_json() {
         let body = "te6ccgEBAQEARAAAgwAAALqUCTqWL8OX7JivfJrAAzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMQAAAAAAAAAAAAAAAEeGjADA==";
         let config = Config::default();
-        decode_body(body, "tests/samples/wallet.abi.json", true, &config).await.unwrap();
+        let abi_path = format!(
+            "{}/../tvm_client/src/tests/contracts/abi_v2/Wallet.abi.json",
+            env!("CARGO_MANIFEST_DIR")
+        );
+        decode_body(body, &abi_path, true, &config).await.unwrap();
     }
 
     #[tokio::test]

--- a/tvm_debugger/src/main.rs
+++ b/tvm_debugger/src/main.rs
@@ -300,6 +300,7 @@ mod tests {
             json: true,
             trace: false,
             replace_code: None,
+            block_seq_no: None,
         }
     }
 

--- a/tvm_executor/src/transaction_executor.rs
+++ b/tvm_executor/src/transaction_executor.rs
@@ -206,6 +206,27 @@ impl Default for ExecuteParams {
     }
 }
 
+struct CellLimitGuard;
+
+impl CellLimitGuard {
+    fn new() -> Self {
+        tvm_types::DataCell::reset_unique_bloom();
+        tvm_types::DataCell::UNIQUE_MAX_ALLOWED_CELL_DEPTH.with_borrow_mut(|x| *x = Some(800));
+        tvm_types::DataCell::UNIQUE_MAX_ALLOWED_NESTED_CELL_BIT_COUNT
+            .with_borrow_mut(|x| *x = Some(1398101 * 1024));
+        Self
+    }
+}
+
+impl Drop for CellLimitGuard {
+    fn drop(&mut self) {
+        tvm_types::DataCell::reset_unique_bloom();
+        tvm_types::DataCell::UNIQUE_MAX_ALLOWED_CELL_DEPTH.with_borrow_mut(|x| *x = None);
+        tvm_types::DataCell::UNIQUE_MAX_ALLOWED_NESTED_CELL_BIT_COUNT
+            .with_borrow_mut(|x| *x = None);
+    }
+}
+
 pub trait TransactionExecutor {
     fn execute_with_params(
         &self,
@@ -221,10 +242,7 @@ pub trait TransactionExecutor {
         account_root: &mut Cell,
         params: ExecuteParams,
     ) -> Result<(Transaction, i128)> {
-        // set exec cell depth limit with threadlocal
-        tvm_types::DataCell::UNIQUE_MAX_ALLOWED_CELL_DEPTH.with_borrow_mut(|x| *x = Some(800));
-        tvm_types::DataCell::UNIQUE_MAX_ALLOWED_NESTED_CELL_BIT_COUNT
-            .with_borrow_mut(|x| *x = Some(1398101 * 1024));
+        let _cell_limit_guard = CellLimitGuard::new();
         let old_hash = account_root.repr_hash();
         let minted_shell: &mut i128 = &mut 0;
         let mut account = Account::construct_from_cell(account_root.clone())?;
@@ -241,10 +259,6 @@ pub trait TransactionExecutor {
         log::trace!(target: "executor", "acc state {:?}, previous_state {:?}, minted_shell {:?}", account.state(), is_previous_state_active, minted_shell);
         *account_root = account.serialize()?;
         let new_hash = account_root.repr_hash();
-        // unset exec cell depth limit with thread local
-        tvm_types::DataCell::UNIQUE_MAX_ALLOWED_CELL_DEPTH.with_borrow_mut(|x| *x = None);
-        tvm_types::DataCell::UNIQUE_MAX_ALLOWED_NESTED_CELL_BIT_COUNT
-            .with_borrow_mut(|x| *x = None);
         transaction.write_state_update(&HashUpdate::with_hashes(old_hash, new_hash))?;
         // let cell = account
         //     .clone()
@@ -2145,6 +2159,8 @@ mod tests {
     use tvm_block::TransactionDescr;
     use tvm_types::BuilderData;
     use tvm_types::Cell;
+    use tvm_types::DataCell;
+    use tvm_types::DataCellError;
     use tvm_types::Result;
     use tvm_types::SliceData;
     use tvm_types::UInt256;
@@ -2197,6 +2213,83 @@ mod tests {
         }
     }
 
+    struct FailingExecutor {
+        config: BlockchainConfig,
+    }
+
+    impl FailingExecutor {
+        fn new() -> Self {
+            Self { config: BlockchainConfig::default() }
+        }
+    }
+
+    impl TransactionExecutor for FailingExecutor {
+        fn execute_with_params(
+            &self,
+            _in_msg: Option<&Message>,
+            _account: &mut Account,
+            _params: ExecuteParams,
+            _minted_shell: &mut i128,
+        ) -> Result<Transaction> {
+            fail!("intentional executor failure")
+        }
+
+        fn ordinary_transaction(&self) -> bool {
+            false
+        }
+
+        fn config(&self) -> &BlockchainConfig {
+            &self.config
+        }
+
+        fn build_stack(&self, _in_msg: Option<&Message>, _account: &Account) -> Stack {
+            Stack::new()
+        }
+    }
+
+    struct BloomProbeExecutor {
+        config: BlockchainConfig,
+        leaf: Cell,
+    }
+
+    impl BloomProbeExecutor {
+        fn new(leaf: Cell) -> Self {
+            Self { config: BlockchainConfig::default(), leaf }
+        }
+    }
+
+    impl TransactionExecutor for BloomProbeExecutor {
+        fn execute_with_params(
+            &self,
+            _in_msg: Option<&Message>,
+            account: &mut Account,
+            _params: ExecuteParams,
+            minted_shell: &mut i128,
+        ) -> Result<Transaction> {
+            let bloom_was_cold = bloom_limited_parent_result(&self.leaf).is_err();
+            *minted_shell = i128::from(bloom_was_cold);
+            let mut tx = Transaction::with_address_and_status(
+                account.get_id().unwrap(),
+                AccountStatus::AccStateUninit,
+            );
+            tx.set_now(if bloom_was_cold { 21 } else { 22 });
+            tx.write_state_update(&HashUpdate::default())?;
+            Ok(tx)
+        }
+
+        fn ordinary_transaction(&self) -> bool {
+            false
+        }
+
+        fn config(&self) -> &BlockchainConfig {
+            &self.config
+        }
+
+        fn build_stack(&self, _in_msg: Option<&Message>, _account: &Account) -> Stack {
+            Stack::new()
+        }
+    }
+
     fn address(byte: u8) -> MsgAddressInt {
         MsgAddressInt::with_standart(None, 0, UInt256::with_array([byte; 32]).into()).unwrap()
     }
@@ -2207,6 +2300,52 @@ mod tests {
 
     fn byte_cell(byte: u8) -> Cell {
         BuilderData::with_raw(vec![byte], 8).unwrap().into_cell().unwrap()
+    }
+
+    fn assert_numeric_cell_limits_cleared() {
+        DataCell::UNIQUE_MAX_ALLOWED_CELL_DEPTH.with_borrow(|x| assert!(x.is_none()));
+        DataCell::UNIQUE_MAX_ALLOWED_NESTED_CELL_BIT_COUNT.with_borrow(|x| assert!(x.is_none()));
+    }
+
+    fn reset_cell_tls() {
+        DataCell::reset_unique_bloom();
+        DataCell::UNIQUE_MAX_ALLOWED_CELL_DEPTH.with_borrow_mut(|x| *x = None);
+        DataCell::UNIQUE_MAX_ALLOWED_NESTED_CELL_BIT_COUNT.with_borrow_mut(|x| *x = None);
+    }
+
+    fn bloom_test_leaf() -> Cell {
+        byte_cell(0xA5)
+    }
+
+    fn build_bloom_test_parent(leaf: &Cell) -> Result<Cell> {
+        BuilderData::with_raw_and_refs(vec![0x5A], 8, [leaf.clone()])?.into_cell()
+    }
+
+    fn warm_unique_bloom_with_leaf(leaf: &Cell) {
+        let old_depth = DataCell::UNIQUE_MAX_ALLOWED_CELL_DEPTH.with_borrow(|x| *x);
+        let old_bits = DataCell::UNIQUE_MAX_ALLOWED_NESTED_CELL_BIT_COUNT.with_borrow(|x| *x);
+        DataCell::UNIQUE_MAX_ALLOWED_CELL_DEPTH.with_borrow_mut(|x| *x = None);
+        DataCell::UNIQUE_MAX_ALLOWED_NESTED_CELL_BIT_COUNT.with_borrow_mut(|x| *x = None);
+        build_bloom_test_parent(leaf).unwrap();
+        DataCell::UNIQUE_MAX_ALLOWED_CELL_DEPTH.with_borrow_mut(|x| *x = old_depth);
+        DataCell::UNIQUE_MAX_ALLOWED_NESTED_CELL_BIT_COUNT.with_borrow_mut(|x| *x = old_bits);
+    }
+
+    fn bloom_limited_parent_result(leaf: &Cell) -> Result<Cell> {
+        let old_depth = DataCell::UNIQUE_MAX_ALLOWED_CELL_DEPTH.with_borrow(|x| *x);
+        let old_bits = DataCell::UNIQUE_MAX_ALLOWED_NESTED_CELL_BIT_COUNT.with_borrow(|x| *x);
+        DataCell::UNIQUE_MAX_ALLOWED_CELL_DEPTH.with_borrow_mut(|x| *x = None);
+        DataCell::UNIQUE_MAX_ALLOWED_NESTED_CELL_BIT_COUNT
+            .with_borrow_mut(|x| *x = Some(leaf.tree_bits_count()));
+        let result = build_bloom_test_parent(leaf);
+        DataCell::UNIQUE_MAX_ALLOWED_CELL_DEPTH.with_borrow_mut(|x| *x = old_depth);
+        DataCell::UNIQUE_MAX_ALLOWED_NESTED_CELL_BIT_COUNT.with_borrow_mut(|x| *x = old_bits);
+        result
+    }
+
+    fn assert_max_boc_size_exceeded(result: Result<Cell>) {
+        let err = result.expect_err("cold Bloom must count the referenced child");
+        assert!(err.downcast_ref::<DataCellError>().is_some(), "{err:?}");
     }
 
     fn storage_prices() -> ConfigParam18 {
@@ -2369,9 +2508,85 @@ mod tests {
         let updated = Account::construct_from_cell(account_root).unwrap();
         assert!(updated.storage_info().is_some());
         assert_eq!(updated.get_id().unwrap(), address(7).address());
-        tvm_types::DataCell::UNIQUE_MAX_ALLOWED_CELL_DEPTH.with_borrow(|x| assert!(x.is_none()));
-        tvm_types::DataCell::UNIQUE_MAX_ALLOWED_NESTED_CELL_BIT_COUNT
-            .with_borrow(|x| assert!(x.is_none()));
+        assert_numeric_cell_limits_cleared();
+    }
+
+    #[test]
+    fn execute_with_libs_and_params_clears_numeric_tls_on_error_path() {
+        reset_cell_tls();
+        let executor = FailingExecutor::new();
+        let account = active_account(31);
+        let mut account_root = account.serialize().unwrap();
+
+        let result = executor.execute_with_libs_and_params(
+            None,
+            &mut account_root,
+            ExecuteParams::default(),
+        );
+
+        assert!(result.is_err());
+        assert_numeric_cell_limits_cleared();
+        reset_cell_tls();
+    }
+
+    #[test]
+    fn execute_with_libs_and_params_resets_bloom_before_transaction_execution() {
+        reset_cell_tls();
+        let leaf = bloom_test_leaf();
+        warm_unique_bloom_with_leaf(&leaf);
+        let executor = BloomProbeExecutor::new(leaf);
+        let account = active_account(32);
+        let mut account_root = account.serialize().unwrap();
+
+        let (tx, minted_shell) = executor
+            .execute_with_libs_and_params(None, &mut account_root, ExecuteParams::default())
+            .unwrap();
+
+        assert_eq!(minted_shell, 1);
+        assert_eq!(tx.now(), 21);
+        assert_numeric_cell_limits_cleared();
+        reset_cell_tls();
+    }
+
+    #[test]
+    fn execute_with_libs_and_params_resets_bloom_after_transaction_execution() {
+        reset_cell_tls();
+        let leaf = bloom_test_leaf();
+        let executor = BloomProbeExecutor::new(leaf.clone());
+        let account = active_account(33);
+        let mut account_root = account.serialize().unwrap();
+
+        executor
+            .execute_with_libs_and_params(None, &mut account_root, ExecuteParams::default())
+            .unwrap();
+
+        assert_max_boc_size_exceeded(bloom_limited_parent_result(&leaf));
+        assert_numeric_cell_limits_cleared();
+        reset_cell_tls();
+    }
+
+    #[test]
+    fn execute_with_libs_and_params_result_is_independent_of_prior_bloom_state() {
+        reset_cell_tls();
+        let leaf = bloom_test_leaf();
+        let executor = BloomProbeExecutor::new(leaf.clone());
+        let mut cold_account_root = active_account(34).serialize().unwrap();
+        let (cold_tx, cold_minted_shell) = executor
+            .execute_with_libs_and_params(None, &mut cold_account_root, ExecuteParams::default())
+            .unwrap();
+
+        reset_cell_tls();
+        warm_unique_bloom_with_leaf(&leaf);
+        let mut warm_account_root = active_account(34).serialize().unwrap();
+        let (warm_tx, warm_minted_shell) = executor
+            .execute_with_libs_and_params(None, &mut warm_account_root, ExecuteParams::default())
+            .unwrap();
+
+        assert_eq!(cold_minted_shell, warm_minted_shell);
+        assert_eq!(cold_tx.now(), warm_tx.now());
+        assert_eq!(cold_tx.logical_time(), warm_tx.logical_time());
+        assert_numeric_cell_limits_cleared();
+        reset_cell_tls();
     }
 
     #[test]

--- a/tvm_types/src/cell/data_cell.rs
+++ b/tvm_types/src/cell/data_cell.rs
@@ -53,13 +53,18 @@ pub enum DataCellError {
 }
 
 thread_local! {
-    static UNIQUE_BLOOM: RefCell<BloomFilter> = RefCell::new(BloomFilter::with_false_pos(0.00001).expected_items(1000000));
+    static UNIQUE_BLOOM: RefCell<BloomFilter> =
+        RefCell::new(BloomFilter::with_false_pos(0.00001).seed(&0u128).expected_items(1000000));
 }
 
 impl DataCell {
     thread_local! {
         pub static UNIQUE_MAX_ALLOWED_CELL_DEPTH: RefCell<Option<u16>> = const { RefCell::new(None) };
         pub static UNIQUE_MAX_ALLOWED_NESTED_CELL_BIT_COUNT: RefCell<Option<u64>> = const { RefCell::new(None) };
+    }
+
+    pub fn reset_unique_bloom() {
+        UNIQUE_BLOOM.with_borrow_mut(|bloom| bloom.clear());
     }
 
     pub fn new() -> Self {


### PR DESCRIPTION
…lter. (#253)

* Problem Solved UNIQUE_BLOOM was thread-local, private, and persistent across transactions. If a producer’s thread had a warm Bloom, repeated cells could be undercounted during size checks, while a verifier with a colder Bloom could count them and hit MaxBOCSizeExceeded. Also, executor TLS limits were cleared only on the success path, so early errors could leave stale limits/Bloom state behind.

  What Changed

  - Added DataCell::reset_unique_bloom() to clear the per-thread Bloom filter.
  - Added CellLimitGuard in the transaction executor:
      - resets Bloom before each transaction
      - sets transaction cell limits - clears Bloom and numeric TLS limits on drop, including error paths
  - Replaced manual TLS cleanup in execute_with_libs_and_params() with the RAII guard.

* Problem Solved UNIQUE_BLOOM was thread-local, private, and persistent across transactions. If a producer’s thread had a warm Bloom, repeated cells could be undercounted during size checks, while a verifier with a colder Bloom could count them and hit MaxBOCSizeExceeded. Also, executor TLS limits were cleared only on the success path, so early errors could leave stale limits/Bloom state behind.

  What Changed

  - Added DataCell::reset_unique_bloom() to clear the per-thread Bloom filter.
  - Added CellLimitGuard in the transaction executor:
      - resets Bloom before each transaction
      - sets transaction cell limits - clears Bloom and numeric TLS limits on drop, including error paths
  - Replaced manual TLS cleanup in execute_with_libs_and_params() with the RAII guard.