### PR TITLE
3.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = [
   "tvm_vm",
 ]
 [workspace.package]
-version = "3.0.0"
+version = "3.0.1"
 
 rust-version = "1.76.0"
 


### PR DESCRIPTION
  UNIQUE_BLOOM was thread-local, private, and persistent across transactions. If a producer’s thread had a warm Bloom, repeated cells could be undercounted during
  size checks, while a verifier with a colder Bloom could count them and hit MaxBOCSizeExceeded. Also, executor TLS limits were cleared only on the success path, so
  early errors could leave stale limits/Bloom state behind.

  What Changed

  - Added DataCell::reset_unique_bloom() to clear the per-thread Bloom filter.
  - Added CellLimitGuard in the transaction executor:
      - resets Bloom before each transaction
      - sets transaction cell limits - clears Bloom and numeric TLS limits on drop, including error paths
  - Replaced manual TLS cleanup in execute_with_libs_and_params() with the RAII guard.