### PR TITLE
fix(deps): pin axiom-eth by rev to stop snark-verifier stable-Rust drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,7 +682,7 @@ dependencies = [
 [[package]]
 name = "axiom-eth"
 version = "0.4.3"
-source = "git+https://github.com/gosh-sh/axiom-eth?branch=gosh-stable-rlcmanager-assignment#f2b3caec928be1a6fef8b1185b580266c0a2195d"
+source = "git+https://github.com/gosh-sh/axiom-eth?rev=1d61be00a63ec73b3f709d74eb9e6b09b754b911#1d61be00a63ec73b3f709d74eb9e6b09b754b911"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3021,7 +3021,7 @@ dependencies = [
 [[package]]
 name = "halo2-base"
 version = "0.4.1"
-source = "git+https://github.com/gosh-sh/halo2-lib-zkevm-sha256-and-bls12-381?branch=bump-halo2-lib-v0.4.1#21f7d97def1297caf5090d40718937601d8edbf2"
+source = "git+https://github.com/gosh-sh/halo2-lib-zkevm-sha256-and-bls12-381?branch=bump-halo2-lib-v0.4.1#026e176de8aff8269ab3bbb7f7192b247adab965"
 dependencies = [
  "ark-std 0.3.0",
  "getset",
@@ -3043,7 +3043,7 @@ dependencies = [
 [[package]]
 name = "halo2-ecc"
 version = "0.4.1"
-source = "git+https://github.com/gosh-sh/halo2-lib-zkevm-sha256-and-bls12-381?branch=bump-halo2-lib-v0.4.1#21f7d97def1297caf5090d40718937601d8edbf2"
+source = "git+https://github.com/gosh-sh/halo2-lib-zkevm-sha256-and-bls12-381?branch=bump-halo2-lib-v0.4.1#026e176de8aff8269ab3bbb7f7192b247adab965"
 dependencies = [
  "halo2-base",
  "itertools 0.11.0",
@@ -6108,8 +6108,8 @@ dependencies = [
 
 [[package]]
 name = "snark-verifier"
-version = "0.2.3"
-source = "git+https://github.com/gosh-sh/snark-verifier?branch=main#a773936d46dbf0ceb7f366b34259fca2d53e0c0f"
+version = "0.1.8"
+source = "git+https://github.com/gosh-sh/snark-verifier?rev=164bd42e300b382239e63b16532faca539d6b324#164bd42e300b382239e63b16532faca539d6b324"
 dependencies = [
  "halo2-base",
  "halo2-ecc",
@@ -6126,8 +6126,8 @@ dependencies = [
 
 [[package]]
 name = "snark-verifier-sdk"
-version = "0.2.3"
-source = "git+https://github.com/gosh-sh/snark-verifier?branch=main#a773936d46dbf0ceb7f366b34259fca2d53e0c0f"
+version = "0.1.8"
+source = "git+https://github.com/gosh-sh/snark-verifier?rev=164bd42e300b382239e63b16532faca539d6b324#164bd42e300b382239e63b16532faca539d6b324"
 dependencies = [
  "bincode",
  "getset",
@@ -8750,7 +8750,7 @@ dependencies = [
 [[package]]
 name = "zkevm-hashes"
 version = "0.2.1"
-source = "git+https://github.com/gosh-sh/halo2-lib-zkevm-sha256-and-bls12-381?branch=bump-halo2-lib-v0.4.1#21f7d97def1297caf5090d40718937601d8edbf2"
+source = "git+https://github.com/gosh-sh/halo2-lib-zkevm-sha256-and-bls12-381?branch=bump-halo2-lib-v0.4.1#026e176de8aff8269ab3bbb7f7192b247adab965"
 dependencies = [
  "array-init",
  "ethers-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,16 +165,22 @@ halo2-ecc = { git = "https://github.com/gosh-sh/halo2-lib-zkevm-sha256-and-bls12
 zkevm-hashes = { git = "https://github.com/gosh-sh/halo2-lib-zkevm-sha256-and-bls12-381", branch = "bump-halo2-lib-v0.4.1" }
 
 # axiom-eth: gosh-sh fork on branch `gosh-stable-rlcmanager-assignment`,
-# four commits ahead of upstream axiom-crypto/axiom-eth `main`:
+# seven commits ahead of upstream axiom-crypto/axiom-eth `main`:
 #   687a6da  RlcManager: name VirtualRegionManager::Assignment explicitly
 #            (required to build against the gosh halo2-base fork above)
 #   ce37a89  Redirect snark-verifier{-sdk} to gosh-sh/snark-verifier (stable-Rust fork)
 #   367d57f  Drop nightly feature gates from axiom-eth/src/lib.rs
 #   f2b3cae  Remove remaining nightly features (CoreBuilderInput / Commiter)
+#   51dec0d  Pin snark-verifier to ccdb510 (pre-rename)  <-- broken on stable
+#   4df1e7f  Spell out KeygenAggregationCircuitIntent::AggregationCircuit
+#   1d61be0  Bump snark-verifier-sdk pin to 164bd42e (stable-rust-on-ccdb510)  <-- fix
 # Together these keep the whole RLC verification path on stable Rust — without
 # them, axiom-eth and the upstream snark-verifier-sdk both need #![feature(trait_alias)]
-# and the workspace would have to pin nightly. Cargo.lock should resolve this
-# patch to `f2b3cae...` or later; after a branch tip move, run
-# `cargo update -p axiom-eth -p zkevm-hashes` to refresh.
+# and the workspace would have to pin nightly.
+#
+# NOTE: pinned by explicit `rev` (not `branch`) so the snark-verifier-sdk rev
+# transitively selected here (currently `164bd42e`, the stable-rust-on-ccdb510
+# backport) cannot drift when the branch tip moves. To bump: update the SHA
+# below AND run `cargo update -p axiom-eth`.
 [patch."https://github.com/axiom-crypto/axiom-eth"]
-axiom-eth = { git = "https://github.com/gosh-sh/axiom-eth", branch = "gosh-stable-rlcmanager-assignment" }
+axiom-eth = { git = "https://github.com/gosh-sh/axiom-eth", rev = "1d61be00a63ec73b3f709d74eb9e6b09b754b911" }


### PR DESCRIPTION
The `branch = "gosh-stable-rlcmanager-assignment"` patch let Cargo.lock silently follow the branch through intermediate commits (51dec0d, 4df1e7f) that pinned snark-verifier to ccdb510 — which begins with `#![feature(associated_type_defaults)]` and fails on stable Rust. Pin axiom-eth explicitly at 1d61be0 (the fork tip: pins snark-verifier at rev=164bd42e, the stable-rust-on-ccdb510 backport) so the sub-pin cannot drift.
